### PR TITLE
Fixed wrong timestep replacement

### DIFF
--- a/input.cc
+++ b/input.cc
@@ -2318,9 +2318,9 @@ void update_parameterfile(int nts)
       if (noncomment_linenum == 2 && nts >= 0)
       {
         /// Number of start and end time step
-        snprintf(c_line, 1024, "%3.3d %3.3d", nts, globals::ftstep);
+        snprintf(c_line, 1024, "%d %d", nts, globals::ftstep);
         // line.assign(c_line);
-        line.replace(0, strlen(c_line), c_line);
+        line.replace(line.begin(), line.end(), c_line);
       }
       else if (noncomment_linenum == 16 && nts >= 0)
       {


### PR DESCRIPTION
### :pencil: Description

**Type:**  `bugfix`

Fixes a bug where timestep update in `input.txt` produces nonsense due to hardcoded `%3.3d` and wrong replace arguments.
Minimal code example to reproduce bug:
```cpp
#include <iostream>
#include <string>

int main ()
{
  std::string base="0000 1000";
  std::string str2="001 1000";

  std::cout << "String as it was read in:\n" << base << '\n';

  std::cout << "Replacement string due to 3.3d formatting:\n" << str2 << '\n';

  std::string str=base;
  str.replace(0,8,str2);

  std::cout << "Saved string after replacement:\n" << str << '\n';

  std::string better=base;

  std::cout << "Better to use flexible string positions:\n";
  better.replace(better.begin(),better.end(),str2);
  std::cout << better << '\n';
  return 0;
}
```
Output:

> String as it was read in:
> 0000 1000
> Replacement string due to 3.3d formatting:
> 001 1000
> Saved string after replacement:
> 001 10000
> Better to use flexible string positions:
> 001 1000

This means that for more than 999 timesteps restarting won't be possible without manual repairing of the `input.txt` file.

The fixes implemented here allow for any number of timesteps.