### PR TITLE
STDPAR parallelise update_grid components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ else
 		ifeq ($(COMPILER_NAME),NVHPC)
 			CXXFLAGS += -fast
 		else
-			CXXFLAGS += -ffast-math -funsafe-math-optimizations -fno-finite-math-only -fopenmp-simd
+			CXXFLAGS += -ffast-math -funsafe-math-optimizations -fno-finite-math-only
 		endif
 	endif
 endif

--- a/atomic.h
+++ b/atomic.h
@@ -58,7 +58,7 @@ inline auto get_nlevels(const int element, const int ion) -> int {
 }
 
 // Return the energy of (element,ion,level).
-#pragma omp declare simd
+
 [[nodiscard]] inline auto epsilon(const int element, const int ion, const int level) -> double {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
@@ -120,7 +120,7 @@ inline auto get_nphixstargets(const int element, const int ion, const int level)
 }
 
 // Return the statistical weight of (element,ion,level).
-#pragma omp declare simd
+
 [[nodiscard]] inline auto stat_weight(const int element, const int ion, const int level) -> double {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));

--- a/grid.cc
+++ b/grid.cc
@@ -1005,6 +1005,7 @@ void setup_nstart_ndo() {
     assert_always(fileout.is_open());
     fileout << "#rank nstart ndo ndo_nonempty\n";
     for (int r = 0; r < nprocesses; r++) {
+      assert_always(ranks_ndo_nonempty[r] <= ranks_ndo[r]);
       fileout << r << " " << ranks_nstart[r] << " " << ranks_ndo[r] << " " << ranks_ndo_nonempty[r] << "\n";
     }
   }

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -262,12 +263,14 @@ void calculate_cooling_rates(const int nonemptymgi, HeatingCoolingRates *heating
   double C_fb_all = 0.;          // free-bound creation of rpkt
   double C_exc_all = 0.;         // collisional excitation of macroatoms
   double C_ionization_all = 0.;  // collisional ionisation of macroatoms
-  for (int allionindex = 0; allionindex < get_includedions(); allionindex++) {
+
+  const auto allionindices = std::ranges::iota_view{0, get_includedions()};
+  std::for_each(EXEC_PAR allionindices.begin(), allionindices.end(), [&](const int allionindex) {
     const auto [element, ion] = get_ionfromuniqueionindex(allionindex);
     grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + allionindex] =
         calculate_cooling_rates_ion<false>(nonemptymgi, element, ion, -1, cellcacheslotid, &C_ff_all, &C_fb_all,
                                            &C_exc_all, &C_ionization_all);
-  }
+  });
 
   // this loop is made separate for future parallelisation of upper loop.
   // the ion contributions must be added in this exact order

