### PR TITLE
Share modelgrid array on node

### DIFF
--- a/decay.cc
+++ b/decay.cc
@@ -1054,15 +1054,8 @@ void setup_decaypath_energy_per_mass() {
       nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
   double *decaypath_energy_per_mass_data{nullptr};
 #ifdef MPI_ON
-  const auto [_, noderank_nonemptycellcount] =
-      get_range_chunk(nonempty_npts_model, globals::node_nprocs, globals::rank_in_node);
-  auto size = static_cast<MPI_Aint>(noderank_nonemptycellcount * get_num_decaypaths() * sizeof(double));
-  int disp_unit = sizeof(double);
-  assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node,
-                                        &decaypath_energy_per_mass_data,
-                                        &win_decaypath_energy_per_mass) == MPI_SUCCESS);
-  assert_always(MPI_Win_shared_query(win_decaypath_energy_per_mass, 0, &size, &disp_unit,
-                                     &decaypath_energy_per_mass_data) == MPI_SUCCESS);
+  std::tie(decaypath_energy_per_mass_data, win_decaypath_energy_per_mass) =
+      MPI_shared_malloc_keepwin<double>(nonempty_npts_model * get_num_decaypaths());
 #else
   decaypath_energy_per_mass_data =
       static_cast<double *>(malloc(nonempty_npts_model * get_num_decaypaths() * sizeof(double)));

--- a/decay.cc
+++ b/decay.cc
@@ -730,7 +730,7 @@ auto get_simtime_endecay_per_ejectamass(const int nonemptymgi, const int decaypa
   return chainendecay;
 }
 
