### PR TITLE
Optionally apply time-dependent thermalisation to electrons/positrons produced from gamma-rays

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -59,6 +59,6 @@ constexpr size_t GSLWSIZE = 16384;  // GSL integration workspace size
 
 enum class TimeStepSizeMethod { LOGARITHMIC, CONSTANT, LOGARITHMIC_THEN_CONSTANT, CONSTANT_THEN_LOGARITHMIC };
 
-enum class ThermalisationScheme { INSTANT, DETAILED, BARNES, WOLLAEGER, GUTTMAN };
+enum class ThermalisationScheme { INSTANT, DETAILED, DETAILEDWITHGAMMAPRODUCTS, BARNES, WOLLAEGER, GUTTMAN };
 
 #endif


### PR DESCRIPTION
Time-dependent thermalisation was only applied to alphas and betas emitted directly by decays. With the DETAILEDWITHGAMMAPRODUCTS thermalisation mode, the time-dependent treatment also applies to the Compton electrons, photoionised ejected electrons, or electron/positrons from pair-production. Their contributions are still called "gamma-ray deposition" and these particles do not contribute to the alpha and beta deposition rates.