### PR TITLE
Use stable_sort only for reproducible CI mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
             - name: Compile
               run: |
-                  make TESTMODE=${{ matrix.testmode }} MPI=ON MAX_NODE_SIZE=2 FASTMATH=OFF -j${{ steps.cpu-count.outputs.count }} sn3d exspec
+                  make REPRODUCIBLE=ON TESTMODE=${{ matrix.testmode }} MPI=ON MAX_NODE_SIZE=2 FASTMATH=OFF -j${{ steps.cpu-count.outputs.count }} sn3d exspec
                   cp sn3d tests/${{ matrix.testname }}_testrun/
                   cp exspec tests/${{ matrix.testname }}_testrun/
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,16 @@ ifeq ($(TESTMODE),ON)
 else ifeq ($(TESTMODE),OFF)
 else ifeq ($(TESTMODE),)
 else
-  $(error bad value for testmode option. Should be ON or OFF)
+  $(error bad value for TESTMODE option. Should be ON or OFF)
+endif
+
+ifeq ($(REPRODUCIBLE),ON)
+	CXXFLAGS += -DREPRODUCIBLE=true
+	BUILD_DIR := $(BUILD_DIR)_reproducable
+else ifeq ($(REPRODUCIBLE),OFF)
+else ifeq ($(REPRODUCIBLE),)
+else
+  $(error bad value for REPRODUCIBLE option. Should be ON or OFF)
 endif
 
 

--- a/decay.cc
+++ b/decay.cc
@@ -393,7 +393,7 @@ void find_decaypaths(const std::vector<int> &custom_zlist, const std::vector<int
     }
   }
 
