### PR TITLE
Add check for bin TR >= 0

### DIFF
--- a/radfield.c
+++ b/radfield.c
@@ -805,7 +805,7 @@ double radfield(double nu, int modelgridindex)
     if (binindex >= 0)
     {
       const struct radfieldbin_current *restrict const bin = &radfieldbin_current[modelgridindex][binindex];
-      if (bin->W >= 0.)
+      if (bin->W >= 0. && bin->T_R >= 0.)
       {
         // if (bin->fit_type == FIT_DILUTED_BLACKBODY)
         {


### PR DESCRIPTION
When bin has no packet contributions TR is set to -99, which allows radfield_dbb to be called when TR=-99 and W=0 returning J_nu=-0