### PR TITLE
NLTE Solver population checks

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -988,6 +988,11 @@ void solve_nlte_pops_element(const int element, const int modelgridindex, const 
       // double solution_ion_pop = 0.;
       for (int level = 1; level <= nlevels_nlte; level++) {
         const int index = get_nlte_vector_index(element, ion, level);
+        double min_nlte_pop = MINPOP;
+        if (gsl_vector_get(popvec, index) < min_nlte_pop) {
+          // set the population to 1e-30 if it is too low
+          gsl_vector_set(popvec, index, min_nlte_pop);
+        }
         grid::modelgrid[modelgridindex].nlte_pops[nlte_start + level - 1] =
             gsl_vector_get(popvec, index) / grid::get_rho(modelgridindex);
         // solution_ion_pop += gsl_vector_get(popvec, index);


### PR DESCRIPTION
I have been thinking about the errors in the multid nebular runs. I think a check at the end of the NLTE solver would be a good idea. We would need to check for two cases:

1) when the population may become sufficiently small to cause problems with floating point numbers. (On this point, I also think min pop should be changed to something larger, 1e-35 to ensure we are not close to the float limit)

2) The case when we have a population inversion. The division by the groundpop when we have a successful solution with a population inversion can cause significant problems at the point the partition function is cast from a double to a float. There is no physical justification for not allowing a population inversion thus simply setting the population to LTE might not be the best approach. Thus, I suggest some tolerance on what we would accept. 

As such, I have attempted to introduce two checks on the solved populations. I believe the changes in the outputs are from numerical round-offs as the spec.out files are the same. Although I'd appreciate some sanity checking of the implementation for the 2nd case. Do you think there's a better way to implement this safety mechanism on the NLTE solver?  