### PR TITLE
Fix resetting particle dep estimators (low impact)

### DIFF
--- a/grid.cc
+++ b/grid.cc
@@ -1190,10 +1190,11 @@ void read_grid_restart_data(const int timestep) {
     float W = 0.;
     float T_J = 0.;
     int thick = 0;
-    double dep_estimator_gamma = 0.;
 
-    assert_always(fscanf(gridsave_file, "%d %a %a %a %a %d %la %a %a", &mgi_in, &T_R, &T_e, &W, &T_J, &thick,
-                         &dep_estimator_gamma, &modelgrid[mgi].nne, &modelgrid[mgi].nnetot) == 9);
+    assert_always(fscanf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", &mgi_in, &T_R, &T_e, &W, &T_J,
+                         &thick, &globals::dep_estimator_gamma[nonemptymgi],
+                         &globals::dep_estimator_positron[nonemptymgi], &globals::dep_estimator_electron[nonemptymgi],
+                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid[mgi].nne, &modelgrid[mgi].nnetot) == 9);
 
     if (mgi_in != mgi) {
       printout("[fatal] read_grid_restart_data: cell mismatch in reading input gridsave.dat ... abort\n");
@@ -1205,14 +1206,16 @@ void read_grid_restart_data(const int timestep) {
     assert_always(T_e >= 0.);
     assert_always(W >= 0.);
     assert_always(T_J >= 0.);
-    assert_always(dep_estimator_gamma >= 0.);
+    assert_always(globals::dep_estimator_gamma[nonemptymgi] >= 0.);
+    assert_always(globals::dep_estimator_positron[nonemptymgi] >= 0.);
+    assert_always(globals::dep_estimator_electron[nonemptymgi] >= 0.);
+    assert_always(globals::dep_estimator_alpha[nonemptymgi] >= 0.);
 
     set_TR(mgi, T_R);
     set_Te(mgi, T_e);
     set_W(mgi, W);
     set_TJ(mgi, T_J);
     modelgrid[mgi].thick = thick;
-    globals::dep_estimator_gamma[nonemptymgi] = dep_estimator_gamma;
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {
@@ -2222,8 +2225,10 @@ void write_grid_restart_data(const int timestep) {
     const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
     assert_always(globals::dep_estimator_gamma[nonemptymgi] >= 0.);
-    fprintf(gridsave_file, "%d %a %a %a %a %d %la %a %a", mgi, get_TR(mgi), get_Te(mgi), get_W(mgi), get_TJ(mgi),
-            modelgrid[mgi].thick, globals::dep_estimator_gamma[nonemptymgi], modelgrid[mgi].nne, modelgrid[mgi].nnetot);
+    fprintf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", mgi, get_TR(mgi), get_Te(mgi), get_W(mgi),
+            get_TJ(mgi), modelgrid[mgi].thick, globals::dep_estimator_gamma[nonemptymgi],
+            globals::dep_estimator_positron[nonemptymgi], globals::dep_estimator_electron[nonemptymgi],
+            globals::dep_estimator_alpha[nonemptymgi], modelgrid[mgi].nne, modelgrid[mgi].nnetot);
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {

--- a/grid.cc
+++ b/grid.cc
@@ -1194,7 +1194,8 @@ void read_grid_restart_data(const int timestep) {
     assert_always(fscanf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", &mgi_in, &T_R, &T_e, &W, &T_J,
                          &thick, &globals::dep_estimator_gamma[nonemptymgi],
                          &globals::dep_estimator_positron[nonemptymgi], &globals::dep_estimator_electron[nonemptymgi],
-                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid[mgi].nne, &modelgrid[mgi].nnetot) == 9);
+                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid[mgi].nne,
+                         &modelgrid[mgi].nnetot) == 12);
 
     if (mgi_in != mgi) {
       printout("[fatal] read_grid_restart_data: cell mismatch in reading input gridsave.dat ... abort\n");

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -613,6 +613,9 @@ void zero_estimators() {
   std::ranges::fill(globals::ffheatingestimator, 0.);
   std::ranges::fill(globals::colheatingestimator, 0.);
   std::ranges::fill(globals::dep_estimator_gamma, 0.);
+  std::ranges::fill(globals::dep_estimator_positron, 0.);
+  std::ranges::fill(globals::dep_estimator_electron, 0.);
+  std::ranges::fill(globals::dep_estimator_alpha, 0.);
 
   if constexpr (USE_LUT_PHOTOION) {
     if (globals::nbfcontinua_ground > 0) {


### PR DESCRIPTION
Dep estimators for electrons, positrons, and alphas were not being zeroed at each timestep. However, since they were being divided by dV * dT for normalisation, they became close to zero anyway. Also enable save/load of these estimators to get sensible values on first timestep after resume.