-auto get_decaypath_power_per_ejectamass(const int decaypathindex, const int modelgridindex, const double time) -> double
+auto get_decaypath_power_per_ejectamass(const int decaypathindex, const int nonemptymgi, const double time) -> double
 // total decay power per mass [erg/s/g] for a given decaypath
 {
   // only decays at the end of the chain contributed from the initial abundance of the top of the chain are counted
@@ -739,6 +739,7 @@ auto get_decaypath_power_per_ejectamass(const int decaypathindex, const int mode
   const int z_top = decaypaths[decaypathindex].z[0];
   const int a_top = decaypaths[decaypathindex].a[0];
   const int nucindex_top = decaypaths[decaypathindex].nucindex[0];
+  const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
   const double top_initabund = grid::get_modelinitnucmassfrac(modelgridindex, nucindex_top);
   assert_always(top_initabund >= 0.);
@@ -1422,7 +1423,7 @@ void setup_radioactive_pellet(const double e0, const int mgi, Packet &pkt) {
         get_simtime_endecay_per_ejectamass(nonemptymgi, decaypathindex) / (globals::tmax - tdecaymin);
     assert_always(avgpower > 0.);
     assert_always(std::isfinite(avgpower));
-    pkt.e_cmf = e0 * get_decaypath_power_per_ejectamass(decaypathindex, mgi, pkt.tdecay) / avgpower;
+    pkt.e_cmf = e0 * get_decaypath_power_per_ejectamass(decaypathindex, nonemptymgi, pkt.tdecay) / avgpower;
     assert_always(pkt.e_cmf >= 0);
     assert_always(std::isfinite(pkt.e_cmf));
   }

--- a/grid.cc
+++ b/grid.cc
@@ -294,12 +294,6 @@ void allocate_nonemptycells_composition_cooling()
     // -1 indicates that there is currently no information on the nlte populations
     std::ranges::fill_n(grid::nltepops_allcells, npts_nonempty * globals::total_nlte_levels, -1.);
   }
-
-  for (ptrdiff_t nonemptymgi = 0; nonemptymgi < npts_nonempty; nonemptymgi++) {
-    const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-
-    modelgrid[modelgridindex].ion_partfuncts = &ion_partfuncts_allcells[nonemptymgi * get_includedions()];
-  }
 }
 
 void allocate_nonemptymodelcells() {

--- a/grid.cc
+++ b/grid.cc
@@ -120,7 +120,9 @@ void set_npts_model(const int new_npts_model) {
 
   assert_always(modelgrid.data() == nullptr);
   modelgrid = MPI_shared_malloc_span<ModelGridCell>(npts_model + 1);
-  std::ranges::fill(modelgrid, ModelGridCell{});
+  if (globals::rank_in_node == 0) {
+    std::ranges::fill(modelgrid, ModelGridCell{});
+  }
 #ifdef MPI_ON
   MPI_Barrier(globals::mpi_comm_node);
 #endif
@@ -303,7 +305,9 @@ void allocate_nonemptymodelcells() {
   // Determine the number of simulation cells associated with the model cells
   for (int mgi = 0; mgi < (get_npts_model() + 1); mgi++) {
     mg_associated_cells[mgi] = 0;
-    modelgrid[mgi].initial_radial_pos_sum = 0.;
+    if (globals::rank_in_node == 0) {
+      modelgrid[mgi].initial_radial_pos_sum = 0.;
+    }
   }
 
   for (int cellindex = 0; cellindex < ngrid; cellindex++) {
@@ -319,7 +323,9 @@ void allocate_nonemptymodelcells() {
     assert_always(!(get_model_type() == GridType::CARTESIAN3D) || (get_rho_tmin(mgi) > 0) || (mgi == get_npts_model()));
 
     mg_associated_cells[mgi] += 1;
-    modelgrid[mgi].initial_radial_pos_sum += radial_pos_mid;
+    if (globals::rank_in_node == 0) {
+      modelgrid[mgi].initial_radial_pos_sum += radial_pos_mid;
+    }
 
     assert_always(!(get_model_type() == GridType::CARTESIAN3D) || (mg_associated_cells[mgi] == 1) ||
                   (mgi == get_npts_model()));

--- a/grid.cc
+++ b/grid.cc
@@ -120,8 +120,8 @@ void set_npts_model(const int new_npts_model) {
 
   assert_always(modelgrid.data() == nullptr);
   modelgrid = std::span(static_cast<ModelGridCell *>(malloc((npts_model + 1) * sizeof(ModelGridCell))), npts_model + 1);
-  // std::fill(modelgrid.begin(), modelgrid.end(), ModelGridCell{});
-  memset(static_cast<void *>(modelgrid.data()), 0, (npts_model + 1) * sizeof(ModelGridCell));
+  std::fill(modelgrid.begin(), modelgrid.end(), ModelGridCell{});
+  // memset(static_cast<void *>(modelgrid.data()), 0, (npts_model + 1) * sizeof(ModelGridCell));
   assert_always(modelgrid.data() != nullptr);
   mg_associated_cells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);

--- a/grid.cc
+++ b/grid.cc
@@ -85,7 +85,6 @@ std::vector<int> ranks_nstart;
 std::vector<int> ranks_nstart_nonempty;
 std::vector<int> ranks_ndo;
 std::vector<int> ranks_ndo_nonempty;
-int maxndo = -1;
 
 void set_rho_tmin(const int modelgridindex, const float x) { modelgrid[modelgridindex].rhoinit = x; }
 
@@ -1210,7 +1209,6 @@ void setup_nstart_ndo() {
   const int npts_nonempty = get_nonempty_npts_model();
   const int min_nonempty_perproc = npts_nonempty / nprocesses;  // integer division, minimum non-empty cells per process
   const int n_remainder = npts_nonempty % nprocesses;
-  maxndo = 0;
 
   ranks_nstart.resize(nprocesses, -1);
   ranks_nstart_nonempty.resize(nprocesses, -1);
@@ -1225,7 +1223,6 @@ void setup_nstart_ndo() {
 
   if (nprocesses >= get_npts_model()) {
     // for convenience, rank == mgi when there is at least one rank per cell
-    maxndo = 1;
     for (int rank = 0; rank < nprocesses; rank++) {
       if (rank < get_npts_model()) {
         const int mgi = rank;
@@ -1250,7 +1247,6 @@ void setup_nstart_ndo() {
       }
 
       ranks_ndo[rank]++;
-      maxndo = std::max(maxndo, ranks_ndo[rank]);
       if (get_numpropcells(mgi) > 0) {
         ranks_ndo_nonempty[rank]++;
       }
@@ -2187,13 +2183,6 @@ void write_grid_restart_data(const int timestep) {
   nltepop_write_restart_data(gridsave_file);
   fclose(gridsave_file);
   printout("done in %ld seconds.\n", std::time(nullptr) - sys_time_start_write_restart);
-}
-
-auto get_maxndo() -> int {
-  if (ranks_ndo.empty()) {
-    setup_nstart_ndo();
-  }
-  return maxndo;
 }
 
 auto get_nstart(const int rank) -> int {

--- a/grid.cc
+++ b/grid.cc
@@ -120,9 +120,10 @@ void set_npts_model(const int new_npts_model) {
 
   assert_always(modelgrid.data() == nullptr);
   modelgrid = std::span(static_cast<ModelGridCell *>(malloc((npts_model + 1) * sizeof(ModelGridCell))), npts_model + 1);
-  std::fill(modelgrid.begin(), modelgrid.end(), ModelGridCell{});
-  // memset(static_cast<void *>(modelgrid.data()), 0, (npts_model + 1) * sizeof(ModelGridCell));
-  assert_always(modelgrid.data() != nullptr);
+  std::ranges::fill(modelgrid, ModelGridCell{});
+#ifdef MPI_ON
+  MPI_Barrier(globals::mpi_comm_node);
+#endif
   mg_associated_cells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);
 }

--- a/grid.cc
+++ b/grid.cc
@@ -2015,8 +2015,8 @@ void set_element_meanweight(const int nonemptymgi, const int element, const floa
   elem_meanweight_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_nelements()) + element] = meanweight;
 }
 
-auto get_electronfrac(const int modelgridindex) -> double {
-  const auto nonemptymgi = get_nonemptymgi_of_mgi(modelgridindex);
+auto get_electronfrac(const int nonemptymgi) -> double {
+  const auto modelgridindex = get_mgi_of_nonemptymgi(nonemptymgi);
   double nucleondens = 0.;
   for (int element = 0; element < get_nelements(); element++) {
     nucleondens += get_elem_numberdens(modelgridindex, element) * get_element_meanweight(nonemptymgi, element) / MH;

--- a/grid.cc
+++ b/grid.cc
@@ -270,6 +270,8 @@ void allocate_nonemptycells_composition_cooling()
   elements_uppermost_ion_allcells = MPI_shared_malloc<int>(npts_nonempty * nelements);
   elem_massfracs_allcells = MPI_shared_malloc<float>(npts_nonempty * nelements);
   ion_groundlevelpops_allcells = MPI_shared_malloc<float>(npts_nonempty * get_includedions());
+  ion_partfuncts_allcells = MPI_shared_malloc<float>(npts_nonempty * get_includedions());
+  ion_cooling_contribs_allcells = MPI_shared_malloc<double>(npts_nonempty * get_includedions());
 
   if (globals::total_nlte_levels > 0) {
 #ifdef MPI_ON
@@ -297,21 +299,8 @@ void allocate_nonemptycells_composition_cooling()
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
     modelgrid[modelgridindex].ion_groundlevelpops = &ion_groundlevelpops_allcells[nonemptymgi * get_includedions()];
-
-    modelgrid[modelgridindex].ion_partfuncts = static_cast<float *>(calloc(get_includedions(), sizeof(float)));
-
-    if (modelgrid[modelgridindex].ion_partfuncts == nullptr) {
-      printout("[fatal] input: not enough memory to initialize partfunctlist in cell %d... abort\n", modelgridindex);
-      std::abort();
-    }
-
-    modelgrid[modelgridindex].ion_cooling_contribs = static_cast<double *>(malloc(get_includedions() * sizeof(double)));
-
-    if (modelgrid[modelgridindex].ion_cooling_contribs == nullptr) {
-      printout("[fatal] input: not enough memory to initialize ion_cooling_contribs for cell %d... abort\n",
-               modelgridindex);
-      std::abort();
-    }
+    modelgrid[modelgridindex].ion_partfuncts = &ion_partfuncts_allcells[nonemptymgi * get_includedions()];
+    modelgrid[modelgridindex].ion_cooling_contribs = &ion_cooling_contribs_allcells[nonemptymgi * get_includedions()];
   }
 }
 

--- a/grid.cc
+++ b/grid.cc
@@ -119,9 +119,8 @@ void set_npts_model(const int new_npts_model) {
   npts_model = new_npts_model;
 
   assert_always(modelgrid.data() == nullptr);
-  modelgrid = MPI_shared_malloc_span<ModelGridCell>(npts_model + 1);
-  // std::fill(modelgrid.begin(), modelgrid.end(), ModelGridCell{});
-  memset(static_cast<void *>(modelgrid.data()), 0, (npts_model + 1) * sizeof(ModelGridCell));
+  modelgrid = std::span(static_cast<ModelGridCell *>(calloc(npts_model + 1, sizeof(ModelGridCell))), npts_model + 1);
+  assert_always(modelgrid.data() != nullptr);
   mg_associated_cells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);
 }

--- a/grid.cc
+++ b/grid.cc
@@ -119,8 +119,9 @@ void set_npts_model(const int new_npts_model) {
   npts_model = new_npts_model;
 
   assert_always(modelgrid.data() == nullptr);
-  modelgrid = std::span(static_cast<ModelGridCell *>(calloc(npts_model + 1, sizeof(ModelGridCell))), npts_model + 1);
-  assert_always(modelgrid.data() != nullptr);
+  modelgrid = MPI_shared_malloc_span<ModelGridCell>(npts_model + 1);
+  // std::fill(modelgrid.begin(), modelgrid.end(), ModelGridCell{});
+  memset(static_cast<void *>(modelgrid.data()), 0, (npts_model + 1) * sizeof(ModelGridCell));
   mg_associated_cells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);
 }

--- a/grid.cc
+++ b/grid.cc
@@ -85,7 +85,6 @@ std::vector<int> ranks_nstart;
 std::vector<int> ranks_nstart_nonempty;
 std::vector<int> ranks_ndo;
 std::vector<int> ranks_ndo_nonempty;
-int maxndo = -1;
 
 void set_rho_tmin(const int modelgridindex, const float x) { modelgrid[modelgridindex].rhoinit = x; }
 
@@ -1204,7 +1203,6 @@ void setup_nstart_ndo() {
   const int npts_nonempty = get_nonempty_npts_model();
   const int min_nonempty_perproc = npts_nonempty / nprocesses;  // integer division, minimum non-empty cells per process
   const int n_remainder = npts_nonempty % nprocesses;
-  maxndo = 0;
 
   ranks_nstart.resize(nprocesses, -1);
   ranks_nstart_nonempty.resize(nprocesses, -1);
@@ -1219,7 +1217,6 @@ void setup_nstart_ndo() {
 
   if (nprocesses >= get_npts_model()) {
     // for convenience, rank == mgi when there is at least one rank per cell
-    maxndo = 1;
     for (int rank = 0; rank < nprocesses; rank++) {
       if (rank < get_npts_model()) {
         const int mgi = rank;
@@ -1244,7 +1241,6 @@ void setup_nstart_ndo() {
       }
 
       ranks_ndo[rank]++;
-      maxndo = std::max(maxndo, ranks_ndo[rank]);
       if (get_numpropcells(mgi) > 0) {
         ranks_ndo_nonempty[rank]++;
       }
@@ -2181,13 +2177,6 @@ void write_grid_restart_data(const int timestep) {
   nltepop_write_restart_data(gridsave_file);
   fclose(gridsave_file);
   printout("done in %ld seconds.\n", std::time(nullptr) - sys_time_start_write_restart);
-}
-
-auto get_maxndo() -> int {
-  if (ranks_ndo.empty()) {
-    setup_nstart_ndo();
-  }
-  return maxndo;
 }
 
 auto get_nstart(const int rank) -> int {

--- a/grid.cc
+++ b/grid.cc
@@ -85,6 +85,7 @@ std::vector<int> ranks_nstart;
 std::vector<int> ranks_nstart_nonempty;
 std::vector<int> ranks_ndo;
 std::vector<int> ranks_ndo_nonempty;
+int maxndo = -1;
 
 void set_rho_tmin(const int modelgridindex, const float x) { modelgrid[modelgridindex].rhoinit = x; }
 
@@ -1203,6 +1204,7 @@ void setup_nstart_ndo() {
   const int npts_nonempty = get_nonempty_npts_model();
   const int min_nonempty_perproc = npts_nonempty / nprocesses;  // integer division, minimum non-empty cells per process
   const int n_remainder = npts_nonempty % nprocesses;
+  maxndo = 0;
 
   ranks_nstart.resize(nprocesses, -1);
   ranks_nstart_nonempty.resize(nprocesses, -1);
@@ -1217,6 +1219,7 @@ void setup_nstart_ndo() {
 
   if (nprocesses >= get_npts_model()) {
     // for convenience, rank == mgi when there is at least one rank per cell
+    maxndo = 1;
     for (int rank = 0; rank < nprocesses; rank++) {
       if (rank < get_npts_model()) {
         const int mgi = rank;
@@ -1241,6 +1244,7 @@ void setup_nstart_ndo() {
       }
 
       ranks_ndo[rank]++;
+      maxndo = std::max(maxndo, ranks_ndo[rank]);
       if (get_numpropcells(mgi) > 0) {
         ranks_ndo_nonempty[rank]++;
       }
@@ -2177,6 +2181,13 @@ void write_grid_restart_data(const int timestep) {
   nltepop_write_restart_data(gridsave_file);
   fclose(gridsave_file);
   printout("done in %ld seconds.\n", std::time(nullptr) - sys_time_start_write_restart);
+}
+
+auto get_maxndo() -> int {
+  if (ranks_ndo.empty()) {
+    setup_nstart_ndo();
+  }
+  return maxndo;
 }
 
 auto get_nstart(const int rank) -> int {

--- a/grid.cc
+++ b/grid.cc
@@ -324,6 +324,12 @@ void allocate_nonemptycells_composition_cooling()
   elements_uppermost_ion_allcells = static_cast<int *>(malloc(npts_nonempty * nelements * sizeof(int)));
   elem_massfracs_allcells = static_cast<float *>(malloc(npts_nonempty * nelements * sizeof(float)));
 #endif
+  if (globals::rank_in_node == 0) {
+    std::fill_n(initmassfracuntrackedstable_allcells, npts_nonempty * nelements, -1.);
+    std::fill_n(elem_meanweight_allcells, npts_nonempty * nelements, -1.);
+    std::fill_n(elements_uppermost_ion_allcells, npts_nonempty * nelements, -1);
+    std::fill_n(elem_massfracs_allcells, npts_nonempty * nelements, -1.);
+  }
 
   if (globals::total_nlte_levels > 0) {
 #ifdef MPI_ON
@@ -349,8 +355,6 @@ void allocate_nonemptycells_composition_cooling()
       std::ranges::fill_n(&grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels)],
                           globals::total_nlte_levels, -1.);
     }
-
-    std::fill_n(&elem_massfracs_allcells[nonemptymgi * nelements], nelements, -1.);
 
     modelgrid[modelgridindex].ion_groundlevelpops = static_cast<float *>(calloc(get_includedions(), sizeof(float)));
     if (modelgrid[modelgridindex].ion_groundlevelpops == nullptr) {

--- a/grid.cc
+++ b/grid.cc
@@ -119,7 +119,7 @@ void set_npts_model(const int new_npts_model) {
   npts_model = new_npts_model;
 
   assert_always(modelgrid.data() == nullptr);
-  modelgrid = std::span(static_cast<ModelGridCell *>(malloc((npts_model + 1) * sizeof(ModelGridCell))), npts_model + 1);
+  modelgrid = MPI_shared_malloc_span<ModelGridCell>(npts_model + 1);
   std::ranges::fill(modelgrid, ModelGridCell{});
 #ifdef MPI_ON
   MPI_Barrier(globals::mpi_comm_node);

--- a/grid.cc
+++ b/grid.cc
@@ -298,7 +298,6 @@ void allocate_nonemptycells_composition_cooling()
   for (ptrdiff_t nonemptymgi = 0; nonemptymgi < npts_nonempty; nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
-    modelgrid[modelgridindex].ion_groundlevelpops = &ion_groundlevelpops_allcells[nonemptymgi * get_includedions()];
     modelgrid[modelgridindex].ion_partfuncts = &ion_partfuncts_allcells[nonemptymgi * get_includedions()];
   }
 }

--- a/grid.cc
+++ b/grid.cc
@@ -300,7 +300,6 @@ void allocate_nonemptycells_composition_cooling()
 
     modelgrid[modelgridindex].ion_groundlevelpops = &ion_groundlevelpops_allcells[nonemptymgi * get_includedions()];
     modelgrid[modelgridindex].ion_partfuncts = &ion_partfuncts_allcells[nonemptymgi * get_includedions()];
-    modelgrid[modelgridindex].ion_cooling_contribs = &ion_cooling_contribs_allcells[nonemptymgi * get_includedions()];
   }
 }
 

--- a/grid.cc
+++ b/grid.cc
@@ -120,6 +120,8 @@ void set_npts_model(const int new_npts_model) {
 
   assert_always(modelgrid.data() == nullptr);
   modelgrid = std::span(static_cast<ModelGridCell *>(malloc((npts_model + 1) * sizeof(ModelGridCell))), npts_model + 1);
+  // std::fill(modelgrid.begin(), modelgrid.end(), ModelGridCell{});
+  memset(static_cast<void *>(modelgrid.data()), 0, (npts_model + 1) * sizeof(ModelGridCell));
   assert_always(modelgrid.data() != nullptr);
   mg_associated_cells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);

--- a/grid.cc
+++ b/grid.cc
@@ -408,7 +408,7 @@ void allocate_nonemptymodelcells() {
   // find number of non-empty cells and allocate nonempty list
   nonempty_npts_model = 0;
   for (int mgi = 0; mgi < get_npts_model(); mgi++) {
-    if (get_numassociatedcells(mgi) > 0) {
+    if (get_numpropcells(mgi) > 0) {
       nonempty_npts_model++;
     }
   }
@@ -419,7 +419,7 @@ void allocate_nonemptymodelcells() {
   int nonemptymgi = 0;  // index within list of non-empty modelgrid cells
 
   for (int mgi = 0; mgi < get_npts_model(); mgi++) {
-    if (get_numassociatedcells(mgi) > 0) {
+    if (get_numpropcells(mgi) > 0) {
       if (get_rho_tmin(mgi) <= 0) {
         printout("Error: negative or zero density. Abort.\n");
         std::abort();
@@ -609,7 +609,7 @@ void abundances_read() {
       abundances_in[anumber - 1] = 0.;
       if (!(ssline >> abund_in)) {
         // at least one element (hydrogen) should have been specified for nonempty cells
-        assert_always(anumber > 1 || get_numassociatedcells(mgi) == 0);
+        assert_always(anumber > 1 || get_numpropcells(mgi) == 0);
         break;
       }
 
@@ -621,7 +621,7 @@ void abundances_read() {
       normfactor += abundances_in[anumber - 1];
     }
 
-    if (get_numassociatedcells(mgi) > 0) {
+    if (get_numpropcells(mgi) > 0) {
       if (threedimensional || normfactor <= 0.) {
         normfactor = 1.;
       }
@@ -1280,7 +1280,7 @@ void assign_initial_temperatures() {
 // start at mgi_start and find the next non-empty cell, or return -1 if none found
 [[nodiscard]] auto get_next_nonemptymgi(const int mgi_start) -> int {
   for (int mgi = mgi_start; mgi < get_npts_model(); mgi++) {
-    if (get_numassociatedcells(mgi) > 0) {
+    if (get_numpropcells(mgi) > 0) {
       return nonemptymgi_of_mgi[mgi];
     }
   }
@@ -1313,8 +1313,8 @@ void setup_nstart_ndo() {
         const int mgi = rank;
         ranks_nstart[rank] = mgi;
         ranks_ndo[rank] = 1;
-        ranks_nstart_nonempty[rank] = (get_numassociatedcells(mgi) > 0) ? get_nonemptymgi_of_mgi(mgi) : 0;
-        ranks_ndo_nonempty[rank] = (get_numassociatedcells(mgi) > 0) ? 1 : 0;
+        ranks_nstart_nonempty[rank] = (get_numpropcells(mgi) > 0) ? get_nonemptymgi_of_mgi(mgi) : 0;
+        ranks_ndo_nonempty[rank] = (get_numpropcells(mgi) > 0) ? 1 : 0;
       }
     }
   } else {
@@ -1333,7 +1333,7 @@ void setup_nstart_ndo() {
 
       ranks_ndo[rank]++;
       maxndo = std::max(maxndo, ranks_ndo[rank]);
-      if (get_numassociatedcells(mgi) > 0) {
+      if (get_numpropcells(mgi) > 0) {
         ranks_ndo_nonempty[rank]++;
       }
     }
@@ -1686,7 +1686,7 @@ auto wid_init(const int cellindex, const int axis) -> double
 auto get_modelcell_assocvolume_tmin(const int modelgridindex) -> double {
   if constexpr (GRID_TYPE == GridType::CARTESIAN3D) {
     return (wid_init(modelgridindex, 0) * wid_init(modelgridindex, 1) * wid_init(modelgridindex, 2)) *
-           get_numassociatedcells(modelgridindex);
+           get_numpropcells(modelgridindex);
   }
 
   if constexpr (GRID_TYPE == GridType::CYLINDRICAL2D) {
@@ -1948,7 +1948,7 @@ __host__ __device__ auto get_cell_modelgridindex(const int cellindex) -> int {
 }
 
 // number of propagation cells associated with each modelgrid cell
-__host__ __device__ auto get_numassociatedcells(const int modelgridindex) -> int {
+__host__ __device__ auto get_numpropcells(const int modelgridindex) -> int {
   assert_testmodeonly(modelgridindex <= get_npts_model());
   return mg_associated_cells[modelgridindex];
 }
@@ -1959,7 +1959,7 @@ __host__ __device__ auto get_nonemptymgi_of_mgi(const int mgi) -> int {
   assert_testmodeonly(mgi < get_npts_model());
 
   const int nonemptymgi = nonemptymgi_of_mgi[mgi];
-  // assert_testmodeonly(nonemptymgi >= 0 || get_numassociatedcells(mgi) == 0);
+  // assert_testmodeonly(nonemptymgi >= 0 || get_numpropcells(mgi) == 0);
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
 

--- a/grid.cc
+++ b/grid.cc
@@ -119,7 +119,7 @@ void set_npts_model(const int new_npts_model) {
   npts_model = new_npts_model;
 
   assert_always(modelgrid.data() == nullptr);
-  modelgrid = std::span(static_cast<ModelGridCell *>(calloc(npts_model + 1, sizeof(ModelGridCell))), npts_model + 1);
+  modelgrid = std::span(static_cast<ModelGridCell *>(malloc((npts_model + 1) * sizeof(ModelGridCell))), npts_model + 1);
   assert_always(modelgrid.data() != nullptr);
   mg_associated_cells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);

--- a/grid.h
+++ b/grid.h
@@ -30,11 +30,10 @@ struct ModelGridCell {
   float initenergyq = 0.;       // q: energy in the model at tmin to use with USE_MODEL_INITIAL_ENERGY [erg/g]
   float ffegrp = 0.;
   float kappagrey = 0.;
-  float grey_depth = 0.;         // Grey optical depth to surface of the modelgridcell
-                                 // This is only stored to print it outside the OpenMP loop in update_grid to the
-                                 // estimatorsfile so there is no need to communicate it via MPI so far!
-  float *ion_groundlevelpops{};  // groundlevel populations of all included ions
-  float *ion_partfuncts{};       // partition functions for all included ions
+  float grey_depth = 0.;    // Grey optical depth to surface of the modelgridcell
+                            // This is only stored to print it outside the OpenMP loop in update_grid to the
+                            // estimatorsfile so there is no need to communicate it via MPI so far!
+  float *ion_partfuncts{};  // partition functions for all included ions
   double totalcooling = -1;
   int thick = 0;
 };

--- a/grid.h
+++ b/grid.h
@@ -116,6 +116,7 @@ void set_model_type(GridType model_type_value);
 [[nodiscard]] auto get_cellindex_from_pos(const std::array<double, 3> &pos, double time) -> int;
 void read_ejecta_model();
 void write_grid_restart_data(int timestep);
+[[nodiscard]] auto get_maxndo() -> int;
 [[nodiscard]] auto get_nstart(int rank) -> int;
 [[nodiscard]] auto get_nstart_nonempty(int rank) -> int;
 [[nodiscard]] auto get_ndo(int rank) -> int;

--- a/grid.h
+++ b/grid.h
@@ -104,7 +104,7 @@ void grid_init(int my_rank);
 [[nodiscard]] auto get_elem_abundance(int modelgridindex, int element) -> float;
 void set_element_meanweight(int nonemptymgi, int element, float meanweight);
 [[nodiscard]] auto get_electronfrac(int nonemptymgi) -> double;
-[[nodiscard]] auto get_numassociatedcells(int modelgridindex) -> int;
+[[nodiscard]] auto get_numpropcells(int modelgridindex) -> int;
 [[nodiscard]] auto get_nonemptymgi_of_mgi(int mgi) -> int;
 [[nodiscard]] auto get_mgi_of_nonemptymgi(int nonemptymgi) -> int;
 [[nodiscard]] auto get_model_type() -> GridType;
@@ -149,7 +149,7 @@ inline auto get_ejecta_kinetic_energy() {
   double E_kin = 0.;
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-    const int assoc_cells = grid::get_numassociatedcells(mgi);
+    const int assoc_cells = grid::get_numpropcells(mgi);
     double M_cell = grid::get_rho_tmin(mgi) * grid::get_modelcell_assocvolume_tmin(mgi);
     const double radial_pos = grid::modelgrid[mgi].initial_radial_pos_sum / assoc_cells;
     E_kin += 0.5 * M_cell * std::pow(radial_pos / globals::tmin, 2);

--- a/grid.h
+++ b/grid.h
@@ -116,7 +116,6 @@ void set_model_type(GridType model_type_value);
 [[nodiscard]] auto get_cellindex_from_pos(const std::array<double, 3> &pos, double time) -> int;
 void read_ejecta_model();
 void write_grid_restart_data(int timestep);
-[[nodiscard]] auto get_maxndo() -> int;
 [[nodiscard]] auto get_nstart(int rank) -> int;
 [[nodiscard]] auto get_nstart_nonempty(int rank) -> int;
 [[nodiscard]] auto get_ndo(int rank) -> int;

--- a/grid.h
+++ b/grid.h
@@ -65,6 +65,8 @@ inline float *elem_massfracs_allcells;  // mass fractions of elements in each ce
 
 inline double *nltepops_allcells{};
 inline float *ion_groundlevelpops_allcells{};
+inline float *ion_partfuncts_allcells{};
+inline double *ion_cooling_contribs_allcells{};
 
 [[nodiscard]] auto get_elements_uppermost_ion(int modelgridindex, int element) -> int;
 void set_elements_uppermost_ion(int modelgridindex, int element, int newvalue);

--- a/grid.h
+++ b/grid.h
@@ -36,7 +36,6 @@ struct ModelGridCell {
   float *ion_groundlevelpops{};  // groundlevel populations of all included ions
   float *ion_partfuncts{};       // partition functions for all included ions
   double totalcooling = -1;
-  double *ion_cooling_contribs{};
   int thick = 0;
 };
 

--- a/grid.h
+++ b/grid.h
@@ -103,7 +103,7 @@ void grid_init(int my_rank);
 [[nodiscard]] auto get_element_meanweight(int nonemptymgi, int element) -> float;
 [[nodiscard]] auto get_elem_abundance(int modelgridindex, int element) -> float;
 void set_element_meanweight(int nonemptymgi, int element, float meanweight);
-[[nodiscard]] auto get_electronfrac(int modelgridindex) -> double;
+[[nodiscard]] auto get_electronfrac(int nonemptymgi) -> double;
 [[nodiscard]] auto get_numassociatedcells(int modelgridindex) -> int;
 [[nodiscard]] auto get_nonemptymgi_of_mgi(int mgi) -> int;
 [[nodiscard]] auto get_mgi_of_nonemptymgi(int nonemptymgi) -> int;

--- a/grid.h
+++ b/grid.h
@@ -64,6 +64,7 @@ inline float *elem_meanweight_allcells{};
 inline float *elem_massfracs_allcells;  // mass fractions of elements in each cell for the current timestep
 
 inline double *nltepops_allcells{};
+inline float *ion_groundlevelpops_allcells{};
 
 [[nodiscard]] auto get_elements_uppermost_ion(int modelgridindex, int element) -> int;
 void set_elements_uppermost_ion(int modelgridindex, int element, int newvalue);

--- a/grid.h
+++ b/grid.h
@@ -30,10 +30,9 @@ struct ModelGridCell {
   float initenergyq = 0.;       // q: energy in the model at tmin to use with USE_MODEL_INITIAL_ENERGY [erg/g]
   float ffegrp = 0.;
   float kappagrey = 0.;
-  float grey_depth = 0.;    // Grey optical depth to surface of the modelgridcell
-                            // This is only stored to print it outside the OpenMP loop in update_grid to the
-                            // estimatorsfile so there is no need to communicate it via MPI so far!
-  float *ion_partfuncts{};  // partition functions for all included ions
+  float grey_depth = 0.;  // Grey optical depth to surface of the modelgridcell
+                          // This is only stored to print it outside the OpenMP loop in update_grid to the
+                          // estimatorsfile so there is no need to communicate it via MPI so far!
   double totalcooling = -1;
   int thick = 0;
 };

--- a/kpkt.h
+++ b/kpkt.h
@@ -14,7 +14,7 @@ inline int ncoolingterms{0};
 auto get_ncoolingterms() -> int;
 void setup_coolinglist();
 void set_kpktdiffusion(float kpktdiffusion_timescale_in, int n_kpktdiffusion_timesteps_in);
-void calculate_cooling_rates(int modelgridindex, HeatingCoolingRates *heatingcoolingrates);
+void calculate_cooling_rates(int nonemptymgi, HeatingCoolingRates *heatingcoolingrates);
 void do_kpkt_blackbody(Packet &pkt);
 void do_kpkt(Packet &pkt, double t2, int nts);
 

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -47,9 +47,12 @@ auto interpolate_ions_spontrecombcoeff(const int uniqueionindex, const double T)
 
 // use Saha equation for LTE ionization balance
 auto phi_lte(const int element, const int ion, const int modelgridindex) -> double {
+  const int nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
   const int uniqueionindex = get_uniqueionindex(element, ion);
-  const auto partfunc_ion = grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex];
-  const auto partfunc_upperion = grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex + 1];
+  const auto partfunc_ion =
+      grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex];
+  const auto partfunc_upperion =
+      grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex + 1];
 
   const auto T_e = grid::get_Te(modelgridindex);
   const double ionpot = epsilon(element, ion + 1, 0) - epsilon(element, ion, 0);
@@ -70,7 +73,8 @@ auto phi_ion_equilib(const int element, const int ion, const int modelgridindex,
   assert_testmodeonly(!elem_has_nlte_levels(element));  // don't use this function if the NLTE solver is active
 
   const int uniqueionindex = get_uniqueionindex(element, ion);
-  const auto partfunc_ion = grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex];
+  const auto partfunc_ion =
+      grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex];
 
   const auto T_e = grid::get_Te(modelgridindex);
 
@@ -98,7 +102,8 @@ auto phi_ion_equilib(const int element, const int ion, const int modelgridindex,
   // Y_nt should generally be higher than the Gamma term for nebular epoch
 
   if (!std::isfinite(phi) || phi == 0.) {
-    const auto partfunc_upperion = grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex + 1];
+    const auto partfunc_upperion =
+        grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex + 1];
     printout(
         "[fatal] phi: phi %g exceeds numerically possible range for element %d, ion %d, T_e %g ... remove higher or "
         "lower ionisation stages\n",
@@ -245,7 +250,8 @@ auto calculate_partfunct(const int element, const int ion, const int modelgridin
     // of groundlevelpop for this calculation doesn't matter, so long as it's not zero!
     pop_store = get_groundlevelpop(modelgridindex, element, ion);
     initial = true;
-    grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex] = 1.;
+    grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex] =
+        1.;
   }
 
   double U = 1.;
@@ -269,7 +275,8 @@ auto calculate_partfunct(const int element, const int ion, const int modelgridin
 
   if (initial) {
     // put back the zero, just in case it matters for something
-    grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex] = pop_store;
+    grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex] =
+        pop_store;
   }
 
   return U;
@@ -349,9 +356,11 @@ void set_groundlevelpops_neutral(const int modelgridindex) {
         nnion = 0.;
       }
       const double groundpop =
-          (nnion * stat_weight(element, ion, 0) / grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex]);
+          (nnion * stat_weight(element, ion, 0) /
+           grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex]);
 
-      grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex] = groundpop;
+      grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex] =
+          groundpop;
     }
   }
 }
@@ -462,8 +471,8 @@ auto get_groundlevelpop(const int modelgridindex, const int element, const int i
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
-  const double nn =
-      grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + get_uniqueionindex(element, ion)];
+  const double nn = grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                                       get_uniqueionindex(element, ion)];
   if (nn < MINPOP) {
     if (grid::get_elem_abundance(modelgridindex, element) > 0) {
       return MINPOP;
@@ -529,10 +538,11 @@ __host__ __device__ auto get_levelpop(const int modelgridindex, const int elemen
 // taken out of calculate_ion_balance_nne to save runtime.
 // TODO: not true if LTEPOP_EXCITATION_USE_TJ is true unless LTE mode only (TJ=TR=Te)
 void calculate_cellpartfuncts(const int modelgridindex, const int element) {
+  const int nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
   const int nions = get_nions(element);
   for (int ion = 0; ion < nions; ion++) {
-    grid::modelgrid[modelgridindex].ion_partfuncts[get_uniqueionindex(element, ion)] =
-        calculate_partfunct(element, ion, modelgridindex);
+    grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                  get_uniqueionindex(element, ion)] = calculate_partfunct(element, ion, modelgridindex);
   }
 }
 
@@ -554,8 +564,11 @@ __host__ __device__ auto calculate_sahafact(const int element, const int ion, co
 
 // Use the ground level population and partition function to get an ion population
 [[nodiscard]] __host__ __device__ auto get_nnion(const int modelgridindex, const int element, const int ion) -> double {
+  const int nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
+
   return get_groundlevelpop(modelgridindex, element, ion) *
-         grid::modelgrid[modelgridindex].ion_partfuncts[get_uniqueionindex(element, ion)] /
+         grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                       get_uniqueionindex(element, ion)] /
          stat_weight(element, ion, 0);
 }
 
@@ -594,13 +607,15 @@ void set_groundlevelpops(const int modelgridindex, const int element, const floa
     }
 
     const double groundpop =
-        nnion * stat_weight(element, ion, 0) / grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex];
+        nnion * stat_weight(element, ion, 0) /
+        grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex];
 
     if (!std::isfinite(groundpop)) {
       printout("[warning] calculate_ion_balance_nne: groundlevelpop infinite in connection with MINPOP\n");
     }
 
-    grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex] = groundpop;
+    grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex] =
+        groundpop;
   }
 }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1193,6 +1193,7 @@ void nltepop_write_restart_data(FILE *restart_file) {
   fprintf(restart_file, "%d\n", 75618527);  // special number marking the beginning of nlte data
 
   fprintf(restart_file, "%d\n", globals::total_nlte_levels);
+  const auto nincludedions = get_includedions();
 
   for (ptrdiff_t nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
@@ -1202,9 +1203,9 @@ void nltepop_write_restart_data(FILE *restart_file) {
       for (int ion = 0; ion < nions; ion++) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
         fprintf(restart_file, "%d %a %a %la\n", ion,
-                grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
-                grid::ion_partfuncts_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
-                grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]);
+                grid::ion_groundlevelpops_allcells[(nonemptymgi * nincludedions) + uniqueionindex],
+                grid::ion_partfuncts_allcells[(nonemptymgi * nincludedions) + uniqueionindex],
+                grid::ion_cooling_contribs_allcells[(nonemptymgi * nincludedions) + uniqueionindex]);
       }
     }
     for (int nlteindex = 0; nlteindex < globals::total_nlte_levels; nlteindex++) {
@@ -1230,6 +1231,7 @@ void nltepop_read_restart_data(FILE *restart_file) {
              total_nlte_levels_in);
     std::abort();
   }
+  const auto nincludedions = get_includedions();
 
   for (ptrdiff_t nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
@@ -1245,11 +1247,11 @@ void nltepop_read_restart_data(FILE *restart_file) {
       for (int ion = 0; ion < nions; ion++) {
         int ion_in = 0;
         const int uniqueionindex = get_uniqueionindex(element, ion);
-        assert_always(
-            fscanf(restart_file, "%d %a %a %la\n", &ion_in,
-                   &grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
-                   &grid::ion_partfuncts_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
-                   &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]) == 4);
+        assert_always(fscanf(restart_file, "%d %a %a %la\n", &ion_in,
+                             &grid::ion_groundlevelpops_allcells[(nonemptymgi * nincludedions) + uniqueionindex],
+                             &grid::ion_partfuncts_allcells[(nonemptymgi * nincludedions) + uniqueionindex],
+                             &grid::ion_cooling_contribs_allcells[(nonemptymgi * nincludedions) + uniqueionindex]) ==
+                      4);
         if (ion_in != ion) {
           printout("ERROR: expected data for ion %d but found ion %d\n", ion, ion_in);
           std::abort();

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -800,6 +800,7 @@ void solve_nlte_pops_element(const int element, const int modelgridindex, const 
 // (ionisation balance follows from this too)
 {
   const int atomic_number = get_atomicnumber(element);
+  const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
 
   if (grid::get_elem_abundance(modelgridindex, element) <= 0.) {
     // abundance of this element is zero, so do not store any NLTE populations
@@ -1042,7 +1043,7 @@ void solve_nlte_pops_element(const int element, const int modelgridindex, const 
       }
 
       // store the ground level population
-      grid::modelgrid[modelgridindex].ion_groundlevelpops[get_uniqueionindex(element, ion)] =
+      grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + get_uniqueionindex(element, ion)] =
           gsl_vector_get(&popvec, index_gs);
       // solution_ion_pop += gsl_vector_get(popvec, index_gs);
 
@@ -1201,7 +1202,7 @@ void nltepop_write_restart_data(FILE *restart_file) {
       for (int ion = 0; ion < nions; ion++) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
         fprintf(restart_file, "%d %a %a %la\n", ion,
-                grid::modelgrid[modelgridindex].ion_groundlevelpops[uniqueionindex],
+                grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
                 grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
                 grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]);
       }
@@ -1246,7 +1247,7 @@ void nltepop_read_restart_data(FILE *restart_file) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
         assert_always(
             fscanf(restart_file, "%d %a %a %la\n", &ion_in,
-                   &grid::modelgrid[modelgridindex].ion_groundlevelpops[uniqueionindex],
+                   &grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
                    &grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
                    &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]) == 4);
         if (ion_in != ion) {

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1043,8 +1043,8 @@ void solve_nlte_pops_element(const int element, const int modelgridindex, const 
       }
 
       // store the ground level population
-      grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + get_uniqueionindex(element, ion)] =
-          gsl_vector_get(&popvec, index_gs);
+      grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                         get_uniqueionindex(element, ion)] = gsl_vector_get(&popvec, index_gs);
       // solution_ion_pop += gsl_vector_get(popvec, index_gs);
 
       calculate_cellpartfuncts(modelgridindex, element);
@@ -1201,10 +1201,13 @@ void nltepop_write_restart_data(FILE *restart_file) {
       const int nions = get_nions(element);
       for (int ion = 0; ion < nions; ion++) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
-        fprintf(restart_file, "%d %a %a %la\n", ion,
-                grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
-                grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
-                grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]);
+        fprintf(
+            restart_file, "%d %a %a %la\n", ion,
+            grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                               uniqueionindex],
+            grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex],
+            grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                                uniqueionindex]);
       }
     }
     for (int nlteindex = 0; nlteindex < globals::total_nlte_levels; nlteindex++) {
@@ -1247,9 +1250,12 @@ void nltepop_read_restart_data(FILE *restart_file) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
         assert_always(
             fscanf(restart_file, "%d %a %a %la\n", &ion_in,
-                   &grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
-                   &grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
-                   &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]) == 4);
+                   &grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                                       uniqueionindex],
+                   &grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                                  uniqueionindex],
+                   &grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                                        uniqueionindex]) == 4);
         if (ion_in != ion) {
           printout("ERROR: expected data for ion %d but found ion %d\n", ion, ion_in);
           std::abort();

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1203,7 +1203,7 @@ void nltepop_write_restart_data(FILE *restart_file) {
         fprintf(restart_file, "%d %a %a %la\n", ion,
                 grid::modelgrid[modelgridindex].ion_groundlevelpops[uniqueionindex],
                 grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
-                grid::modelgrid[modelgridindex].ion_cooling_contribs[uniqueionindex]);
+                grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]);
       }
     }
     for (int nlteindex = 0; nlteindex < globals::total_nlte_levels; nlteindex++) {
@@ -1244,10 +1244,11 @@ void nltepop_read_restart_data(FILE *restart_file) {
       for (int ion = 0; ion < nions; ion++) {
         int ion_in = 0;
         const int uniqueionindex = get_uniqueionindex(element, ion);
-        assert_always(fscanf(restart_file, "%d %a %a %la\n", &ion_in,
-                             &grid::modelgrid[modelgridindex].ion_groundlevelpops[uniqueionindex],
-                             &grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
-                             &grid::modelgrid[modelgridindex].ion_cooling_contribs[uniqueionindex]) == 4);
+        assert_always(
+            fscanf(restart_file, "%d %a %a %la\n", &ion_in,
+                   &grid::modelgrid[modelgridindex].ion_groundlevelpops[uniqueionindex],
+                   &grid::modelgrid[modelgridindex].ion_partfuncts[uniqueionindex],
+                   &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]) == 4);
         if (ion_in != ion) {
           printout("ERROR: expected data for ion %d but found ion %d\n", ion, ion_in);
           std::abort();

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1194,20 +1194,17 @@ void nltepop_write_restart_data(FILE *restart_file) {
 
   fprintf(restart_file, "%d\n", globals::total_nlte_levels);
 
-  for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
+  for (ptrdiff_t nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
     fprintf(restart_file, "%d %la\n", modelgridindex, grid::modelgrid[modelgridindex].totalcooling);
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);
       for (int ion = 0; ion < nions; ion++) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
-        fprintf(
-            restart_file, "%d %a %a %la\n", ion,
-            grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                               uniqueionindex],
-            grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex],
-            grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                                uniqueionindex]);
+        fprintf(restart_file, "%d %a %a %la\n", ion,
+                grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
+                grid::ion_partfuncts_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
+                grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]);
       }
     }
     for (int nlteindex = 0; nlteindex < globals::total_nlte_levels; nlteindex++) {
@@ -1234,7 +1231,7 @@ void nltepop_read_restart_data(FILE *restart_file) {
     std::abort();
   }
 
-  for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
+  for (ptrdiff_t nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
     int mgi_in = 0;
     assert_always(fscanf(restart_file, "%d %la\n", &mgi_in, &grid::modelgrid[modelgridindex].totalcooling) == 2);
@@ -1250,12 +1247,9 @@ void nltepop_read_restart_data(FILE *restart_file) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
         assert_always(
             fscanf(restart_file, "%d %a %a %la\n", &ion_in,
-                   &grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                                       uniqueionindex],
-                   &grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                                  uniqueionindex],
-                   &grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                                        uniqueionindex]) == 4);
+                   &grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
+                   &grid::ion_partfuncts_allcells[(nonemptymgi * get_includedions()) + uniqueionindex],
+                   &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]) == 4);
         if (ion_in != ion) {
           printout("ERROR: expected data for ion %d but found ion %d\n", ion, ion_in);
           std::abort();

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1387,7 +1387,7 @@ auto get_eff_ionpot(const int modelgridindex, const int element, const int ion) 
 // Kozma & Fransson 1992 equation 13
 // returns the rate coefficient in s^-1
 auto nt_ionization_ratecoeff_sf(const int modelgridindex, const int element, const int ion) -> double {
-  assert_testmodeonly(grid::get_numassociatedcells(modelgridindex) > 0);
+  assert_testmodeonly(grid::get_numpropcells(modelgridindex) > 0);
 
   const double deposition_rate_density = get_deposition_rate_density(modelgridindex);
   if (deposition_rate_density > 0.) {
@@ -2150,7 +2150,7 @@ void init(const int my_rank, const int ndo_nonempty) {
     nt_solution[modelgridindex].nneperion_when_solved = -1.;
     nt_solution[modelgridindex].timestep_last_solved = -1;
 
-    if (grid::get_numassociatedcells(modelgridindex) > 0) {
+    if (grid::get_numpropcells(modelgridindex) > 0) {
       nt_solution[modelgridindex].allions =
           static_cast<NonThermalSolutionIon *>(malloc(get_includedions() * sizeof(NonThermalSolutionIon)));
 
@@ -2241,7 +2241,7 @@ void close_file() {
     nonthermalfile = nullptr;
   }
   for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-    if (grid::get_numassociatedcells(modelgridindex) > 0) {
+    if (grid::get_numpropcells(modelgridindex) > 0) {
       free(nt_solution[modelgridindex].allions);
     }
   }
@@ -2352,7 +2352,7 @@ __host__ __device__ auto nt_random_upperion(const int modelgridindex, const int 
 
 __host__ __device__ auto nt_ionization_ratecoeff(const int modelgridindex, const int element, const int ion) -> double {
   assert_always(NT_ON);
-  assert_always(grid::get_numassociatedcells(modelgridindex) > 0);
+  assert_always(grid::get_numpropcells(modelgridindex) > 0);
 
   if (NT_SOLVE_SPENCERFANO) {
     const double Y_nt = nt_ionization_ratecoeff_sf(modelgridindex, element, ion);
@@ -2392,7 +2392,7 @@ __host__ __device__ auto nt_excitation_ratecoeff(const int modelgridindex, const
     return 0.;
   }
 
-  assert_testmodeonly(grid::get_numassociatedcells(modelgridindex) > 0);
+  assert_testmodeonly(grid::get_numpropcells(modelgridindex) > 0);
 
   // binary search, assuming the excitation list is sorted by lineindex ascending
   const auto ntexclist = std::span(nt_solution[modelgridindex].frac_excitations_list,
@@ -2509,7 +2509,7 @@ __host__ __device__ void do_ntlepton_deposit(Packet &pkt) {
 // based on Equation (2) of Li et al. (2012)
 void solve_spencerfano(const int modelgridindex, const int timestep, const int iteration) {
   bool skip_solution = false;
-  if (grid::get_numassociatedcells(modelgridindex) < 1) {
+  if (grid::get_numpropcells(modelgridindex) < 1) {
     printout("Associated_cells < 1 in cell %d at timestep %d. Skipping Spencer-Fano solution.\n", modelgridindex,
              timestep);
 

--- a/packet.cc
+++ b/packet.cc
@@ -112,7 +112,7 @@ void packet_init(Packet *pkt)
   double norm = 0.;
   for (int m = 0; m < grid::ngrid; m++) {
     const int mgi = grid::get_cell_modelgridindex(m);
-    if (mgi < grid::get_npts_model() && grid::get_numassociatedcells(mgi) > 0)  // some grid cells are empty
+    if (mgi < grid::get_npts_model() && grid::get_numpropcells(mgi) > 0)  // some grid cells are empty
     {
       const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
       double q = decay::get_modelcell_simtime_endecay_per_mass(nonemptymgi);

--- a/radfield.cc
+++ b/radfield.cc
@@ -152,7 +152,7 @@ void realloc_detailed_lines(const int new_size) {
   detailed_lineindicies = newptr;
 
   for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-    if (grid::get_numassociatedcells(modelgridindex) > 0) {
+    if (grid::get_numpropcells(modelgridindex) > 0) {
       prev_Jb_lu_normed[modelgridindex] = static_cast<Jb_lu_estimator *>(
           realloc(prev_Jb_lu_normed[modelgridindex], new_size * sizeof(Jb_lu_estimator)));
 
@@ -176,7 +176,7 @@ void add_detailed_line(const int lineindex) {
   }
 
   for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-    if (grid::get_numassociatedcells(modelgridindex) > 0) {
+    if (grid::get_numpropcells(modelgridindex) > 0) {
       prev_Jb_lu_normed[modelgridindex][detailed_linecount].value = 0;
       prev_Jb_lu_normed[modelgridindex][detailed_linecount].contribcount = 0;
 
@@ -1161,7 +1161,7 @@ void reduce_estimators()
     printout("Reducing detailed line estimators");
 
     for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-      if (grid::get_numassociatedcells(modelgridindex) > 0) {
+      if (grid::get_numpropcells(modelgridindex) > 0) {
         for (int jblueindex = 0; jblueindex < detailed_linecount; jblueindex++) {
           MPI_Allreduce(MPI_IN_PLACE, &Jb_lu_raw[modelgridindex][jblueindex].value, 1, MPI_DOUBLE, MPI_SUM,
                         MPI_COMM_WORLD);
@@ -1225,7 +1225,7 @@ void write_restart_data(FILE *gridsave_file) {
     fprintf(gridsave_file, "%d\n", bfestimcount);
 
     for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-      if (grid::get_numassociatedcells(modelgridindex) > 0) {
+      if (grid::get_numpropcells(modelgridindex) > 0) {
         const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
         fprintf(gridsave_file, "%d\n", modelgridindex);
         for (int i = 0; i < bfestimcount; i++) {
@@ -1244,7 +1244,7 @@ void write_restart_data(FILE *gridsave_file) {
   }
 
   for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-    if (grid::get_numassociatedcells(modelgridindex) > 0) {
+    if (grid::get_numpropcells(modelgridindex) > 0) {
       const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
       assert_testmodeonly(nonemptymgi >= 0);
       fprintf(gridsave_file, "%d %la\n", modelgridindex, J_normfactor[nonemptymgi]);
@@ -1328,7 +1328,7 @@ void read_restart_data(FILE *gridsave_file) {
     assert_always(gridsave_nbfestim_in == globals::bfestimcount);
 
     for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-      if (grid::get_numassociatedcells(modelgridindex) > 0) {
+      if (grid::get_numpropcells(modelgridindex) > 0) {
         const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
         int mgi_in = 0;
         assert_always(fscanf(gridsave_file, "%d\n", &mgi_in) == 1);
@@ -1361,7 +1361,7 @@ void read_restart_data(FILE *gridsave_file) {
   }
 
   for (int modelgridindex = 0; modelgridindex < grid::get_npts_model(); modelgridindex++) {
-    if (grid::get_numassociatedcells(modelgridindex) > 0) {
+    if (grid::get_numpropcells(modelgridindex) > 0) {
       const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
       int mgi_in = 0;
       assert_always(fscanf(gridsave_file, "%d %la\n", &mgi_in, &J_normfactor[nonemptymgi]) == 2);

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -857,54 +857,26 @@ void setup_photoion_luts() {
   assert_always(globals::nbfcontinua > 0);
   size_t mem_usage_photoionluts = 2 * TABLESIZE * globals::nbfcontinua * sizeof(double);
 
-#ifdef MPI_ON
-  MPI_Win win = MPI_WIN_NULL;
-  MPI_Aint size =
-      (globals::rank_in_node == 0) ? TABLESIZE * globals::nbfcontinua * static_cast<MPI_Aint>(sizeof(double)) : 0;
-  int disp_unit = sizeof(double);
-  assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node, &spontrecombcoeffs,
-                                        &win) == MPI_SUCCESS);
-  assert_always(MPI_Win_shared_query(win, 0, &size, &disp_unit, &spontrecombcoeffs) == MPI_SUCCESS);
-#else
-  spontrecombcoeffs = static_cast<double *>(malloc(TABLESIZE * globals::nbfcontinua * sizeof(double)));
-#endif
+  spontrecombcoeffs = MPI_shared_malloc<double>(TABLESIZE * globals::nbfcontinua);
   assert_always(spontrecombcoeffs != nullptr);
 
   if constexpr (USE_LUT_PHOTOION) {
-#ifdef MPI_ON
-    size = (globals::rank_in_node == 0) ? TABLESIZE * globals::nbfcontinua * static_cast<MPI_Aint>(sizeof(double)) : 0;
-    assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node, &corrphotoioncoeffs,
-                                          &win) == MPI_SUCCESS);
-    assert_always(MPI_Win_shared_query(win, 0, &size, &disp_unit, &corrphotoioncoeffs) == MPI_SUCCESS);
-#else
-    corrphotoioncoeffs = static_cast<double *>(malloc(TABLESIZE * globals::nbfcontinua * sizeof(double)));
-#endif
+    corrphotoioncoeffs = MPI_shared_malloc<double>(TABLESIZE * globals::nbfcontinua);
     assert_always(corrphotoioncoeffs != nullptr);
     mem_usage_photoionluts += TABLESIZE * globals::nbfcontinua * sizeof(double);
   }
 
   if constexpr (USE_LUT_BFHEATING) {
-#ifdef MPI_ON
-    size = (globals::rank_in_node == 0) ? TABLESIZE * globals::nbfcontinua * static_cast<MPI_Aint>(sizeof(double)) : 0;
-    assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node,
-                                          &globals::bfheating_coeff, &win) == MPI_SUCCESS);
-    assert_always(MPI_Win_shared_query(win, 0, &size, &disp_unit, &globals::bfheating_coeff) == MPI_SUCCESS);
-#else
-    globals::bfheating_coeff = static_cast<double *>(malloc(TABLESIZE * globals::nbfcontinua * sizeof(double)));
-#endif
+    globals::bfheating_coeff = MPI_shared_malloc<double>(TABLESIZE * globals::nbfcontinua);
     assert_always(globals::bfheating_coeff != nullptr);
     mem_usage_photoionluts += TABLESIZE * globals::nbfcontinua * sizeof(double);
   }
 
 #ifdef MPI_ON
-  size = (globals::rank_in_node == 0) ? TABLESIZE * globals::nbfcontinua * static_cast<MPI_Aint>(sizeof(double)) : 0;
-  assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node, &bfcooling_coeffs,
-                                        &win) == MPI_SUCCESS);
-  assert_always(MPI_Win_shared_query(win, 0, &size, &disp_unit, &bfcooling_coeffs) == MPI_SUCCESS);
+  bfcooling_coeffs = MPI_shared_malloc<double>(TABLESIZE * globals::nbfcontinua);
 #else
   bfcooling_coeffs = static_cast<double *>(malloc(TABLESIZE * globals::nbfcontinua * sizeof(double)));
 #endif
-  assert_always(bfcooling_coeffs != nullptr);
 
   printout(
       "[info] mem_usage: lookup tables derived from photoionisation (spontrecombcoeff, bfcooling and "

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -987,35 +987,23 @@ void allocate_expansionopacities() {
   double *expansionopacity_planck_cumulative_data{};
 
 #ifdef MPI_ON
-  const auto [_, noderank_nonemptycellcount] =
-      get_range_chunk(npts_nonempty, globals::node_nprocs, globals::rank_in_node);
 
-  {
-    MPI_Aint size = noderank_nonemptycellcount * expopac_nbins * static_cast<MPI_Aint>(sizeof(float));
-    int disp_unit = sizeof(float);
-    assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node,
-                                          &expansionopacities_data, &win_expansionopacities) == MPI_SUCCESS);
-    assert_always(MPI_Win_shared_query(win_expansionopacities, 0, &size, &disp_unit, &expansionopacities_data) ==
-                  MPI_SUCCESS);
-  }
-
-  if constexpr (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY >= 0.) {
-    MPI_Aint size = noderank_nonemptycellcount * expopac_nbins * static_cast<MPI_Aint>(sizeof(double));
-    int disp_unit = sizeof(double);
-    assert_always(MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, globals::mpi_comm_node,
-                                          &expansionopacity_planck_cumulative_data,
-                                          &win_expansionopacity_planck_cumulative) == MPI_SUCCESS);
-    assert_always(MPI_Win_shared_query(win_expansionopacity_planck_cumulative, 0, &size, &disp_unit,
-                                       &expansionopacity_planck_cumulative_data) == MPI_SUCCESS);
-  }
-
+  std::tie(expansionopacities_data, win_expansionopacities) =
+      MPI_shared_malloc_keepwin<float>(npts_nonempty * expopac_nbins);
 #else
   expansionopacities_data = static_cast<float *>(malloc(npts_nonempty * expopac_nbins * sizeof(float)));
+#endif
+
   if constexpr (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY >= 0.) {
+#ifdef MPI_ON
+    std::tie(expansionopacity_planck_cumulative_data, win_expansionopacity_planck_cumulative) =
+        MPI_shared_malloc_keepwin<double>(npts_nonempty * expopac_nbins);
+#else
     expansionopacity_planck_cumulative_data =
         static_cast<double *>(malloc(npts_nonempty * expopac_nbins * sizeof(double)));
-  }
 #endif
+  }
+
   expansionopacities = std::span(expansionopacities_data, npts_nonempty * expopac_nbins);
   expansionopacity_planck_cumulative =
       std::span(expansionopacity_planck_cumulative_data,

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -987,7 +987,6 @@ void allocate_expansionopacities() {
   double *expansionopacity_planck_cumulative_data{};
 
 #ifdef MPI_ON
-
   std::tie(expansionopacities_data, win_expansionopacities) =
       MPI_shared_malloc_keepwin<float>(npts_nonempty * expopac_nbins);
 #else

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -259,7 +259,11 @@ void mpi_communicate_grid_properties() {
 
       MPI_Bcast_binned_opacities(nonemptymgi, root_node_id);
     }
+  }
 
+  for (int root = 0; root < globals::nprocs; root++) {
+    const int root_nstart_nonempty = grid::get_nstart_nonempty(root);
+    const int root_ndo_nonempty = grid::get_ndo_nonempty(root);
     if (root == globals::my_rank) {
       int position = 0;
       for (ptrdiff_t nonemptymgi = root_nstart_nonempty; nonemptymgi < (root_nstart_nonempty + root_ndo_nonempty);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -219,10 +219,10 @@ void mpi_communicate_grid_properties() {
     int root_node_id = globals::node_id;
     MPI_Bcast(&root_node_id, 1, MPI_INT, root, MPI_COMM_WORLD);
 
-    const int root_nstart_nonempty = grid::get_nstart_nonempty(root);
-    const int root_ndo_nonempty = grid::get_ndo_nonempty(root);
+    const ptrdiff_t root_nstart_nonempty = grid::get_nstart_nonempty(root);
+    const ptrdiff_t root_ndo_nonempty = grid::get_ndo_nonempty(root);
 
-    for (int nonemptymgi = root_nstart_nonempty; nonemptymgi < (root_nstart_nonempty + root_ndo_nonempty);
+    for (ptrdiff_t nonemptymgi = root_nstart_nonempty; nonemptymgi < (root_nstart_nonempty + root_ndo_nonempty);
          nonemptymgi++) {
       assert_always(root_ndo_nonempty > 0);
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -291,8 +291,8 @@ void mpi_communicate_grid_properties() {
         MPI_Pack(&grid::elem_massfracs_allcells[(nonemptymgi * nelements)], nelements, MPI_FLOAT, mpi_grid_buffer,
                  mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
 
-        MPI_Pack(grid::modelgrid[mgi].ion_groundlevelpops, nincludedions, MPI_FLOAT, mpi_grid_buffer,
-                 mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
+        MPI_Pack(&grid::ion_groundlevelpops_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
+                 mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
         MPI_Pack(grid::modelgrid[mgi].ion_partfuncts, nincludedions, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size,
                  &position, MPI_COMM_WORLD);
         MPI_Pack(&grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
@@ -338,8 +338,9 @@ void mpi_communicate_grid_properties() {
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
                  &grid::elem_massfracs_allcells[(nonemptymgi * nelements)], nelements, MPI_FLOAT, MPI_COMM_WORLD);
 
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, grid::modelgrid[mgi].ion_groundlevelpops,
-                 nincludedions, MPI_FLOAT, MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 &grid::ion_groundlevelpops_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
+                 MPI_COMM_WORLD);
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, grid::modelgrid[mgi].ion_partfuncts, nincludedions,
                  MPI_FLOAT, MPI_COMM_WORLD);
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -293,8 +293,8 @@ void mpi_communicate_grid_properties() {
 
         MPI_Pack(&grid::ion_groundlevelpops_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
                  mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
-        MPI_Pack(grid::modelgrid[mgi].ion_partfuncts, nincludedions, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size,
-                 &position, MPI_COMM_WORLD);
+        MPI_Pack(&grid::ion_partfuncts_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
+                 mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
         MPI_Pack(&grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
                  mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
       }
@@ -341,8 +341,9 @@ void mpi_communicate_grid_properties() {
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
                  &grid::ion_groundlevelpops_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
                  MPI_COMM_WORLD);
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, grid::modelgrid[mgi].ion_partfuncts, nincludedions,
-                 MPI_FLOAT, MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 &grid::ion_partfuncts_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
+                 MPI_COMM_WORLD);
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
                  &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
                  MPI_COMM_WORLD);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -72,6 +72,11 @@ auto real_time_start = -1;
 auto time_timestep_start = -1;  // this will be set after the first update of the grid and before packet prop
 FILE *estimators_file{};
 
+#ifdef MPI_ON
+size_t mpi_grid_buffer_size = 0;
+char *mpi_grid_buffer{};
+#endif
+
 void initialise_linestat_file() {
   if (globals::simulation_continued_from_saved && !RECORD_LINESTAT) {
     // only write linestat.out on the first run, unless it contains statistics for each timestep
@@ -258,14 +263,83 @@ void mpi_communicate_grid_properties() {
                   globals::mpi_comm_internode);
         MPI_Bcast(&grid::ion_cooling_contribs_allcells[nonemptymgi * nincludedions], nincludedions, MPI_DOUBLE,
                   root_node_id, globals::mpi_comm_internode);
-        MPI_Bcast(&grid::modelgrid[grid::get_mgi_of_nonemptymgi(nonemptymgi)], sizeof(grid::ModelGridCell), MPI_BYTE,
-                  root_node_id, globals::mpi_comm_internode);
+        // MPI_Bcast(&grid::modelgrid[grid::get_mgi_of_nonemptymgi(nonemptymgi)], sizeof(grid::ModelGridCell), MPI_BYTE,
+        //           root_node_id, globals::mpi_comm_internode);
       }
 
       MPI_Bcast_binned_opacities(nonemptymgi, root_node_id);
     }
   }
 
+  for (int root = 0; root < globals::nprocs; root++) {
+    const int root_nstart_nonempty = grid::get_nstart_nonempty(root);
+    const int root_ndo_nonempty = grid::get_ndo_nonempty(root);
+    if (root == globals::my_rank) {
+      int position = 0;
+      for (ptrdiff_t nonemptymgi = root_nstart_nonempty; nonemptymgi < (root_nstart_nonempty + root_ndo_nonempty);
+           nonemptymgi++) {
+        const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+        MPI_Pack(&mgi, 1, MPI_INT, mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
+
+        MPI_Pack(&grid::modelgrid[mgi].Te, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].TR, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].TJ, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].W, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].rho, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].nne, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].nnetot, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].kappagrey, 1, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].totalcooling, 1, MPI_DOUBLE, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+        MPI_Pack(&grid::modelgrid[mgi].thick, 1, MPI_INT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 MPI_COMM_WORLD);
+      }
+      printout("[info] mem_usage: MPI_BUFFER: used %d of %zu bytes allocated to mpi_grid_buffer\n", position,
+               mpi_grid_buffer_size);
+      assert_always(static_cast<size_t>(position) <= mpi_grid_buffer_size);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Bcast(mpi_grid_buffer, mpi_grid_buffer_size, MPI_PACKED, root, MPI_COMM_WORLD);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int position = 0;
+    for (ptrdiff_t nonemptymgi = root_nstart_nonempty; nonemptymgi < (root_nstart_nonempty + root_ndo_nonempty);
+         nonemptymgi++) {
+      const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+      int mgi_check = -1;
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &mgi_check, 1, MPI_INT, MPI_COMM_WORLD);
+      assert_always(mgi == mgi_check);
+
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].Te, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].TR, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].TJ, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].W, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].rho, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].nne, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].nnetot, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].kappagrey, 1, MPI_FLOAT,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].totalcooling, 1, MPI_DOUBLE,
+                 MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].thick, 1, MPI_INT,
+                 MPI_COMM_WORLD);
+    }
+  }
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -898,6 +972,15 @@ auto main(int argc, char *argv[]) -> int {
 
 #ifdef MPI_ON
   MPI_Barrier(MPI_COMM_WORLD);
+  const size_t maxndo = grid::get_maxndo();
+  // Initialise the exchange buffer
+  // The factor 4 comes from the fact that our buffer should contain elements of 4 byte
+  // instead of 1 byte chars. But the MPI routines don't care about the buffers datatype
+  mpi_grid_buffer_size = 4 * ((12 + 4 * get_includedions() + get_nelements()) * (maxndo) + 1);
+  printout("reserve mpi_grid_buffer_size %zu space for MPI communication buffer\n", mpi_grid_buffer_size);
+  mpi_grid_buffer = static_cast<char *>(malloc(mpi_grid_buffer_size * sizeof(char)));
+  assert_always(mpi_grid_buffer != nullptr);
+  MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
   globals::timestep = globals::timestep_initial;
@@ -950,6 +1033,7 @@ auto main(int argc, char *argv[]) -> int {
 
 #ifdef MPI_ON
   MPI_Barrier(MPI_COMM_WORLD);
+  free(mpi_grid_buffer);
 #endif
 
   if (linestat_file != nullptr) {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -255,6 +255,16 @@ void mpi_communicate_grid_properties() {
       if (globals::rank_in_node == 0) {
         MPI_Bcast(&grid::elem_meanweight_allcells[nonemptymgi * nelements], nelements, MPI_FLOAT, root_node_id,
                   globals::mpi_comm_internode);
+        MPI_Bcast(&grid::elem_massfracs_allcells[nonemptymgi * nelements], nelements, MPI_FLOAT, root_node_id,
+                  globals::mpi_comm_internode);
+        MPI_Bcast(&grid::ion_groundlevelpops_allcells[nonemptymgi * nincludedions], nincludedions, MPI_FLOAT,
+                  root_node_id, globals::mpi_comm_internode);
+        MPI_Bcast(&grid::ion_partfuncts_allcells[nonemptymgi * nincludedions], nincludedions, MPI_FLOAT, root_node_id,
+                  globals::mpi_comm_internode);
+        MPI_Bcast(&grid::ion_cooling_contribs_allcells[nonemptymgi * nincludedions], nincludedions, MPI_DOUBLE,
+                  root_node_id, globals::mpi_comm_internode);
+        // MPI_Bcast(&grid::modelgrid[grid::get_mgi_of_nonemptymgi(nonemptymgi)], sizeof(grid::ModelGridCell), MPI_BYTE,
+        //           root_node_id, globals::mpi_comm_internode);
       }
 
       MPI_Bcast_binned_opacities(nonemptymgi, root_node_id);
@@ -291,16 +301,6 @@ void mpi_communicate_grid_properties() {
                  MPI_COMM_WORLD);
         MPI_Pack(&grid::modelgrid[mgi].thick, 1, MPI_INT, mpi_grid_buffer, mpi_grid_buffer_size, &position,
                  MPI_COMM_WORLD);
-
-        MPI_Pack(&grid::elem_massfracs_allcells[(nonemptymgi * nelements)], nelements, MPI_FLOAT, mpi_grid_buffer,
-                 mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
-
-        MPI_Pack(&grid::ion_groundlevelpops_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
-                 mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
-        MPI_Pack(&grid::ion_partfuncts_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
-                 mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
-        MPI_Pack(&grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
-                 mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
       }
       printout("[info] mem_usage: MPI_BUFFER: used %d of %zu bytes allocated to mpi_grid_buffer\n", position,
                mpi_grid_buffer_size);
@@ -337,19 +337,6 @@ void mpi_communicate_grid_properties() {
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].totalcooling, 1, MPI_DOUBLE,
                  MPI_COMM_WORLD);
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, &grid::modelgrid[mgi].thick, 1, MPI_INT,
-                 MPI_COMM_WORLD);
-
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
-                 &grid::elem_massfracs_allcells[(nonemptymgi * nelements)], nelements, MPI_FLOAT, MPI_COMM_WORLD);
-
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
-                 &grid::ion_groundlevelpops_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
-                 MPI_COMM_WORLD);
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
-                 &grid::ion_partfuncts_allcells[nonemptymgi * get_includedions()], nincludedions, MPI_FLOAT,
-                 MPI_COMM_WORLD);
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
-                 &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
                  MPI_COMM_WORLD);
     }
   }

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -295,8 +295,8 @@ void mpi_communicate_grid_properties() {
                  mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
         MPI_Pack(grid::modelgrid[mgi].ion_partfuncts, nincludedions, MPI_FLOAT, mpi_grid_buffer, mpi_grid_buffer_size,
                  &position, MPI_COMM_WORLD);
-        MPI_Pack(grid::modelgrid[mgi].ion_cooling_contribs, nincludedions, MPI_DOUBLE, mpi_grid_buffer,
-                 mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
+        MPI_Pack(&grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
+                 mpi_grid_buffer, mpi_grid_buffer_size, &position, MPI_COMM_WORLD);
       }
       printout("[info] mem_usage: MPI_BUFFER: used %d of %zu bytes allocated to mpi_grid_buffer\n", position,
                mpi_grid_buffer_size);
@@ -342,8 +342,9 @@ void mpi_communicate_grid_properties() {
                  nincludedions, MPI_FLOAT, MPI_COMM_WORLD);
       MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, grid::modelgrid[mgi].ion_partfuncts, nincludedions,
                  MPI_FLOAT, MPI_COMM_WORLD);
-      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position, grid::modelgrid[mgi].ion_cooling_contribs,
-                 nincludedions, MPI_DOUBLE, MPI_COMM_WORLD);
+      MPI_Unpack(mpi_grid_buffer, mpi_grid_buffer_size, &position,
+                 &grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions())], nincludedions, MPI_DOUBLE,
+                 MPI_COMM_WORLD);
     }
   }
   MPI_Barrier(MPI_COMM_WORLD);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -211,8 +211,8 @@ void write_deposition_file() {
 
 #ifdef MPI_ON
 void mpi_communicate_grid_properties() {
-  const auto nincludedions = get_includedions();
-  const auto nelements = get_nelements();
+  const ptrdiff_t nincludedions = get_includedions();
+  const ptrdiff_t nelements = get_nelements();
   for (int root = 0; root < globals::nprocs; root++) {
     MPI_Barrier(MPI_COMM_WORLD);
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -247,23 +247,30 @@ void mpi_communicate_grid_properties() {
         MPI_Bcast(&globals::gammaestimator[nonemptymgi * globals::nbfcontinua_ground], globals::nbfcontinua_ground,
                   MPI_DOUBLE, root, MPI_COMM_WORLD);
       }
+
       if (globals::rank_in_node == 0) {
-        MPI_Bcast(&grid::elem_meanweight_allcells[nonemptymgi * nelements], nelements, MPI_FLOAT, root_node_id,
-                  globals::mpi_comm_internode);
-        MPI_Bcast(&grid::elem_massfracs_allcells[nonemptymgi * nelements], nelements, MPI_FLOAT, root_node_id,
-                  globals::mpi_comm_internode);
-        MPI_Bcast(&grid::ion_groundlevelpops_allcells[nonemptymgi * nincludedions], nincludedions, MPI_FLOAT,
-                  root_node_id, globals::mpi_comm_internode);
-        MPI_Bcast(&grid::ion_partfuncts_allcells[nonemptymgi * nincludedions], nincludedions, MPI_FLOAT, root_node_id,
-                  globals::mpi_comm_internode);
-        MPI_Bcast(&grid::ion_cooling_contribs_allcells[nonemptymgi * nincludedions], nincludedions, MPI_DOUBLE,
-                  root_node_id, globals::mpi_comm_internode);
         MPI_Bcast(&grid::modelgrid[grid::get_mgi_of_nonemptymgi(nonemptymgi)], sizeof(grid::ModelGridCell), MPI_BYTE,
                   root_node_id, globals::mpi_comm_internode);
       }
 
       MPI_Bcast_binned_opacities(nonemptymgi, root_node_id);
     }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (globals::rank_in_node == 0) {
+      MPI_Bcast(&grid::elem_meanweight_allcells[root_nstart_nonempty * nelements], root_ndo_nonempty * nelements,
+                MPI_FLOAT, root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast(&grid::elem_massfracs_allcells[root_nstart_nonempty * nelements], root_ndo_nonempty * nelements,
+                MPI_FLOAT, root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast(&grid::ion_groundlevelpops_allcells[root_nstart_nonempty * nincludedions],
+                root_ndo_nonempty * nincludedions, MPI_FLOAT, root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast(&grid::ion_partfuncts_allcells[root_nstart_nonempty * nincludedions], root_ndo_nonempty * nincludedions,
+                MPI_FLOAT, root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast(&grid::ion_cooling_contribs_allcells[root_nstart_nonempty * nincludedions],
+                root_ndo_nonempty * nincludedions, MPI_DOUBLE, root_node_id, globals::mpi_comm_internode);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
   }
 
   MPI_Barrier(MPI_COMM_WORLD);

--- a/sn3d.h
+++ b/sn3d.h
@@ -374,7 +374,7 @@ template <typename T>
 
 template <typename T>
 [[nodiscard]] auto MPI_shared_malloc_span(const ptrdiff_t num_allranks) -> std::span<T> {
-  return std::span(MPI_shared_malloc<T>(num_allranks), num_allranks);
+  return {MPI_shared_malloc<T>(num_allranks), num_allranks};
 }
 
 #endif  // SN3D_H

--- a/sn3d.h
+++ b/sn3d.h
@@ -374,7 +374,7 @@ template <typename T>
 
 template <typename T>
 [[nodiscard]] auto MPI_shared_malloc_span(const ptrdiff_t num_allranks) -> std::span<T> {
-  return {MPI_shared_malloc<T>(num_allranks), num_allranks};
+  return std::span(MPI_shared_malloc<T>(num_allranks), num_allranks);
 }
 
 #endif  // SN3D_H

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -213,7 +213,8 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, void *paras) -> double {
   const auto nne = grid::get_nne(modelgridindex);
 
   // Then calculate heating and cooling rates
-  kpkt::calculate_cooling_rates(modelgridindex, heatingcoolingrates);
+  const int nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
+  kpkt::calculate_cooling_rates(nonemptymgi, heatingcoolingrates);
   calculate_heating_rates(modelgridindex, T_e, nne, heatingcoolingrates, *params->bfheatingcoeffs);
 
   const auto ntlepton_frac_heating = nonthermal::get_nt_frac_heating(modelgridindex);

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -313,8 +313,9 @@ void calculate_bfheatingcoeffs(int modelgridindex, std::vector<double> &bfheatin
   }
 }
 
-void call_T_e_finder(const int modelgridindex, const double t_current, const double T_min, const double T_max,
+void call_T_e_finder(const int nonemptymgi, const double t_current, const double T_min, const double T_max,
                      HeatingCoolingRates *heatingcoolingrates, const std::vector<double> &bfheatingcoeffs) {
+  const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   const double T_e_old = grid::get_Te(modelgridindex);
   printout("Finding T_e in cell %d at timestep %d...", modelgridindex, globals::timestep);
 

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -268,9 +268,9 @@ auto get_bfheatingcoeff_ana(const int element, const int ion, const int level, c
 }
 
 // depends only the radiation field - no dependence on T_e or populations
-void calculate_bfheatingcoeffs(int modelgridindex, std::vector<double> &bfheatingcoeffs) {
+void calculate_bfheatingcoeffs(int nonemptymgi, std::vector<double> &bfheatingcoeffs) {
   bfheatingcoeffs.resize(get_includedlevels());
-  const int nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
+  const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   const double minelfrac = 0.01;
   for (int element = 0; element < get_nelements(); element++) {
     if (grid::get_elem_abundance(modelgridindex, element) <= minelfrac && !USE_LUT_BFHEATING) {

--- a/thermalbalance.h
+++ b/thermalbalance.h
@@ -24,7 +24,7 @@ struct HeatingCoolingRates {
   double eps_alpha_ana{0};
 };
 
-void call_T_e_finder(int modelgridindex, double t_current, double T_min, double T_max,
+void call_T_e_finder(int nonemptymgi, double t_current, double T_min, double T_max,
                      HeatingCoolingRates *heatingcoolingrates, const std::vector<double> &bfheatingcoeffs);
 [[nodiscard]] auto get_bfheatingcoeff_ana(int element, int ion, int level, int phixstargetindex, double T_R, double W)
     -> double;

--- a/thermalbalance.h
+++ b/thermalbalance.h
@@ -28,6 +28,6 @@ void call_T_e_finder(int nonemptymgi, double t_current, double T_min, double T_m
                      HeatingCoolingRates *heatingcoolingrates, const std::vector<double> &bfheatingcoeffs);
 [[nodiscard]] auto get_bfheatingcoeff_ana(int element, int ion, int level, int phixstargetindex, double T_R, double W)
     -> double;
-void calculate_bfheatingcoeffs(int modelgridindex, std::vector<double> &bfheatingcoeffs);
+void calculate_bfheatingcoeffs(int nonemptymgi, std::vector<double> &bfheatingcoeffs);
 
 #endif  // THERMALBALANCE_H

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -50,7 +50,7 @@ void write_to_estimators_file(FILE *estimators_file, const int mgi, const int ti
 
   const auto T_e = grid::get_Te(mgi);
   const auto nne = grid::get_nne(mgi);
-  const auto Y_e = grid::get_electronfrac(mgi);
+  const auto Y_e = grid::get_electronfrac(nonemptymgi);
   // fprintf(estimators_file,"%d %g %g %g %g %d
   // ",n,get_TR(n),grid::get_Te(n),get_W(n),get_TJ(n),grid::modelgrid[n].thick); fprintf(estimators_file,"%d %g %g %g
   // %g %g ",n,get_TR(n),grid::get_Te(n),get_W(n),get_TJ(n),grey_optical_depth);

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1127,14 +1127,7 @@ void update_grid(FILE *estimators_file, const int nts, const int nts_prev, const
       // If yes, update the cell and write out the estimators
       HeatingCoolingRates heatingcoolingrates{};
       const int assoc_cells = grid::get_numpropcells(mgi);
-      if (assoc_cells < 0) {
-        // For modelgrid cells that are not represented in the simulation grid,
-        // Set grid properties to zero
-        grid::set_TR(mgi, 0.);
-        grid::set_TJ(mgi, 0.);
-        grid::set_Te(mgi, 0.);
-        grid::set_W(mgi, 0.);
-      } else {
+      if (assoc_cells > 0) {
         update_grid_cell(mgi, nts, nts_prev, titer, tratmid, deltat, &heatingcoolingrates);
       }
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -884,7 +884,7 @@ void update_grid_cell(const int mgi, const int nts, const int nts_prev, const in
     return;
   }
 
-  const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
+  const ptrdiff_t nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
 
   const double deltaV =
       grid::get_modelcell_assocvolume_tmin(mgi) * pow(globals::timesteps[nts_prev].mid / globals::tmin, 3);
@@ -1050,14 +1050,13 @@ void update_grid_cell(const int mgi, const int nts, const int nts_prev, const in
     // cooling rates calculation can be skipped for thick cells
     // flag with negative numbers to indicate that the rates are invalid
     grid::modelgrid[mgi].totalcooling = -1.;
-    grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + 0] = -1.;
+    grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] = -1.;
   } else if (globals::simulation_continued_from_saved && nts == globals::timestep_initial) {
     // cooling rates were read from the gridsave file for this timestep
     // make sure they are valid
     printout("cooling rates read from gridsave file for timestep %d cell %d...", nts, mgi);
     assert_always(grid::modelgrid[mgi].totalcooling >= 0.);
-    assert_always(grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + 0] >=
-                  0.);
+    assert_always(grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] >= 0.);
   } else {
     // Cooling rates depend only on cell properties, precalculate total cooling
     // and ion contributions inside update grid and communicate between MPI tasks

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -35,7 +35,7 @@ void write_to_estimators_file(FILE *estimators_file, const int mgi, const int ti
                               const HeatingCoolingRates *heatingcoolingrates) {
   // return; disable for better performance (if estimators files are not needed)
 
-  if (grid::get_numassociatedcells(mgi) < 1) {
+  if (grid::get_numpropcells(mgi) < 1) {
     // modelgrid cells that are not represented in the simulation grid
     fprintf(estimators_file, "timestep %d modelgridindex %d EMPTYCELL\n\n", timestep, mgi);
     fflush(estimators_file);
@@ -872,7 +872,7 @@ static void titer_average_estimators(const int nonemptymgi) {
 
 void update_grid_cell(const int mgi, const int nts, const int nts_prev, const int titer, const double tratmid,
                       const double deltat, HeatingCoolingRates *heatingcoolingrates) {
-  const int assoc_cells = grid::get_numassociatedcells(mgi);
+  const int assoc_cells = grid::get_numpropcells(mgi);
   if (assoc_cells < 1) {
     // For modelgrid cells that are not represented in the simulation grid,
     // Set grid properties to zero

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1049,13 +1049,13 @@ void update_grid_cell(const int mgi, const int nts, const int nts_prev, const in
     // cooling rates calculation can be skipped for thick cells
     // flag with negative numbers to indicate that the rates are invalid
     grid::modelgrid[mgi].totalcooling = -1.;
-    grid::modelgrid[mgi].ion_cooling_contribs[0] = -1.;
+    grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] = -1.;
   } else if (globals::simulation_continued_from_saved && nts == globals::timestep_initial) {
     // cooling rates were read from the gridsave file for this timestep
     // make sure they are valid
     printout("cooling rates read from gridsave file for timestep %d cell %d...", nts, mgi);
     assert_always(grid::modelgrid[mgi].totalcooling >= 0.);
-    assert_always(grid::modelgrid[mgi].ion_cooling_contribs[0] >= 0.);
+    assert_always(grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] >= 0.);
   } else {
     // Cooling rates depend only on cell properties, precalculate total cooling
     // and ion contributions inside update grid and communicate between MPI tasks
@@ -1065,7 +1065,7 @@ void update_grid_cell(const int mgi, const int nts, const int nts_prev, const in
 
     // don't pass pointer to heatingcoolingrates because current populations and rates weren't
     // used to determine T_e
-    kpkt::calculate_cooling_rates(mgi, nullptr);
+    kpkt::calculate_cooling_rates(nonemptymgi, nullptr);
 
     printout("took %ld seconds\n", std::time(nullptr) - sys_time_start_calc_kpkt_rates);
   }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1049,13 +1049,14 @@ void update_grid_cell(const int mgi, const int nts, const int nts_prev, const in
     // cooling rates calculation can be skipped for thick cells
     // flag with negative numbers to indicate that the rates are invalid
     grid::modelgrid[mgi].totalcooling = -1.;
-    grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] = -1.;
+    grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + 0] = -1.;
   } else if (globals::simulation_continued_from_saved && nts == globals::timestep_initial) {
     // cooling rates were read from the gridsave file for this timestep
     // make sure they are valid
     printout("cooling rates read from gridsave file for timestep %d cell %d...", nts, mgi);
     assert_always(grid::modelgrid[mgi].totalcooling >= 0.);
-    assert_always(grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] >= 0.);
+    assert_always(grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + 0] >=
+                  0.);
   } else {
     // Cooling rates depend only on cell properties, precalculate total cooling
     // and ion contributions inside update grid and communicate between MPI tasks

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -686,7 +686,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
   const auto sys_time_start_calculate_bfheatingcoeffs = std::time(nullptr);
   thread_local static auto bfheatingcoeffs = std::vector<double>(get_includedlevels());
 
-  calculate_bfheatingcoeffs(mgi, bfheatingcoeffs);
+  calculate_bfheatingcoeffs(nonemptymgi, bfheatingcoeffs);
   printout("took %ld seconds\n", std::time(nullptr) - sys_time_start_calculate_bfheatingcoeffs);
 
   const double convergence_tolerance = 0.04;

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -675,9 +675,11 @@ void write_to_estimators_file(FILE *estimators_file, const int mgi, const int ti
   }
 }
 
-void solve_Te_nltepops(const int mgi, const int nts, const int nts_prev, HeatingCoolingRates *heatingcoolingrates)
+void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
+                       HeatingCoolingRates *heatingcoolingrates)
 // nts is the timestep number
 {
+  const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   // bfheating coefficients are needed for the T_e solver, but
   // they only depend on the radiation field, which is fixed during the iterations below
   printout("calculate_bfheatingcoeffs for timestep %d cell %d...", nts, mgi);
@@ -708,7 +710,8 @@ void solve_Te_nltepops(const int mgi, const int nts, const int nts_prev, Heating
     const auto sys_time_start_Te = std::time(nullptr);
 
     // Find T_e as solution for thermal balance
-    call_T_e_finder(mgi, globals::timesteps[nts_prev].mid, MINTEMP, MAXTEMP, heatingcoolingrates, bfheatingcoeffs);
+    call_T_e_finder(nonemptymgi, globals::timesteps[nts_prev].mid, MINTEMP, MAXTEMP, heatingcoolingrates,
+                    bfheatingcoeffs);
 
     const int duration_solve_T_e = std::time(nullptr) - sys_time_start_Te;
 
@@ -1008,7 +1011,7 @@ void update_grid_cell(const int mgi, const int nts, const int nts_prev, const in
       // full-spectrum and binned J and nuJ estimators
       radfield::fit_parameters(mgi, nts);
 
-      solve_Te_nltepops(mgi, nts, nts_prev, heatingcoolingrates);
+      solve_Te_nltepops(nonemptymgi, nts, nts_prev, heatingcoolingrates);
     }
     printout("Temperature/NLTE solution for cell %d timestep %d took %ld seconds\n", mgi, nts,
              std::time(nullptr) - sys_time_start_temperature_corrections);


### PR DESCRIPTION
Reduce MPI communication by sharing modelgrid, ion_groundlevelpops, ion_partfuncts, ion_cooling_contribs on node. Eliminate MPI_Pack calls and complicated buffer size calculation.