### PR TITLE
Shrink upper-triangular Spencer-Fano matrix during construction and avoid linelist lookups while looping through excitations

### DIFF
--- a/atomic.h
+++ b/atomic.h
@@ -414,6 +414,9 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
     }
   }
   assert_testmodeonly(false);
+  if constexpr (!TESTMODE) {
+    __builtin_unreachable();
+  }
   return -1;
 }
 

--- a/atomic.h
+++ b/atomic.h
@@ -413,8 +413,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
       return phixstargetindex;
     }
   }
-  printout("Could not find phixstargetindex\n");
-  std::abort();
+  assert_testmodeonly(false);
   return -1;
 }
 

--- a/atomic.h
+++ b/atomic.h
@@ -110,14 +110,6 @@ inline auto get_nphixstargets(const int element, const int ion, const int level)
   return globals::elements[element].ions[ion].levels[level].phixstargets[phixstargetindex].probability;
 }
 
-// double einstein_spontaneous_emission(int element, int ion, int upper, int lower)
-// reads A_ul from levellist which consists of
-// (epsilon_upper; 0) | (g_upper; 0) | (A_upper,upper-1; f_upper,upper-1) | (A_uppper,upper-2; f_upper,upper-2) | ... |
-// (A_upper,1; f_upper,1)
-[[nodiscard]] inline auto einstein_spontaneous_emission(const int lineindex) -> double {
-  return globals::linelist[lineindex].einstein_A;
-}
-
 // Return the statistical weight of (element,ion,level).
 [[nodiscard]] inline auto stat_weight(const int element, const int ion, const int level) -> double {
   assert_testmodeonly(element < get_nelements());
@@ -219,7 +211,7 @@ inline auto get_nphixstargets(const int element, const int ion, const int level)
   const double n_l = get_levelpop(modelgridindex, element, ion, lower);
 
   const double nu_trans = (epsilon(element, ion, upper) - epsilon(element, ion, lower)) / H;
-  const double A_ul = einstein_spontaneous_emission(lineindex);
+  const double A_ul = globals::linelist[lineindex].einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
   const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -671,7 +671,6 @@ auto rad_deexcitation_ratecoeff(const int modelgridindex, const int element, con
   {
     const double nu_trans = epsilon_trans / H;
 
-    // const double A_ul = einstein_spontaneous_emission(lineindex);
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
     const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -474,10 +474,10 @@ void nltepop_matrix_add_boundbound(const int modelgridindex, const int element, 
 
     // excitation
     const int nuptrans = get_nuptrans(element, ion, level);
+    const auto &leveluptrans = globals::elements[element].ions[ion].levels[level].uptrans;
     for (int i = 0; i < nuptrans; i++) {
-      const int lineindex = globals::elements[element].ions[ion].levels[level].uptrans[i].lineindex;
-      const TransitionLine *line = &globals::linelist[lineindex];
-      const int upper = line->upperlevelindex;
+      const int lineindex = leveluptrans[i].lineindex;
+      const int upper = leveluptrans[i].targetlevelindex;
       const double epsilon_trans = epsilon(element, ion, upper) - epsilon_level;
 
       const double R =

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -218,10 +218,10 @@ constexpr void compactify_triangular_matrix(std::vector<double> &matrix) {
   for (int i = 1; i < SFPTS; i++) {
     const int rowoffset = uppertriangular(i, 0);
     for (int j = 0; j < i; j++) {
-      assert_always(matrix[i * SFPTS + j] == 0.);
+      assert_always(matrix[(i * SFPTS) + j] == 0.);
     }
     for (int j = i; j < SFPTS; j++) {
-      matrix[rowoffset + j] = matrix[i * SFPTS + j];
+      matrix[rowoffset + j] = matrix[(i * SFPTS) + j];
     }
   }
 }
@@ -230,10 +230,10 @@ constexpr void decompactify_triangular_matrix(std::vector<double> &matrix) {
   for (int i = SFPTS - 1; i > 0; i--) {
     const int rowoffset = uppertriangular(i, 0);
     for (int j = SFPTS - 1; j >= i; j--) {
-      matrix[i * SFPTS + j] = matrix[rowoffset + j];
+      matrix[(i * SFPTS) + j] = matrix[rowoffset + j];
     }
     for (int j = i - 1; j >= 0; j--) {
-      matrix[i * SFPTS + j] = 0.;
+      matrix[(i * SFPTS) + j] = 0.;
     }
   }
 }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -514,8 +514,7 @@ auto get_possible_nt_excitation_count() -> int {
       for (int lower = 0; lower < lower_nlevels; lower++) {
         const int nuptrans = get_nuptrans(element, ion, lower);
         for (int t = 0; t < nuptrans; t++) {
-          const int lineindex = globals::elements[element].ions[ion].levels[lower].uptrans[t].lineindex;
-          const int upper = globals::linelist[lineindex].upperlevelindex;
+          const int upper = globals::elements[element].ions[ion].levels[lower].uptrans[t].targetlevelindex;
           if (upper < NTEXCITATION_MAXNLEVELS_UPPER) {
             ntexcitationcount++;
           }
@@ -803,8 +802,7 @@ auto N_e(const int modelgridindex, const double energy, const std::array<double,
         const double epsilon_lower = epsilon(element, ion, lower);
         const auto statweight_lower = stat_weight(element, ion, lower);
         for (int t = 0; t < nuptrans; t++) {
-          const int lineindex = globals::elements[element].ions[ion].levels[lower].uptrans[t].lineindex;
-          const int upper = globals::linelist[lineindex].upperlevelindex;
+          const int upper = globals::elements[element].ions[ion].levels[lower].uptrans[t].targetlevelindex;
           if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
             continue;
           }
@@ -1497,8 +1495,7 @@ void analyse_sf_solution(const int modelgridindex, const int timestep, const boo
         const double epsilon_lower = epsilon(element, ion, lower);
 
         for (int t = 0; t < nuptrans; t++) {
-          const int lineindex = globals::elements[element].ions[ion].levels[lower].uptrans[t].lineindex;
-          const int upper = globals::linelist[lineindex].upperlevelindex;
+          const int upper = globals::elements[element].ions[ion].levels[lower].uptrans[t].targetlevelindex;
           if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
             continue;
           }
@@ -1517,6 +1514,7 @@ void analyse_sf_solution(const int modelgridindex, const int timestep, const boo
               // if (get_coll_str(lineindex) < 0) // if collision strength is not defined, the rate coefficient is
               // unreliable
               //   ratecoeffperdeposition = 0.;
+              const int lineindex = globals::elements[element].ions[ion].levels[lower].uptrans[t].lineindex;
 
               tmp_excitation_list.push_back({
                   .frac_deposition = frac_excitation_thistrans,
@@ -1696,8 +1694,7 @@ void sfmatrix_add_excitation(std::vector<double> &sfmatrix, const int modelgridi
     const double epsilon_lower = epsilon(element, ion, lower);
     const int nuptrans = get_nuptrans(element, ion, lower);
     for (int t = 0; t < nuptrans; t++) {
-      const int lineindex = globals::elements[element].ions[ion].levels[lower].uptrans[t].lineindex;
-      const int upper = globals::linelist[lineindex].upperlevelindex;
+      const int upper = globals::elements[element].ions[ion].levels[lower].uptrans[t].targetlevelindex;
       if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
         continue;
       }
@@ -1803,7 +1800,7 @@ void sfmatrix_add_ionization(std::vector<double> &sfmatrix, const int Z, const i
 
       if constexpr (SF_AUGER_CONTRIBUTION_ON) {
         int augerstopindex = 0;
-        if (SF_AUGER_CONTRIBUTION_DISTRIBUTE_EN) {
+        if constexpr (SF_AUGER_CONTRIBUTION_DISTRIBUTE_EN) {
           // en_auger_ev is (if LJS understands it correctly) averaged to include some probability of zero Auger
           // electrons so we need a boost to get the average energy of Auger electrons given that there are one or
           // more

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -686,7 +686,8 @@ auto get_xs_ionization_vector(std::array<double, SFPTS> &xs_vec, const collionro
 
   for (int i = startindex; i < SFPTS; i++) {
     const double u = engrid(i) / ionpot_ev;
-    const double xs_ioniz = 1e-14 * (A * (1 - 1 / u) + B * std::pow((1 - (1 / u)), 2) + C * log(u) + D * log(u) / u) /
+    const double xs_ioniz = 1e-14 *
+                            (A * (1 - 1 / u) + B * std::pow((1 - (1 / u)), 2) + C * std::log(u) + D * std::log(u) / u) /
                             (u * std::pow(ionpot_ev, 2));
     xs_vec[i] = xs_ioniz;
   }
@@ -752,7 +753,7 @@ constexpr auto xs_excitation(const int element, const int ion, const int lower, 
     // constexpr double g_bar = 0.2;
     constexpr double A = 0.28;
     constexpr double B = 0.15;
-    const double g_bar = (A * log(U)) + B;
+    const double g_bar = (A * std::log(U)) + B;
 
     constexpr double prefactor = 45.585750051;  // 8 * pi^2/sqrt(3)
     // Eq 4 of Mewe 1972, possibly from Seaton 1962?
@@ -776,11 +777,11 @@ constexpr auto electron_loss_rate(const double energy, const double nne) -> doub
   const double omegap = std::sqrt(4 * PI * nne * std::pow(QE, 2) / ME);
   const double zetae = H * omegap / 2 / PI;
   if (energy > 14 * EV) {
-    return boostfactor * nne * 2 * PI * std::pow(QE, 4) / energy * log(2 * energy / zetae);
+    return boostfactor * nne * 2 * PI * std::pow(QE, 4) / energy * std::log(2 * energy / zetae);
   }
   const double v = std::sqrt(2 * energy / ME);
   return boostfactor * nne * 2 * PI * std::pow(QE, 4) / energy *
-         log(ME * std::pow(v, 3) / (EULERGAMMA * std::pow(QE, 2) * omegap));
+         std::log(ME * std::pow(v, 3) / (EULERGAMMA * std::pow(QE, 2) * omegap));
 }
 
 // impact ionization cross section in cm^2
@@ -799,7 +800,7 @@ constexpr auto xs_impactionization(const double energy_ev, const collionrow &col
   const double C = colliondata.C;
   const double D = colliondata.D;
 
-  return 1e-14 * (A * (1 - 1 / u) + B * std::pow((1 - (1 / u)), 2) + C * log(u) + D * log(u) / u) /
+  return 1e-14 * (A * (1 - 1 / u) + B * std::pow((1 - (1 / u)), 2) + C * std::log(u) + D * std::log(u) / u) /
          (u * std::pow(ionpot_ev, 2));
 }
 
@@ -1331,7 +1332,7 @@ auto get_xs_excitation_vector(const int element, const int ion, const int lower,
     std::fill_n(xs_excitation_vec.begin(), en_startindex, 0.);
 
     // U = en / epsilon
-    // g_bar = A * log(U) + b
+    // g_bar = A * std::log(U) + b
     // xs[j] = constantfactor * g_bar / engrid(j)
     const double logepsilon = std::log(epsilon_trans_ev);
     for (int j = en_startindex; j < SFPTS; j++) {

--- a/radfield.cc
+++ b/radfield.cc
@@ -506,7 +506,7 @@ void init(const int my_rank, const int ndo_nonempty) {
         // const int upperlevel = linelist[i].upperlevelindex;
         // const int ion = linelist[i].ionindex;
         // const int ionstage = get_ionstage(element, ion);
-        const double A_ul = einstein_spontaneous_emission(i);
+        const double A_ul = globals::linelist[i].einstein_A;
 
         bool addline = false;
         // if (ionstage == 1 && lowerlevel == 6 && upperlevel == 55)

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -131,7 +131,7 @@ auto get_event(const int modelgridindex, const Packet &pkt, const Rpkt_continuum
         const int ion = globals::linelist[lineindex].ionindex;
         const int upper = globals::linelist[lineindex].upperlevelindex;
         const int lower = globals::linelist[lineindex].lowerlevelindex;
-        const double A_ul = einstein_spontaneous_emission(lineindex);
+        const double A_ul = globals::linelist[lineindex].einstein_A;
         const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
         const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -109,7 +109,7 @@ void printout_tracemission_stats() {
         const double statweight_lower = stat_weight(element, ion, lower);
 
         const double nu_trans = (epsilon(element, ion, upper) - epsilon(element, ion, lower)) / H;
-        const double A_ul = einstein_spontaneous_emission(lineindex);
+        const double A_ul = globals::linelist[lineindex].einstein_A;
         const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
         const double B_lu = statweight_target / statweight_lower * B_ul;
 
@@ -122,7 +122,7 @@ void printout_tracemission_stats() {
         printout("%7.2e (%5.1f%%) %4d %9d %5d %5d %8.1f %8.2e %4d %7.1f %7.1f %7.1e %7.1e\n", encontrib,
                  100 * encontrib / totalenergy, get_atomicnumber(element), get_ionstage(element, ion),
                  globals::linelist[lineindex].upperlevelindex, globals::linelist[lineindex].lowerlevelindex,
-                 downtrans->coll_str, einstein_spontaneous_emission(lineindex), downtrans->forbidden, linelambda, v_rad,
+                 downtrans->coll_str, globals::linelist[lineindex].einstein_A, downtrans->forbidden, linelambda, v_rad,
                  B_lu, B_ul);
       } else {
         break;


### PR DESCRIPTION
Gives about a 6% speedup for nebular test model on Apple M1.