### PR TITLE
Avoid dereferencing pointers to zero-size photoionisation arrays

### DIFF
--- a/grid.cc
+++ b/grid.cc
@@ -995,8 +995,8 @@ static void allocate_nonemptymodelcells() {
 
   auto ionestimsize = get_nonempty_npts_model() * globals::nbfcontinua_ground * sizeof(double);
 
+  if (USE_LUT_PHOTOION && ionestimsize > 0) {
 #ifdef MPI_ON
-  if constexpr (USE_LUT_PHOTOION) {
     auto my_rank_cells = get_nonempty_npts_model() / globals::node_nprocs;
     // rank_in_node 0 gets any remainder
     if (globals::rank_in_node == 0) {
@@ -1010,25 +1010,31 @@ static void allocate_nonemptymodelcells() {
                                           &globals::win_corrphotoionrenorm) == MPI_SUCCESS);
     assert_always(MPI_Win_shared_query(globals::win_corrphotoionrenorm, 0, &size, &disp_unit,
                                        &globals::corrphotoionrenorm) == MPI_SUCCESS);
-  }
 #else
-  if constexpr (USE_LUT_PHOTOION) {
     globals::corrphotoionrenorm = static_cast<double *>(malloc(ionestimsize));
-  }
 #endif
 
-  if constexpr (USE_LUT_BFHEATING) {
+    globals::gammaestimator = static_cast<double *>(malloc(ionestimsize));
+#ifdef DO_TITER
+    globals::gammaestimator_save = static_cast<double *>(malloc(ionestimsize));
+#endif
+  } else {
+    globals::corrphotoionrenorm = nullptr;
+    globals::gammaestimator = nullptr;
+#ifdef DO_TITER
+    globals::gammaestimator_save = nullptr;
+#endif
+  }
+
+  if (USE_LUT_BFHEATING && ionestimsize > 0) {
     globals::bfheatingestimator = static_cast<double *>(malloc(ionestimsize));
 #ifdef DO_TITER
     globals::bfheatingestimator_save = static_cast<double *>(malloc(ionestimsize));
 #endif
-  }
-
-  if constexpr (USE_LUT_PHOTOION) {
-    globals::gammaestimator = static_cast<double *>(malloc(ionestimsize));
-
+  } else {
+    globals::bfheatingestimator = nullptr;
 #ifdef DO_TITER
-    globals::gammaestimator_save = static_cast<double *>(malloc(ionestimsize));
+    globals::bfheatingestimator_save = nullptr;
 #endif
   }
 

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -1287,7 +1287,7 @@ void calculate_expansion_opacities(const int modelgridindex) {
     expansionopacities[nonemptymgi * expopac_nbins + binindex] = bin_kappa_bb;
 
     if constexpr (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY >= 0.) {
-      // static thread_local struct Rpkt_continuum_absorptioncoeffs chi_rpkt_cont {};
+      // thread_local Rpkt_continuum_absorptioncoeffs chi_rpkt_cont {};
       // calculate_chi_rpkt_cont(nu_mid, chi_rpkt_cont, nullptr, modelgridindex);
       // const auto bin_kappa_cont = chi_rpkt_cont.total / rho;
       const auto bin_kappa_cont = calculate_chi_ffheating(modelgridindex, nu_mid) / rho;

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -587,12 +587,14 @@ void zero_estimators() {
   std::fill_n(globals::colheatingestimator, grid::get_nonempty_npts_model(), 0.);
   std::ranges::fill(globals::dep_estimator_gamma, 0.);
 
-  if (globals::nbfcontinua_ground > 0) {
-    if constexpr (USE_LUT_PHOTOION) {
+  if constexpr (USE_LUT_PHOTOION) {
+    if (globals::nbfcontinua_ground > 0) {
       std::fill_n(globals::gammaestimator, grid::get_nonempty_npts_model() * globals::nbfcontinua_ground, 0.);
     }
+  }
 
-    if constexpr (USE_LUT_BFHEATING) {
+  if constexpr (USE_LUT_BFHEATING) {
+    if (globals::nbfcontinua_ground > 0) {
       std::fill_n(globals::bfheatingestimator, grid::get_nonempty_npts_model() * globals::nbfcontinua_ground, 0.);
     }
   }

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -587,12 +587,14 @@ void zero_estimators() {
   std::fill_n(globals::colheatingestimator, grid::get_nonempty_npts_model(), 0.);
   std::ranges::fill(globals::dep_estimator_gamma, 0.);
 
-  if constexpr (USE_LUT_PHOTOION) {
-    std::fill_n(globals::gammaestimator, grid::get_nonempty_npts_model() * globals::nbfcontinua_ground, 0.);
-  }
+  if (globals::nbfcontinua_ground > 0) {
+    if constexpr (USE_LUT_PHOTOION) {
+      std::fill_n(globals::gammaestimator, grid::get_nonempty_npts_model() * globals::nbfcontinua_ground, 0.);
+    }
 
-  if constexpr (USE_LUT_BFHEATING) {
-    std::fill_n(globals::bfheatingestimator, grid::get_nonempty_npts_model() * globals::nbfcontinua_ground, 0.);
+    if constexpr (USE_LUT_BFHEATING) {
+      std::fill_n(globals::bfheatingestimator, grid::get_nonempty_npts_model() * globals::nbfcontinua_ground, 0.);
+    }
   }
 
 #ifdef MPI_ON

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -241,7 +241,7 @@ void mpi_communicate_grid_properties(const int my_rank, const int nprocs, const 
                   globals::mpi_comm_internode);
       }
 
-      if constexpr (USE_LUT_PHOTOION) {
+      if (USE_LUT_PHOTOION && globals::nbfcontinua_ground > 0) {
         const auto nonemptymgi = grid::get_modelcell_nonemptymgi(modelgridindex);
         assert_always(globals::corrphotoionrenorm != nullptr);
         if (globals::rank_in_node == 0) {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -367,18 +367,20 @@ void mpi_reduce_estimators(int nts) {
   MPI_Allreduce(MPI_IN_PLACE, globals::colheatingestimator, nonempty_npts_model, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  if constexpr (USE_LUT_PHOTOION) {
-    MPI_Barrier(MPI_COMM_WORLD);
-    assert_always(globals::gammaestimator != nullptr);
-    MPI_Allreduce(MPI_IN_PLACE, globals::gammaestimator, nonempty_npts_model * globals::nbfcontinua_ground, MPI_DOUBLE,
-                  MPI_SUM, MPI_COMM_WORLD);
-  }
+  if (globals::nbfcontinua_ground > 0) {
+    if constexpr (USE_LUT_PHOTOION) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      assert_always(globals::gammaestimator != nullptr);
+      MPI_Allreduce(MPI_IN_PLACE, globals::gammaestimator, nonempty_npts_model * globals::nbfcontinua_ground,
+                    MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    }
 
-  if constexpr (USE_LUT_BFHEATING) {
-    MPI_Barrier(MPI_COMM_WORLD);
-    assert_always(globals::bfheatingestimator != nullptr);
-    MPI_Allreduce(MPI_IN_PLACE, globals::bfheatingestimator, nonempty_npts_model * globals::nbfcontinua_ground,
-                  MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    if constexpr (USE_LUT_BFHEATING) {
+      MPI_Barrier(MPI_COMM_WORLD);
+      assert_always(globals::bfheatingestimator != nullptr);
+      MPI_Allreduce(MPI_IN_PLACE, globals::bfheatingestimator, nonempty_npts_model * globals::nbfcontinua_ground,
+                    MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    }
   }
 
   if constexpr (RECORD_LINESTAT) {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -249,6 +249,8 @@ void mpi_communicate_grid_properties(const int my_rank, const int nprocs, const 
                     globals::nbfcontinua_ground, MPI_DOUBLE, root_node_id, globals::mpi_comm_internode);
         }
 
+        MPI_Barrier(MPI_COMM_WORLD);
+
         assert_always(globals::gammaestimator != nullptr);
         MPI_Bcast(globals::gammaestimator + (nonemptymgi * globals::nbfcontinua_ground), globals::nbfcontinua_ground,
                   MPI_DOUBLE, root, MPI_COMM_WORLD);


### PR DESCRIPTION
Some MPI implementations can return null pointers from MPI_Win_allocate_shared/MPI_Win_shared_query when the requested size is 0, which triggers null pointer checks even when the arrays are not used (nbfcontinua_ground == 0).