### PR TITLE
Set vpkts negative line optical depths to zero

### DIFF
--- a/atomic.cc
+++ b/atomic.cc
@@ -60,7 +60,7 @@ auto get_tau_sobolev(const int modelgridindex, const int lineindex, const double
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
   const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 
-  const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
+  const double tau_sobolev = std::max(0., (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current);
   return tau_sobolev;
 }
 

--- a/scripts/artis-cosma8.sh
+++ b/scripts/artis-cosma8.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -l
+
+#SBATCH --ntasks 3072
+#SBATCH -J artis-cosma8.sh
+## SBATCH -o standard_output_file.%J.out
+## SBATCH -e standard_error_file.%J.err
+#SBATCH -p cosma8
+#SBATCH -A dp033
+## SBATCH --exclusive
+#SBATCH -t 70:00:00
+#SBATCH --mail-type=ALL                          # notifications for job done & fail
+## SBATCH --mail-user=f.callan@qub.ac.uk
+
+module purge
+#load the modules used to build your program.
+module load cosma
+module load gsl/2.4
+module load gnu_comp/13.1.0
+module load openmpi/4.1.4
+module load python/3.10.12
+
+module list
+
+cd $SLURM_SUBMIT_DIR
+
+echo "CPU type: $(c++ -march=native -Q --help=target | grep -- '-march=  ' | cut -f3)"
+
+hoursleft=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
+echo "$(date): before srun sn3d. hours left: $hoursleft"
+# time srun -- ./sn3d -w $hoursleft > out.txt
+time mpirun ./sn3d -w $hoursleft > out.txt
+hoursleftafter=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
+echo "$(date): after srun sn3d finished. hours left: $hoursleftafter"
+hourselapsed=$(python3 -c "print($hoursleft - $hoursleftafter)")
+echo "hours of runtime: $hourselapsed"
+cpuhrs=$(python3 -c "print($SLURM_NTASKS * $hourselapsed)")
+echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
+
+mkdir ${SLURM_JOB_ID}.slurm
+./artis/scripts/movefiles.sh ${SLURM_JOB_ID}.slurm
+
+if grep -q "RESTART_NEEDED" "output_0-0.txt"
+then
+    sbatch ./artis-cosma8.sh
+    # sbatch $SLURM_JOB_NAME
+fi
+
+if [ -f packets00_0000.out ]; then
+    sbatch ./artis/scripts/exspec-gzip-cosma8.sh
+fi

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -346,7 +346,7 @@ static void rlc_emiss_vpkt(const struct packet *const pkt_ptr, const double t_cu
 
           const auto n_u = calculate_levelpop(mgi, element, ion, upper);
           const auto n_l = calculate_levelpop(mgi, element, ion, lower);
-          const double tau_line = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_line;
+          const double tau_line = std::max(0., (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_line);
 
           // Check on the element to exclude
           // NB: ldist before need to be computed anyway (I want to move the packets to the


### PR DESCRIPTION
-Set vpkts line optical depths to zero if they are negative. Line optical depths were never negative in ARTIS-CLASSIC as the level populations are coming from Boltzmann statistics but population inversions can occur when running in ARTIS-NLTE resulting in negative line optical depths. There was previously no check for this for vpkts.
-Set line optical depths to zero in unused function get_tau_sobolev for consistency
-Add slurm submit script for cosma8 HPC