### PR TITLE
Use node-shared memory for non-thermal excitation ratecoeffs

### DIFF
--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1635,19 +1635,19 @@ void analyse_sf_solution(const int modelgridindex, const int timestep, const boo
     const int ntransdisplayed = std::min(50, nt_solution[modelgridindex].frac_excitations_list_size);
 
     for (excitationindex = 0; excitationindex < ntransdisplayed; excitationindex++) {
-      const double frac_deposition = nt_solution[modelgridindex].frac_excitations_list[excitationindex].frac_deposition;
+      const auto &ntexc = nt_solution[modelgridindex].frac_excitations_list[excitationindex];
+      const double frac_deposition = ntexc.frac_deposition;
       if (frac_deposition > 0.) {
-        const int lineindex = nt_solution[modelgridindex].frac_excitations_list[excitationindex].lineindex;
-        const TransitionLine *line = &globals::linelist[lineindex];
-        const int element = line->elementindex;
-        const int ion = line->ionindex;
-        const int lower = line->lowerlevelindex;
-        const int upper = line->upperlevelindex;
-        const int uptransindex = nt_solution[modelgridindex].frac_excitations_list[excitationindex].loweruptransindex;
+        const int lineindex = ntexc.lineindex;
+        const TransitionLine &line = globals::linelist[lineindex];
+        const int element = line.elementindex;
+        const int ion = line.ionindex;
+        const int lower = line.lowerlevelindex;
+        const int upper = line.upperlevelindex;
+        const int uptransindex = ntexc.loweruptransindex;
         const double epsilon_trans = epsilon(element, ion, upper) - epsilon(element, ion, lower);
 
-        const double ratecoeffperdeposition =
-            nt_solution[modelgridindex].frac_excitations_list[excitationindex].ratecoeffperdeposition;
+        const double ratecoeffperdeposition = ntexc.ratecoeffperdeposition;
         const double ntcollexc_ratecoeff = ratecoeffperdeposition * deposition_rate_density;
 
         const double t_mid = globals::timesteps[timestep].mid;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -168,8 +168,8 @@ struct nt_solution_struct {
 
 nt_solution_struct *nt_solution;
 
-double *deposition_rate_density;
-int *deposition_rate_density_timestep;
+std::vector<double> deposition_rate_density;
+std::vector<int> deposition_rate_density_timestep;
 
 void read_shell_configs() {
   assert_always(NT_WORKFUNCTION_USE_SHELL_OCCUPANCY_FILE);
@@ -1946,8 +1946,8 @@ void init(const int my_rank, const int ndo_nonempty) {
   assert_always(nonthermal_initialized == false);
   nonthermal_initialized = true;
 
-  deposition_rate_density = static_cast<double *>(malloc(grid::get_npts_model() * sizeof(double)));
-  deposition_rate_density_timestep = static_cast<int *>(malloc(grid::get_npts_model() * sizeof(int)));
+  deposition_rate_density.resize(grid::get_npts_model());
+  deposition_rate_density_timestep.resize(grid::get_npts_model());
 
   for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
     deposition_rate_density[modelgridindex] = -1.;
@@ -2179,9 +2179,6 @@ __host__ __device__ auto get_deposition_rate_density(const int modelgridindex) -
 
 void close_file() {
   nonthermal_initialized = false;
-
-  free(deposition_rate_density);
-  free(deposition_rate_density_timestep);
 
   if (!NT_ON || !NT_SOLVE_SPENCERFANO) {
     return;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -100,11 +100,15 @@ struct collionrow {
   double B;
   double C;
   double D;
-  double auger_g_accumulated;  // track the statistical weight represented by the values below, so they can be updated
-                               // with new g-weighted averaged values
-  double prob_num_auger[NT_MAX_AUGER_ELECTRONS + 1];  // probability of 0, 1, ..., NT_MAX_AUGER_ELECTRONS Auger
-                                                      // electrons being ejected when the shell is ionised
-  float en_auger_ev;  // the average kinetic energy released in Auger electrons after making a hole in this shell
+  // track the statistical weight represented by the values below, so they can be updated with new g-weighted averaged
+  // values
+  double auger_g_accumulated;
+
+  // probability of 0, 1, ..., NT_MAX_AUGER_ELECTRONS Auger electrons being ejected when the shell is ionised
+  std::array<double, NT_MAX_AUGER_ELECTRONS + 1> prob_num_auger;
+
+  // the average kinetic energy released in Auger electrons after making a hole in this shell
+  float en_auger_ev;
   float n_auger_elec_avg;
 };
 
@@ -150,11 +154,10 @@ struct nt_solution_struct {
   float frac_excitation = 0.;  // fraction of deposition energy going to excitation
 
   // these points arrays of length includedions
-  float *eff_ionpot{};  // these are used to calculate the non-thermal ionization rate
-  double *fracdep_ionization_ion =
-      nullptr;  // the fraction of the non-thermal deposition energy going to ionizing this ion
+  float *eff_ionpot{};               // these are used to calculate the non-thermal ionization rate
+  double *fracdep_ionization_ion{};  // the fraction of the non-thermal deposition energy going to ionizing each ion
 
-  // these  point to arrays of length includedions * (NT_MAX_AUGER_ELECTRONS + 1)
+  // these point to arrays of length includedions * (NT_MAX_AUGER_ELECTRONS + 1)
   float *prob_num_auger{};       // probability that one ionisation of this ion will produce n Auger electrons.
                                  // elements sum to 1.0 for a given ion
   float *ionenfrac_num_auger{};  // like above, but energy weighted. elements sum to 1.0 for an ion

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -24,7 +24,7 @@ void calculate_deposition_rate_density(int modelgridindex, int timestep, Heating
 void do_ntlepton_deposit(Packet &pkt);
 void write_restart_data(FILE *gridsave_file);
 void read_restart_data(FILE *gridsave_file);
-void nt_MPI_Bcast(int modelgridindex, int root, int my_rank);
+void nt_MPI_Bcast(int modelgridindex, int root, int root_node_id);
 void nt_reset_stats();
 void nt_print_stats(double modelvolume, double deltat);
 }  // namespace nonthermal

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -238,7 +238,7 @@ void mpi_communicate_grid_properties(const int my_rank, const int nprocs, const 
 
       radfield::do_MPI_Bcast(modelgridindex, root, root_node_id);
 
-      nonthermal::nt_MPI_Bcast(modelgridindex, root, my_rank);
+      nonthermal::nt_MPI_Bcast(modelgridindex, root, root_node_id);
 
       if (globals::total_nlte_levels > 0 && globals::rank_in_node == 0) {
         MPI_Bcast(grid::modelgrid[modelgridindex].nlte_pops.data(), globals::total_nlte_levels, MPI_DOUBLE,


### PR DESCRIPTION
The main NT_EXCITATIONS list is now stored on node memory instead of local memory as dynamically allocating memory on each rank requires an extremely large amount of memory for 3D nebular simulations.