--- a/ltepop.h
+++ b/ltepop.h
@@ -4,11 +4,11 @@
 #include <vector>
 
 [[nodiscard]] auto get_groundlevelpop(int nonemptymgi, int element, int ion) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto calculate_levelpop(int nonemptymgi, int element, int ion, int level) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto calculate_levelpop_lte(int nonemptymgi, int element, int ion, int level) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto get_levelpop(int nonemptymgi, int element, int ion, int level) -> double;
 [[nodiscard]] auto calculate_sahafact(int element, int ion, int level, int upperionlevel, double T, double E_threshold)
     -> double;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -646,7 +646,7 @@ void macroatom_close_file() {
 
 // radiative deexcitation rate: paperII 3.5.2
 // multiply by upper level population to get a rate per second
-#pragma omp declare simd
+
 auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const int ion, const int lower,
                                 const double epsilon_trans, const float A_ul, const double upperstatweight,
                                 const double nnlevelupper, const double t_current) -> double {
@@ -690,7 +690,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
 
 // radiative excitation rate: paperII 3.5.2
 // multiply by lower level population to get a rate per second
-#pragma omp declare simd
+
 auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const int ion, const int lower,
                               const int uptransindex, const double epsilon_trans, const double nnlevel_lower,
                               const int lineindex, const double t_current) -> double {
@@ -732,7 +732,7 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const in
 
 // radiative recombination rate: paperII 3.5.2
 // multiply by upper level population to get a rate per second
-#pragma omp declare simd
+
 auto rad_recombination_ratecoeff(const float T_e, const float nne, const int element, const int upperion,
                                  const int upperionlevel, const int lowerionlevel, const int nonemptymgi) -> double {
   // it's probably faster to only check this condition outside this function
@@ -777,7 +777,7 @@ auto stim_recombination_ratecoeff(const float nne, const int element, const int 
 }
 
 // multiply by upper level population to get a rate per second
-#pragma omp declare simd
+
 auto col_recombination_ratecoeff(const float T_e, const float nne, const int element, const int upperion,
                                  const int upper, const int lower, const double epsilon_trans) -> double {
   // it's probably faster to only check this condition outside this function
@@ -818,7 +818,7 @@ auto col_recombination_ratecoeff(const float T_e, const float nne, const int ele
 
 // collisional ionization rate: paperII 3.5.1
 // multiply by lower level population to get a rate per second
-#pragma omp declare simd
+
 auto col_ionization_ratecoeff(const float T_e, const float nne, const int element, const int ion, const int lower,
                               const int phixstargetindex, const double epsilon_trans) -> double {
   assert_testmodeonly(phixstargetindex >= 0);
@@ -850,7 +850,7 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 }
 
 // multiply by upper level population to get a rate per second
-#pragma omp declare simd
+
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans, const int element,
                                 const int ion, const int upper, const LevelTransition &downtransition) -> double {
   const int lower = downtransition.targetlevelindex;
@@ -901,7 +901,7 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
 }
 
 // multiply by lower level population to get a rate per second
-#pragma omp declare simd
+
 auto col_excitation_ratecoeff(const float T_e, const float nne, const int element, const int ion, const int lower,
                               const int uptransindex, const double epsilon_trans, const double lowerstatweight)
     -> double {

--- a/macroatom.h
+++ b/macroatom.h
@@ -9,33 +9,29 @@ void macroatom_close_file();
 
 void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 
-#pragma omp declare simd
 [[nodiscard]] auto rad_deexcitation_ratecoeff(int nonemptymgi, int element, int ion, int lower, double epsilon_trans,
                                               float A_ul, double upperstatweight, double nnlevelupper, double t_current)
     -> double;
 
-#pragma omp declare simd
 [[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int element, int ion, int lower, int uptransindex,
                                             double epsilon_trans, double nnlevel_lower, int lineindex, double t_current)
     -> double;
 
-#pragma omp declare simd
 [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upperionlevel,
                                                int lowerionlevel, int nonemptymgi) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto stim_recombination_ratecoeff(float nne, int element, int upperion, int upper, int lower,
                                                 int nonemptymgi) -> double;
 
-#pragma omp declare simd
 [[nodiscard]] auto col_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upper, int lower,
                                                double epsilon_trans) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto col_ionization_ratecoeff(float T_e, float nne, int element, int ion, int lower, int phixstargetindex,
                                             double epsilon_trans) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, int element, int ion,
                                               int upper, const LevelTransition &downtransition) -> double;
-#pragma omp declare simd
+
 [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, int element, int ion, int lower, int uptransindex,
                                             double epsilon_trans, double lowerstatweight) -> double;
 

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -18,7 +18,7 @@ void solve_spencerfano(int nonemptymgi, int timestep, int iteration);
 void calculate_deposition_rate_density(int nonemptymgi, int timestep, HeatingCoolingRates &heatingcoolingrates);
 [[nodiscard]] auto get_deposition_rate_density(int nonemptymgi) -> double;
 [[nodiscard]] auto get_nt_frac_heating(int modelgridindex) -> float;
-#pragma omp declare simd
+
 [[nodiscard]] auto nt_excitation_ratecoeff(int nonemptymgi, int element, int ion, int lowerlevel, int uptransindex,
                                            int lineindex) -> double;
 void do_ntalpha_deposit(Packet &pkt);

--- a/packet.cc
+++ b/packet.cc
@@ -132,8 +132,8 @@ void packet_init(Packet *pkt)
   // Now place the pellets in the ejecta and decide at what time they will decay.
 
   printout("Placing pellets...\n");
-  auto allpkts = std::ranges::iota_view{0, globals::npkts};
-  std::ranges::for_each(allpkts, [&, norm, e0](const int n) {
+  const auto allpkts = std::ranges::iota_view{0, globals::npkts};
+  std::for_each(EXEC_PAR allpkts.begin(), allpkts.end(), [&, norm, e0](const int n) {
     pkt[n] = Packet{};
     const double targetval = rng_uniform() * norm;
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -112,7 +112,7 @@ constexpr auto get_bin_nu_lower(const int binindex) -> double {
 }
 
 // find the left-closed bin [nu_lower, nu_upper) that nu belongs to
-#pragma omp declare simd
+
 constexpr auto select_bin(const double nu) -> int {
   if (nu < nu_lower_first_initial) {
     return -2;  // out of range, nu lower than lowest bin's lower boundary
@@ -224,7 +224,7 @@ void update_bfestimators(const int nonemptymgi, const double distance_e_cmf, con
                             globals::bfestim_nu_edge.data();
 
   const auto bfestimcount = globals::bfestimcount;
-#pragma omp simd
+
   for (auto bfestimindex = bfestimbegin; bfestimindex < bfestimend; bfestimindex++) {
     atomicadd(bfrate_raw[(nonemptymgi * bfestimcount) + bfestimindex],
               phixslist.gamma_contr[bfestimindex] * distance_e_cmf_over_nu);

--- a/sn3d.h
+++ b/sn3d.h
@@ -180,7 +180,7 @@ __attribute__((__format__(__printf__, 1, 2))) inline auto printout(const char *f
 
 #ifdef __cpp_lib_atomic_ref
 #define atomicadd(var, val) \
-  std::atomic_ref<std::remove_reference<decltype(var)>::type>(var).fetch_add(val, std::memory_order_relaxed);
+  std::atomic_ref<typename std::remove_reference<decltype(var)>::type>(var).fetch_add(val, std::memory_order_relaxed);
 #else
 // needed for Apple clang
 #define atomicadd(var, val) __atomic_fetch_add(&var, val, __ATOMIC_RELAXED);

--- a/sn3d.h
+++ b/sn3d.h
@@ -46,6 +46,7 @@
 
 #ifdef STDPAR_ON
 #include <execution>
+#include <thread>
 
 #define EXEC_PAR_UNSEQ std::execution::par_unseq,
 #define EXEC_PAR std::execution::par,
@@ -254,10 +255,14 @@ inline void gsl_error_handler_printout(const char *reason, const char *file, int
 }
 
 [[nodiscard]] inline auto get_max_threads() -> int {
-#if defined _OPENMP
+#ifdef STDPAR_ON
+  return static_cast<int>(std::thread::hardware_concurrency());
+#else
+#ifdef _OPENMP
   return omp_get_max_threads();
 #else
   return 1;
+#endif
 #endif
 }
 

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 #include <vector>
 
 #include "artisoptions.h"
@@ -278,7 +279,8 @@ void calculate_bfheatingcoeffs(int nonemptymgi, std::vector<double> &bfheatingco
     const int nions = get_nions(element);
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels = get_nlevels(element, ion);
-      for (int level = 0; level < nlevels; level++) {
+      const auto levels = std::ranges::iota_view{0, nlevels};
+      std::for_each(EXEC_PAR levels.begin(), levels.end(), [&](const int level) {
         double bfheatingcoeff = 0.;
         if (grid::get_elem_abundance(nonemptymgi, element) > minelfrac || USE_LUT_BFHEATING) {
           const auto nphixstargets = get_nphixstargets(element, ion, level);
@@ -306,7 +308,7 @@ void calculate_bfheatingcoeffs(int nonemptymgi, std::vector<double> &bfheatingco
           }
         }
         bfheatingcoeffs[get_uniquelevelindex(element, ion, level)] = bfheatingcoeff;
-      }
+      });
     }
   }
 }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1105,28 +1105,29 @@ void update_grid(FILE *estimators_file, const int nts, const int nts_prev, const
     radfield::normalise_bf_estimators(nts, nts_prev, titer, deltat);
   }
 
-  const int nstart = grid::get_nstart(my_rank);
-  const int ndo = grid::get_ndo(my_rank);
-  heatingcoolingrates_thisrankcells.resize(ndo);
+  const auto nstart_nonempty = grid::get_nstart_nonempty(my_rank);
+  const auto ndo_nonempty = grid::get_ndo_nonempty(my_rank);
+  heatingcoolingrates_thisrankcells.resize(ndo_nonempty);
   std::ranges::fill(heatingcoolingrates_thisrankcells, HeatingCoolingRates{});
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic)
 #endif
-  for (int mgi = nstart; mgi < nstart + ndo; mgi++) {
-    const auto nonemptymgi = (grid::get_numpropcells(mgi) > 0) ? grid::get_nonemptymgi_of_mgi(mgi) : -1;
-    if (nonemptymgi >= 0) {
-      update_grid_cell(nonemptymgi, nts, nts_prev, titer, tratmid, deltat,
-                       heatingcoolingrates_thisrankcells.at(mgi - nstart));
-    }
+  for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+    update_grid_cell(nonemptymgi, nts, nts_prev, titer, tratmid, deltat,
+                     heatingcoolingrates_thisrankcells.at(nonemptymgi - nstart_nonempty));
   }  // end parallel for loop over all modelgrid cells
 
   // serial output of estimator data to this ranks estimator file cell by cell
-  for (int mgi = nstart; mgi < nstart + ndo; mgi++) {
+  const auto nstart = grid::get_nstart(my_rank);
+  const auto ndo = grid::get_ndo(my_rank);
+  for (int mgi = nstart; mgi < (nstart + ndo); mgi++) {
     const auto nonemptymgi = (grid::get_numpropcells(mgi) > 0) ? grid::get_nonemptymgi_of_mgi(mgi) : -1;
     if (nonemptymgi >= 0) {
+      assert_always(nonemptymgi >= nstart_nonempty);
+      assert_always(nonemptymgi < (nstart_nonempty + ndo_nonempty));
       write_to_estimators_file(estimators_file, nonemptymgi, nts, titer,
-                               heatingcoolingrates_thisrankcells.at(mgi - nstart));
+                               heatingcoolingrates_thisrankcells.at(nonemptymgi - nstart_nonempty));
     } else {
       // modelgrid cells that are not represented in the simulation grid
       fprintf(estimators_file, "timestep %d modelgridindex %d EMPTYCELL\n\n", nts, mgi);

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1105,10 +1105,11 @@ void update_grid(FILE *estimators_file, const int nts, const int nts_prev, const
     radfield::normalise_bf_estimators(nts, nts_prev, titer, deltat);
   }
 
-  const auto nstart_nonempty = grid::get_nstart_nonempty(my_rank);
   const auto ndo_nonempty = grid::get_ndo_nonempty(my_rank);
   heatingcoolingrates_thisrankcells.resize(ndo_nonempty);
   std::ranges::fill(heatingcoolingrates_thisrankcells, HeatingCoolingRates{});
+
+  const auto nstart_nonempty = grid::get_nstart_nonempty(my_rank);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic)
@@ -1116,7 +1117,7 @@ void update_grid(FILE *estimators_file, const int nts, const int nts_prev, const
   for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
     update_grid_cell(nonemptymgi, nts, nts_prev, titer, tratmid, deltat,
                      heatingcoolingrates_thisrankcells.at(nonemptymgi - nstart_nonempty));
-  }  // end parallel for loop over all modelgrid cells
+  }
 
   // serial output of estimator data to this ranks estimator file cell by cell
   const auto nstart = grid::get_nstart(my_rank);


### PR DESCRIPTION
in STDPAR mode, cells are processed one at a time using multiple threads for accelerating various solvers (compare to OpenMP mode in which each thread updates a different cell).