-  std::ranges::stable_sort(decaypaths, [](const DecayPath &d1, const DecayPath &d2) {
+  std::ranges::SORT_OR_STABLE_SORT(decaypaths, [](const DecayPath &d1, const DecayPath &d2) {
     // true if d1 < d2
     // chains are sorted by mass number, then atomic number, then length
     const int d1_length = get_decaypathlength(d1);

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -175,7 +175,7 @@ void init_gamma_linelist() {
   }
   allnuc_gamma_line_list.shrink_to_fit();
   assert_always(static_cast<int>(allnuc_gamma_line_list.size()) == total_lines);
-  std::ranges::stable_sort(allnuc_gamma_line_list, [](const NucGammaLine &g1, const NucGammaLine &g2) {
+  std::ranges::SORT_OR_STABLE_SORT(allnuc_gamma_line_list, [](const NucGammaLine &g1, const NucGammaLine &g2) {
     // true if d1 < d2
     if (g1.energy < g2.energy) {
       return true;

--- a/input.cc
+++ b/input.cc
@@ -942,8 +942,8 @@ void read_atomicdata_files() {
 
   if (globals::rank_in_node == 0) {
     // sort the lineline in descending frequency
-    std::stable_sort(EXEC_PAR_UNSEQ temp_linelist.begin(), temp_linelist.end(),
-                     [](const auto &a, const auto &b) { return a.nu > b.nu; });
+    std::SORT_OR_STABLE_SORT(EXEC_PAR_UNSEQ temp_linelist.begin(), temp_linelist.end(),
+                             [](const auto &a, const auto &b) { return a.nu > b.nu; });
 
     for (int i = 0; i < globals::nlines - 1; i++) {
       const double nu = temp_linelist[i].nu;
@@ -1371,7 +1371,7 @@ void setup_phixs_list() {
       }
     }
     assert_always(groundcontindex == globals::nbfcontinua_ground);
-    std::ranges::stable_sort(globals::groundcont, std::ranges::less{}, &GroundPhotoion::nu_edge);
+    std::ranges::SORT_OR_STABLE_SORT(globals::groundcont, std::ranges::less{}, &GroundPhotoion::nu_edge);
   }
 
   auto *nonconstallcont =
@@ -1433,8 +1433,8 @@ void setup_phixs_list() {
   globals::bfestimcount = 0;
   if (globals::nbfcontinua > 0) {
     // indicies above were temporary only. continum index should be to the sorted list
-    std::ranges::stable_sort(std::span(nonconstallcont, globals::nbfcontinua), std::ranges::less{},
-                             &FullPhotoionTransition::nu_edge);
+    std::ranges::SORT_OR_STABLE_SORT(std::span(nonconstallcont, globals::nbfcontinua), std::ranges::less{},
+                                     &FullPhotoionTransition::nu_edge);
 
     globals::bfestim_nu_edge.clear();
     for (int i = 0; i < globals::nbfcontinua; i++) {
@@ -1694,6 +1694,10 @@ void read_parameterfile(int rank) {
     MPI_Bcast(&pre_zseed, 1, MPI_INT64_T, 0, MPI_COMM_WORLD);
 #endif
     printout("randomly-generated random number seed is %" PRId64 "\n", pre_zseed);
+#if defined REPRODUCIBLE && REPRODUCIBLE
+    printout("ERROR: reproducible mode is on, so random number seed is required.\n");
+    std::abort();
+#endif
   }
 
 #if defined(_OPENMP) && !defined(GPU_ON)

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1613,7 +1613,8 @@ void analyse_sf_solution(const int modelgridindex, const int timestep, const boo
 
   if (nt_excitations_stored > 0) {
     // sort by descending frac_deposition
-    std::ranges::stable_sort(tmp_excitation_list, std::ranges::greater{}, &NonThermalExcitation::frac_deposition);
+    std::ranges::SORT_OR_STABLE_SORT(tmp_excitation_list, std::ranges::greater{},
+                                     &NonThermalExcitation::frac_deposition);
 
     // the excitation list is now sorted by frac_deposition descending
     const double deposition_rate_density = get_deposition_rate_density(modelgridindex);
@@ -1673,9 +1674,9 @@ void analyse_sf_solution(const int modelgridindex, const int timestep, const boo
     }
 
     // sort the excitation list by ascending lineindex for fast lookup with a binary search
-    std::ranges::stable_sort(std::span(nt_solution[modelgridindex].frac_excitations_list,
-                                       nt_solution[modelgridindex].frac_excitations_list_size),
-                             std::ranges::less{}, &NonThermalExcitation::lineindex);
+    std::ranges::SORT_OR_STABLE_SORT(std::span(nt_solution[modelgridindex].frac_excitations_list,
+                                               nt_solution[modelgridindex].frac_excitations_list_size),
+                                     std::ranges::less{}, &NonThermalExcitation::lineindex);
 
   }  // NT_EXCITATION_ON
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -537,7 +537,7 @@ void init(const int my_rank, const int ndo_nonempty) {
     // these are probably sorted anyway because the previous loop goes in ascending
     // lineindex. But this sorting step is quick and makes sure that the
     // binary searching later will work correctly
-    std::stable_sort(detailed_lineindicies, detailed_lineindicies + detailed_linecount);
+    std::SORT_OR_STABLE_SORT(detailed_lineindicies, detailed_lineindicies + detailed_linecount);
   }
 
   printout("There are %d lines with detailed Jblue_lu estimators.\n", detailed_linecount);

--- a/sn3d.h
+++ b/sn3d.h
@@ -148,6 +148,12 @@ inline void print_line_start() {
 #define assert_testmodeonly(e) (void)0
 #endif
 
+#if defined REPRODUCIBLE && REPRODUCIBLE
+#define SORT_OR_STABLE_SORT stable_sort
+#else
+#define SORT_OR_STABLE_SORT sort
+#endif
+
 template <typename T>
 inline void atomicadd(T &var, const T &val) {
 #ifdef _OPENMP

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -53,8 +53,8 @@ void printout_tracemission_stats() {
   // mode is 0 for emission and 1 for absorption
   for (int mode = 0; mode < 2; mode++) {
     if (mode == 0) {
-      std::ranges::stable_sort(traceemissionabsorption,
-                               [](const auto &a, const auto &b) { return a.energyemitted > b.energyemitted; });
+      std::ranges::SORT_OR_STABLE_SORT(traceemissionabsorption,
+                                       [](const auto &a, const auto &b) { return a.energyemitted > b.energyemitted; });
       printout("lambda [%5.1f, %5.1f] nu %g %g\n", traceemissabs_lambdamin, traceemissabs_lambdamax,
                traceemissabs_nulower, traceemissabs_nuupper);
 
@@ -62,8 +62,8 @@ void printout_tracemission_stats() {
                traceemissabs_lambdamin, traceemissabs_lambdamax, traceemissabs_timemin / DAY,
                traceemissabs_timemax / DAY, traceemission_totalenergy);
     } else {
-      std::ranges::stable_sort(traceemissionabsorption, std::ranges::greater{},
-                               &emissionabsorptioncontrib::energyabsorbed);
+      std::ranges::SORT_OR_STABLE_SORT(traceemissionabsorption, std::ranges::greater{},
+                                       &emissionabsorptioncontrib::energyabsorbed);
       printout("Top line absorption contributions in the range lambda [%5.1f, %5.1f] time [%5.1fd, %5.1fd] (%g erg)\n",
                traceemissabs_lambdamin, traceemissabs_lambdamax, traceemissabs_timemin / DAY,
                traceemissabs_timemax / DAY, traceabsorption_totalenergy);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -361,7 +361,7 @@ void update_packets(const int my_rank, const int nts, std::span<Packet> packets)
 
     // printout("sorting packets...");
 
-    std::ranges::stable_sort(packets, std_compare_packets_bymodelgriddensity);
+    std::ranges::SORT_OR_STABLE_SORT(packets, std_compare_packets_bymodelgriddensity);
 
     // printout("took %lds\n", std::time(nullptr) - sys_time_start_pass);
 


### PR DESCRIPTION
Gives an 18% speedup for nebular test calculation on Apple M1.