### PR TITLE
Add more robust checks on NLTE population solver and safer treatment when NLTE solver fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,10 @@ jobs:
               working-directory: tests/${{ matrix.testname }}_testrun/
               run: cat job0/estimators*.out
 
-            - name: cat job0 output log
+            - name: cat job output logs
               if: always()
               working-directory: tests/${{ matrix.testname }}_testrun/
-              run: cat job0/output_0-0.txt
+              run: cat job0/output_*.txt
 
             - name: Checksum job0 output files
               if: always()
@@ -163,10 +163,10 @@ jobs:
               working-directory: tests/${{ matrix.testname }}_testrun/
               run: cat job1/estimators*.out
 
-            - name: cat job1 output log
+            - name: cat job1 output logs
               if: always()
               working-directory: tests/${{ matrix.testname }}_testrun/
-              run: cat job1/output_0-0.txt
+              run: cat job1/output_*.txt
 
             - name: show deposition.out
               if: always() && inputs.testmode != 'ON'

--- a/artisoptions_christinenonthermal.h
+++ b/artisoptions_christinenonthermal.h
@@ -156,5 +156,7 @@ constexpr auto PARTICLE_THERMALISATION_SCHEME = ThermalisationScheme::INSTANT;
 
 constexpr auto GAMMA_THERMALISATION_SCHEME = ThermalisationScheme::DETAILED;
 
+constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = false;
+
 // NOLINTEND(modernize*,misc-unused-parameters)
 #endif  // ARTISOPTIONS_H

--- a/artisoptions_classic.h
+++ b/artisoptions_classic.h
@@ -151,5 +151,7 @@ constexpr auto PARTICLE_THERMALISATION_SCHEME = ThermalisationScheme::INSTANT;
 
 constexpr auto GAMMA_THERMALISATION_SCHEME = ThermalisationScheme::DETAILED;
 
+constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = false;
+
 // NOLINTEND(modernize*,misc-unused-parameters)
 #endif  // ARTISOPTIONS_H

--- a/artisoptions_kilonova_lte.h
+++ b/artisoptions_kilonova_lte.h
@@ -151,5 +151,7 @@ constexpr auto PARTICLE_THERMALISATION_SCHEME = ThermalisationScheme::DETAILED;
 
 constexpr auto GAMMA_THERMALISATION_SCHEME = ThermalisationScheme::DETAILED;
 
+constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = false;
+
 // NOLINTEND(modernize*,misc-unused-parameters)
 #endif  // ARTISOPTIONS_H

--- a/artisoptions_nltenebular.h
+++ b/artisoptions_nltenebular.h
@@ -162,5 +162,7 @@ constexpr auto PARTICLE_THERMALISATION_SCHEME = ThermalisationScheme::INSTANT;
 
 constexpr auto GAMMA_THERMALISATION_SCHEME = ThermalisationScheme::DETAILED;
 
+constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = false;
+
 // NOLINTEND(modernize*,misc-unused-parameters)
 #endif  // ARTISOPTIONS_H

--- a/artisoptions_nltewithoutnonthermal.h
+++ b/artisoptions_nltewithoutnonthermal.h
@@ -154,5 +154,7 @@ constexpr auto PARTICLE_THERMALISATION_SCHEME = ThermalisationScheme::INSTANT;
 
 constexpr auto GAMMA_THERMALISATION_SCHEME = ThermalisationScheme::DETAILED;
 
+constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = false;
+
 // NOLINTEND(modernize*,misc-unused-parameters)
 #endif  // ARTISOPTIONS_H

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -398,12 +398,12 @@ auto find_converged_nne(const int nonemptymgi, double nne_hi, const bool force_l
     }
   }
 
-  // double factor = 1.;
+  double factor = 1.;
   int ion = 0;
   for (ion = 0; ion < uppermost_ion; ion++) {
     const auto phifactor =
         use_phi_lte ? phi_lte(element, ion, nonemptymgi) : phi_rate_balance(element, ion, nonemptymgi);
-    // factor *= nne_hi * phifactor;
+    factor *= nne_hi * phifactor;
 
     if (phifactor > 1e50) {
       printout(

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -405,12 +405,12 @@ auto find_converged_nne(const int nonemptymgi, double nne_hi, const bool force_l
         use_phi_lte ? phi_lte(element, ion, nonemptymgi) : phi_rate_balance(element, ion, nonemptymgi);
     factor *= nne_hi * phifactor;
 
-    if (phifactor > 1e50) {
+    if (!std::isfinite(factor)) {
       printout(
           "[info] calculate_ion_balance_nne: uppermost_ion limited by phi factors for element "
-          "Z=%d, ionstage %d in cell %d (phifactor for ion %g greater than 1e50 setting ion %d as uppermost ion)\n",
-          get_atomicnumber(element), get_ionstage(element, ion), modelgridindex, phifactor, get_ionstage(element, ion - 1));
-      return ion - 1;
+          "Z=%d, ionstage %d in cell %d\n",
+          get_atomicnumber(element), get_ionstage(element, ion), modelgridindex);
+      return ion;
     }
   }
   uppermost_ion = ion;

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -373,7 +373,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_hi, const bool force_l
 
 }  // anonymous namespace
 
-[[nodiscard]] __host__ __device__ auto find_uppermost_ion(const int nonemptymgi, const int element, const double nne_hi, const bool force_lte) -> int {
+[[nodiscard]] __host__ __device__ auto find_uppermost_ion(const int nonemptymgi, const int element, const bool force_lte) -> int {
   const int nions = get_nions(element);
   if (nions == 0) {
     return -1;
@@ -611,7 +611,7 @@ auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
   bool only_lowest_ionstage = true;  // could be completely neutral, or just at each element's lowest ion stage
   for (int element = 0; element < get_nelements(); element++) {
     if (grid::get_elem_abundance(nonemptymgi, element) > 0) {
-      const auto uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
+      const auto uppermost_ion = find_uppermost_ion(nonemptymgi, element, force_lte);
       grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
 
       only_lowest_ionstage = only_lowest_ionstage && (uppermost_ion <= 0);

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -130,6 +130,7 @@ auto get_element_nne_contrib(const int nonemptymgi, const int element) -> double
     const auto nnion = get_nnion(nonemptymgi, element, ion);
     const int ioncharge = get_ionstage(element, ion) - 1;
     nne += ioncharge * nnion;
+    printout("nne = %g", nne);
   }
   return nne;
 }
@@ -148,6 +149,8 @@ auto nne_solution_f(const double nne_assumed, void *const voidparas) -> double {
       if (!force_lte && elem_has_nlte_levels(element)) {
         // populations from the NLTE solver are fixed during the nne solver
         nne_after += get_element_nne_contrib(nonemptymgi, element);
+        printout(" line 151 nne_solution f printout inne after = %g for element %d\n", nne_after, get_atomicnumber(element));
+
       } else {
         const bool use_phi_lte = force_lte || FORCE_SAHA_ION_BALANCE(get_atomicnumber(element));
         const auto ionfractions = calculate_ionfractions(element, nonemptymgi, nne_assumed, use_phi_lte);
@@ -156,9 +159,11 @@ auto nne_solution_f(const double nne_assumed, void *const voidparas) -> double {
           const double nnion = nnelement * ionfractions[ion];
           const int ioncharge = get_ionstage(element, ion) - 1;
           nne_after += ioncharge * nnion;
+        printout(" line 161 nne_solution f printout inne after = %g for element %d\n", nne_after, get_atomicnumber(element));
+
         }
       }
-
+      printout("nne_solution f printout nne after = %g\n", nne_after);
       assert_always(std::isfinite(nne_after));
     }
   }

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -398,12 +398,12 @@ auto find_converged_nne(const int nonemptymgi, double nne_hi, const bool force_l
     }
   }
 
-  double factor = 1.;
+  // double factor = 1.;
   int ion = 0;
   for (ion = 0; ion < uppermost_ion; ion++) {
     const auto phifactor =
         use_phi_lte ? phi_lte(element, ion, nonemptymgi) : phi_rate_balance(element, ion, nonemptymgi);
-    factor *= nne_hi * phifactor;
+    // factor *= nne_hi * phifactor;
 
     if (phifactor > 1e50) {
       printout(

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -373,7 +373,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_hi, const bool force_l
 
 }  // anonymous namespace
 
-[[nodiscard]] __host__ __device__ auto find_uppermost_ion(const int nonemptymgi, const int element, const bool force_lte) -> int {
+[[nodiscard]] __host__ __device__ auto find_uppermost_ion(const int nonemptymgi, const int element, const double nne_hi, const bool force_lte) -> int {
   const int nions = get_nions(element);
   if (nions == 0) {
     return -1;
@@ -611,7 +611,7 @@ auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
   bool only_lowest_ionstage = true;  // could be completely neutral, or just at each element's lowest ion stage
   for (int element = 0; element < get_nelements(); element++) {
     if (grid::get_elem_abundance(nonemptymgi, element) > 0) {
-      const auto uppermost_ion = find_uppermost_ion(nonemptymgi, element, force_lte);
+      const auto uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
       grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
 
       only_lowest_ionstage = only_lowest_ionstage && (uppermost_ion <= 0);

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -276,7 +276,7 @@ auto calculate_partfunct(const int element, const int ion, const int nonemptymgi
   return U;
 }
 
-auto find_uppermost_ion(const int nonemptymgi, const int element, const double nne_hi, const bool force_lte) -> int {
+[[nodiscard]] __host__ __device__ auto find_uppermost_ion(const int nonemptymgi, const int element, const double nne_hi, const bool force_lte) -> int {
   const int nions = get_nions(element);
   if (nions == 0) {
     return -1;
@@ -611,7 +611,7 @@ auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
   bool only_lowest_ionstage = true;  // could be completely neutral, or just at each element's lowest ion stage
   for (int element = 0; element < get_nelements(); element++) {
     if (grid::get_elem_abundance(nonemptymgi, element) > 0) {
-      const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
+      const auto uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
       grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
 
       only_lowest_ionstage = only_lowest_ionstage && (uppermost_ion <= 0);

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -405,12 +405,12 @@ auto find_converged_nne(const int nonemptymgi, double nne_hi, const bool force_l
         use_phi_lte ? phi_lte(element, ion, nonemptymgi) : phi_rate_balance(element, ion, nonemptymgi);
     factor *= nne_hi * phifactor;
 
-    if (!std::isfinite(factor)) {
+    if (phifactor > 1e50) {
       printout(
           "[info] calculate_ion_balance_nne: uppermost_ion limited by phi factors for element "
-          "Z=%d, ionstage %d in cell %d\n",
-          get_atomicnumber(element), get_ionstage(element, ion), modelgridindex);
-      return ion;
+          "Z=%d, ionstage %d in cell %d (phifactor for ion %g greater than 1e50 setting ion %d as uppermost ion)\n",
+          get_atomicnumber(element), get_ionstage(element, ion), modelgridindex, phifactor, get_ionstage(element, ion - 1));
+      return ion - 1;
     }
   }
   uppermost_ion = ion;

--- a/ltepop.h
+++ b/ltepop.h
@@ -13,6 +13,7 @@
 [[nodiscard]] auto calculate_sahafact(int element, int ion, int level, int upperionlevel, double T, double E_threshold)
     -> double;
 [[nodiscard]] auto get_nnion(int nonemptymgi, int element, int ion) -> double;
+[[nodiscard]] auto find_uppermost_ion(int nonemptymgi, int element, double nne_hi, bool force_lte) -> int;
 void calculate_ion_balance_nne(int nonemptymgi);
 void calculate_cellpartfuncts(int nonemptymgi, int element);
 [[nodiscard]] auto calculate_ionfractions(int element, int nonemptymgi, double nne, bool use_phi_lte)

--- a/ltepop.h
+++ b/ltepop.h
@@ -13,7 +13,7 @@
 [[nodiscard]] auto calculate_sahafact(int element, int ion, int level, int upperionlevel, double T, double E_threshold)
     -> double;
 [[nodiscard]] auto get_nnion(int nonemptymgi, int element, int ion) -> double;
-[[nodiscard]] auto find_uppermost_ion(int nonemptymgi, int element, bool force_lte) -> int;
+[[nodiscard]] auto find_uppermost_ion(int nonemptymgi, int element, double nne_hi, bool force_lte) -> int;
 void calculate_ion_balance_nne(int nonemptymgi);
 void calculate_cellpartfuncts(int nonemptymgi, int element);
 [[nodiscard]] auto calculate_ionfractions(int element, int nonemptymgi, double nne, bool use_phi_lte)

--- a/ltepop.h
+++ b/ltepop.h
@@ -13,7 +13,7 @@
 [[nodiscard]] auto calculate_sahafact(int element, int ion, int level, int upperionlevel, double T, double E_threshold)
     -> double;
 [[nodiscard]] auto get_nnion(int nonemptymgi, int element, int ion) -> double;
-[[nodiscard]] auto find_uppermost_ion(int nonemptymgi, int element, double nne_hi, bool force_lte) -> int;
+[[nodiscard]] auto find_uppermost_ion(int nonemptymgi, int element, bool force_lte) -> int;
 void calculate_ion_balance_nne(int nonemptymgi);
 void calculate_cellpartfuncts(int nonemptymgi, int element);
 [[nodiscard]] auto calculate_ionfractions(int element, int nonemptymgi, double nne, bool use_phi_lte)

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -647,6 +647,12 @@ void nltepop_matrix_normalise(const int nonemptymgi, const int element, gsl_matr
 void set_element_pops_lte(const int nonemptymgi, const int element) {
   nltepop_reset_element(nonemptymgi, element);  // set NLTE pops as invalid so that LTE pops will be used instead
   calculate_cellpartfuncts(nonemptymgi, element);
+  // Recall find_uppermost_ion with force_lte = true so uppermost ion used in set_groundlevelpops
+  // is reset based on LTE phi factors instead of coming from NLTE phi factors
+  const double nne_hi = grid::get_rho(nonemptymgi) / MH;
+  const bool force_lte = true;
+  const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
+  grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
   set_groundlevelpops(nonemptymgi, element, grid::get_nne(nonemptymgi), true);
 }
 
@@ -1058,7 +1064,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
   if (!matrix_solve_success) {
     printout(
         "WARNING: Can't solve for NLTE populations in cell %d at timestep %d for element Z=%d due to singular matrix. "
-        "Attempting to use LTE solution instead\n",
+        ", negative population or large population inversion. Attempting to use LTE solution instead\n",
         modelgridindex, timestep, atomic_number);
     set_element_pops_lte(nonemptymgi, element);
   } else {

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -815,6 +815,33 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
               "  WARNING: negative pop = %g greater than -1*MINPOP (-%g) likely a rounding error to zero so continue "
               "with NLTE pops \n", gsl_vector_get(popvec, row), MINPOP);
     }
+    if (row != row_ground_state &&
+        gsl_vector_get(popvec, row_ground_state) <
+        (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
+            printout("[debug] WARNING: pop inversion: (g_pop %g)/(e_pop %g) = %g is less than (g_sw %g)/(e_sw %g) = %g "
+            "for index %zud Z=%d ionstage %d level %d (factor %g inversion) - ",
+            gsl_vector_get(popvec, row_ground_state), gsl_vector_get(popvec, row),
+            gsl_vector_get(popvec, row_ground_state) / gsl_vector_get(popvec, row),
+            stat_weight(element, ion, 0), stat_weight(element, ion, level), stat_weight(element, ion, 0) / stat_weight(element, ion, level),
+            row, get_atomicnumber(element), get_ionstage(element, ion), level,
+            (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) / (gsl_vector_get(popvec, row_ground_state) / gsl_vector_get(popvec, row)));
+
+            if (gsl_vector_get(popvec, row_ground_state) * 10000. <
+                (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
+              printout(
+                  "large pop inversion (ground_pop * 10000 < ([g_gs / g_es] * excited_pop) - return matrix solve "
+                  "fail and use LTE pops for element \n");
+              return false;
+            }
+        if (gsl_vector_get(popvec, row_ground_state) * 10. < (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
+          printout("more substantial pop inversion (ground_pop * 10 < ([g_gs / g_es] * excited_pop) - "
+              "but continue with NLTE solution\n");
+        }
+        else {
+          printout("relatively small pop inversion (ground_pop * 10 > ([g_gs / g_es] * excited_pop) - "
+              "continue with NLTE solution\n");
+        }
+      }
   }
 
   return true;

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -649,9 +649,9 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   calculate_cellpartfuncts(nonemptymgi, element);
   // Recall find_uppermost_ion with force_lte = true so uppermost ion used in set_groundlevelpops
   // is reset based on LTE phi factors instead of coming from NLTE phi factors
-  // const double nne_hi = grid::get_rho(nonemptymgi) / MH;
+  const double nne_hi = grid::get_rho(nonemptymgi) / MH;
   const bool force_lte = true;
-  const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, force_lte);
+  const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
   grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
   set_groundlevelpops(nonemptymgi, element, grid::get_nne(nonemptymgi), true);
 }

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -38,12 +38,12 @@ constexpr bool individual_process_matrices = true;
 
 // this is the index for the NLTE solver that is handling all ions of a single element
 // This is NOT an index into grid::modelgrid[nonemptymgi].nlte_pops that contains all elements
-auto get_nlte_vector_index(const int element, const int ion, const int level) -> int {
+auto get_nlte_vector_index(const int element, const int ion, const int level, const int first_ion_used) -> int {
   // have to convert from nlte_pops index to nlte_vector index
   // the difference is that nlte vectors apply to a single element and include ground states
   // The (+ ion) term accounts for the ground state population indices that are not counted in the NLTE array
-  const int gs_index =
-      globals::elements[element].ions[ion].first_nlte - globals::elements[element].ions[0].first_nlte + ion;
+  const int gs_index = globals::elements[element].ions[ion].first_nlte -
+                       globals::elements[element].ions[first_ion_used].first_nlte + ion;
 
   // add in level or superlevel number
   const int level_index = gs_index + (is_nlte(element, ion, level) ? level : (get_nlevels_nlte(element, ion) + 1));
@@ -51,11 +51,12 @@ auto get_nlte_vector_index(const int element, const int ion, const int level) ->
   return level_index;
 }
 
-[[nodiscard]] auto get_ion_level_of_nlte_vector_index(const int index, const int element) -> std::tuple<int, int> {
+[[nodiscard]] auto get_ion_level_of_nlte_vector_index(const int index, const int element, const int first_ion_used)
+    -> std::tuple<int, int> {
   // this could easily be optimized if need be
   for (int dion = 0; dion < get_nions(element); dion++) {
     for (int dlevel = 0; dlevel < get_nlevels(element, dion); dlevel++) {
-      if (get_nlte_vector_index(element, dion, dlevel) == index) {
+      if (get_nlte_vector_index(element, dion, dlevel, first_ion_used) == index) {
         return {dion, dlevel};
       }
     }
@@ -87,7 +88,7 @@ void eliminate_nlte_matrix_rowcol(const int index, const int gs_index, gsl_matri
 // removing them by zeroing their interactions and setting their departure
 // coeff to 1.0
 void filter_nlte_matrix(const int element, gsl_matrix *rate_matrix, gsl_vector *balance_vector,
-                        const gsl_vector * /*pop_norm_factor_vec*/) {
+                        const gsl_vector * /*pop_norm_factor_vec*/, const int first_ion_used) {
   const gsl_matrix rate_matrix_var = *rate_matrix;
   const int nlte_dimension = rate_matrix_var.size1;
   for (int index = 0; index < nlte_dimension; index++) {
@@ -102,7 +103,7 @@ void filter_nlte_matrix(const int element, gsl_matrix *rate_matrix, gsl_vector *
       const double element_value = fabs(gsl_matrix_get(rate_matrix, row, index));
       col_max = std::max(element_value, col_max);
     }
-    const auto [ion, level] = get_ion_level_of_nlte_vector_index(index, element);
+    const auto [ion, level] = get_ion_level_of_nlte_vector_index(index, element, first_ion_used);
     // printout("index%4d (ionstage%2d level%4d) row_max %.1e col_max %.1e ",
     //          index,get_ionstage(element,ion),level,row_max,col_max);
 
@@ -113,7 +114,7 @@ void filter_nlte_matrix(const int element, gsl_matrix *rate_matrix, gsl_vector *
         // gsl_vector_set(balance_vector, index, MINPOP / get_vector_get(pop_norm_factor_vec, index));
         // printout("(Eliminating this ground state)");
       } else {
-        const int gs_index = get_nlte_vector_index(element, ion, 0);
+        const int gs_index = get_nlte_vector_index(element, ion, 0, first_ion_used);
         eliminate_nlte_matrix_rowcol(index, gs_index, rate_matrix, balance_vector);
         // printout("(forcing LTE population)");
       }
@@ -184,8 +185,8 @@ void print_level_rates_summary(const int element, const int selected_ion, const 
                                const gsl_vector *popvec, const gsl_matrix *rate_matrix_rad_bb,
                                const gsl_matrix *rate_matrix_coll_bb, const gsl_matrix *rate_matrix_ntcoll_bb,
                                const gsl_matrix *rate_matrix_rad_bf, const gsl_matrix *rate_matrix_coll_bf,
-                               const gsl_matrix *rate_matrix_ntcoll_bf) {
-  const int selected_index = get_nlte_vector_index(element, selected_ion, selected_level);
+                               const gsl_matrix *rate_matrix_ntcoll_bf, const int first_ion_used) {
+  const int selected_index = get_nlte_vector_index(element, selected_ion, selected_level, first_ion_used);
 
   for (int i = 0; i <= 3; i++) {
     // rates in from below, in from above, out to below, out to above
@@ -243,10 +244,11 @@ void print_element_rates_summary(const int element, const int modelgridindex, co
                                  const gsl_vector *popvec, const gsl_matrix *rate_matrix_rad_bb,
                                  const gsl_matrix *rate_matrix_coll_bb, const gsl_matrix *rate_matrix_ntcoll_bb,
                                  const gsl_matrix *rate_matrix_rad_bf, const gsl_matrix *rate_matrix_coll_bf,
-                                 const gsl_matrix *rate_matrix_ntcoll_bf) {
+                                 const gsl_matrix *rate_matrix_ntcoll_bf, const int first_ion_used,
+                                 const int nions_used) {
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
-  const int nions = get_nions(element);
-  for (int ion = 0; ion < nions; ion++) {
+  // const int nions = get_nions(element);
+  for (int ion = first_ion_used; ion < first_ion_used + nions_used - 1; ion++) {
     const int nlevels = get_nlevels(element, ion);
     const int nlevels_nlte = get_nlevels_nlte(element, ion);
 
@@ -266,14 +268,16 @@ void print_element_rates_summary(const int element, const int modelgridindex, co
       }
 
       print_level_rates_summary(element, ion, level, popvec, rate_matrix_rad_bb, rate_matrix_coll_bb,
-                                rate_matrix_ntcoll_bb, rate_matrix_rad_bf, rate_matrix_coll_bf, rate_matrix_ntcoll_bf);
+                                rate_matrix_ntcoll_bb, rate_matrix_rad_bf, rate_matrix_coll_bf, rate_matrix_ntcoll_bf,
+                                first_ion_used);
     }
 
     if (ion_has_superlevel(element, ion) && max_printed_levels < (nlevels_nlte + 1)) {
       const int level_superlevel = nlevels_nlte + 1;
 
       print_level_rates_summary(element, ion, level_superlevel, popvec, rate_matrix_rad_bb, rate_matrix_coll_bb,
-                                rate_matrix_ntcoll_bb, rate_matrix_rad_bf, rate_matrix_coll_bf, rate_matrix_ntcoll_bf);
+                                rate_matrix_ntcoll_bb, rate_matrix_rad_bf, rate_matrix_coll_bf, rate_matrix_ntcoll_bf,
+                                first_ion_used);
     }
   }
 }
@@ -282,7 +286,7 @@ void print_level_rates(const int modelgridindex, const int timestep, const int e
                        const int selected_level, const gsl_vector *popvec, const gsl_matrix *rate_matrix_rad_bb,
                        const gsl_matrix *rate_matrix_coll_bb, const gsl_matrix *rate_matrix_ntcoll_bb,
                        const gsl_matrix *rate_matrix_rad_bf, const gsl_matrix *rate_matrix_coll_bf,
-                       const gsl_matrix *rate_matrix_ntcoll_bf) {
+                       const gsl_matrix *rate_matrix_ntcoll_bf, const int first_ion_used) {
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
   // very detailed output of the NLTE processes for a particular levels
 
@@ -303,7 +307,7 @@ void print_level_rates(const int modelgridindex, const int timestep, const int e
   const int nlte_dimension = popvector.size;
   const int atomic_number = get_atomicnumber(element);
   const int selected_ionstage = get_ionstage(element, selected_ion);
-  const int selected_index = get_nlte_vector_index(element, selected_ion, selected_level);
+  const int selected_index = get_nlte_vector_index(element, selected_ion, selected_level, first_ion_used);
   const double pop_selectedlevel = gsl_vector_get(popvec, selected_index);
   printout(
       "timestep %d cell %d Te %g nne %g NLTE level diagnostics for Z=%d ionstage %d level %d rates into and out of "
@@ -342,7 +346,7 @@ void print_level_rates(const int modelgridindex, const int timestep, const int e
     if (index == selected_index) {
       continue;
     }
-    const auto [ion, level] = get_ion_level_of_nlte_vector_index(index, element);
+    const auto [ion, level] = get_ion_level_of_nlte_vector_index(index, element, first_ion_used);
     const int ionstage = get_ionstage(element, ion);
     // in means populating the selected level, out means depopulating the selected level
     const double pop = gsl_vector_get(popvec, index);
@@ -411,10 +415,12 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
   return superlevel_partfuncs;
 }
 
-[[nodiscard]] auto get_element_nlte_dimension(const int element) -> int {
+// CHECK THIS
+[[nodiscard]] auto get_element_nlte_dimension(const int element, const int nions_used, const int first_ion_used)
+    -> int {
   int nlte_dimension = 0;
-  const int nions = get_nions(element);
-  for (int ion = 0; ion < nions; ion++) {
+  // const int nions = get_nions(element);
+  for (int ion = first_ion_used; ion < nions_used + first_ion_used; ion++) {
     const int nlevels_nlte = get_nlevels_nlte(element, ion);
 
     nlte_dimension += nlevels_nlte + 1;  // ground state is not counted in nlevels_nlte
@@ -429,23 +435,24 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
 }
 
 // get the maximum NLTE dimension for any of the included elements
-[[nodiscard]] auto get_max_nlte_dimension() {
+[[nodiscard]] auto get_max_nlte_dimension(const int nions_used, const int first_ion_used) -> int {
   int max_nlte_dimension = 0;
   for (int element = 0; element < get_nelements(); element++) {
-    max_nlte_dimension = std::max(max_nlte_dimension, get_element_nlte_dimension(element));
+    max_nlte_dimension = std::max(max_nlte_dimension, get_element_nlte_dimension(element, nions_used, first_ion_used));
   }
   return max_nlte_dimension;
 }
 
 void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, const int ion, const double t_mid,
                                    const std::vector<double> &s_renorm, gsl_matrix *rate_matrix_rad_bb,
-                                   gsl_matrix *rate_matrix_coll_bb, gsl_matrix *rate_matrix_ntcoll_bb) {
+                                   gsl_matrix *rate_matrix_coll_bb, gsl_matrix *rate_matrix_ntcoll_bb,
+                                   const int first_ion_used) {
   const auto T_e = grid::get_Te(nonemptymgi);
   const float nne = grid::get_nne(nonemptymgi);
   const int nlevels = get_nlevels(element, ion);
   const auto levels = std::ranges::iota_view{0, nlevels};
   std::for_each(levels.begin(), levels.end(), [&](const auto level) {
-    const int level_index = get_nlte_vector_index(element, ion, level);
+    const int level_index = get_nlte_vector_index(element, ion, level, first_ion_used);
     const double epsilon_level = epsilon(element, ion, level);
     const double statweight = stat_weight(element, ion, level);
     const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
@@ -466,7 +473,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
           col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, level, downtransition) * s_renorm[level];
 
       const int upper_index = level_index;
-      const int lower_index = get_nlte_vector_index(element, ion, lower);
+      const int lower_index = get_nlte_vector_index(element, ion, lower, first_ion_used);
 
       atomicadd(*gsl_matrix_ptr(rate_matrix_rad_bb, upper_index, upper_index), -R);
       atomicadd(*gsl_matrix_ptr(rate_matrix_rad_bb, lower_index, upper_index), R);
@@ -502,7 +509,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
           nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, lineindex) * s_renorm[level];
 
       const int lower_index = level_index;
-      const int upper_index = get_nlte_vector_index(element, ion, upper);
+      const int upper_index = get_nlte_vector_index(element, ion, upper, first_ion_used);
 
       atomicadd(*gsl_matrix_ptr(rate_matrix_rad_bb, lower_index, lower_index), -R);
       atomicadd(*gsl_matrix_ptr(rate_matrix_rad_bb, upper_index, lower_index), R);
@@ -521,7 +528,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
 
 void nltepop_matrix_add_ionisation(const int modelgridindex, const int element, const int ion,
                                    const std::vector<double> &s_renorm, gsl_matrix *rate_matrix_rad_bf,
-                                   gsl_matrix *rate_matrix_coll_bf) {
+                                   gsl_matrix *rate_matrix_coll_bf, const int first_ion_used) {
   assert_always((ion + 1) < get_nions(element));  // can't ionise the top ion
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
   const auto T_e = grid::get_Te(nonemptymgi);
@@ -531,7 +538,7 @@ void nltepop_matrix_add_ionisation(const int modelgridindex, const int element, 
 
   const auto levels = std::ranges::iota_view{0, nionisinglevels};
   std::for_each(EXEC_PAR levels.begin(), levels.end(), [&](const auto level) {
-    const int lower_index = get_nlte_vector_index(element, ion, level);
+    const int lower_index = get_nlte_vector_index(element, ion, level, first_ion_used);
 
     // thermal collisional ionization, photoionisation and recombination processes
     const double epsilon_current = epsilon(element, ion, level);
@@ -539,7 +546,7 @@ void nltepop_matrix_add_ionisation(const int modelgridindex, const int element, 
     const auto nphixstargets = get_nphixstargets(element, ion, level);
     for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
       const int upper = get_phixsupperlevel(element, ion, level, phixstargetindex);
-      const int upper_index = get_nlte_vector_index(element, ion + 1, upper);
+      const int upper_index = get_nlte_vector_index(element, ion + 1, upper, first_ion_used);
       const double epsilon_trans = epsilon(element, ion + 1, upper) - epsilon_current;
 
       // ionization
@@ -580,7 +587,8 @@ void nltepop_matrix_add_ionisation(const int modelgridindex, const int element, 
 }
 
 void nltepop_matrix_add_nt_ionisation(const int nonemptymgi, const int element, const int ion,
-                                      const std::vector<double> &s_renorm, gsl_matrix *rate_matrix_ntcoll_bf) {
+                                      const std::vector<double> &s_renorm, gsl_matrix *rate_matrix_ntcoll_bf,
+                                      const int first_ion_used) {
   // collisional ionization by non-thermal electrons
 
   assert_always(ion + 1 < get_nions(element));  // can't ionise the top ion
@@ -596,9 +604,9 @@ void nltepop_matrix_add_nt_ionisation(const int nonemptymgi, const int element, 
         Y_nt * nonthermal::nt_ionization_upperion_probability(nonemptymgi, element, ion, upperion, false);
 
     if (Y_nt_thisupperion > 0.) {
-      const int upper_groundstate_index = get_nlte_vector_index(element, upperion, 0);
+      const int upper_groundstate_index = get_nlte_vector_index(element, upperion, 0, first_ion_used);
       for (int level = 0; level < nlevels; level++) {
-        const int lower_index = get_nlte_vector_index(element, ion, level);
+        const int lower_index = get_nlte_vector_index(element, ion, level, first_ion_used);
 
         atomicadd(*gsl_matrix_ptr(rate_matrix_ntcoll_bf, lower_index, lower_index),
                   -Y_nt_thisupperion * s_renorm[level]);
@@ -610,7 +618,7 @@ void nltepop_matrix_add_nt_ionisation(const int nonemptymgi, const int element, 
 }
 
 void nltepop_matrix_normalise(const int nonemptymgi, const int element, gsl_matrix *rate_matrix,
-                              gsl_vector *pop_norm_factor_vec) {
+                              gsl_vector *pop_norm_factor_vec, const int first_ion_used) {
   const size_t nlte_dimension = pop_norm_factor_vec->size;
   assert_always(pop_norm_factor_vec->size == nlte_dimension);
   assert_always(rate_matrix->size1 == nlte_dimension);
@@ -619,7 +627,7 @@ void nltepop_matrix_normalise(const int nonemptymgi, const int element, gsl_matr
   // TODO: consider replacing normalisation by LTE populations with
   // GSL's gsl_linalg_balance_matrix(gsl_matrix * A, gsl_vector * D) function instead
   for (size_t column = 0; column < nlte_dimension; column++) {
-    const auto [ion, level] = get_ion_level_of_nlte_vector_index(column, element);
+    const auto [ion, level] = get_ion_level_of_nlte_vector_index(column, element, first_ion_used);
 
     gsl_vector_set(pop_norm_factor_vec, column, calculate_levelpop_lte(nonemptymgi, element, ion, level));
 
@@ -654,15 +662,16 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
   grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
   set_groundlevelpops(nonemptymgi, element, grid::get_nne(nonemptymgi), true);
+  // assert_always(get_atomicnumber(element) < 26);
 }
 
-[[nodiscard]] auto lumatrix_is_singular(const gsl_matrix *LU, const int element) -> bool {
+[[nodiscard]] auto lumatrix_is_singular(const gsl_matrix *LU, const int element, const int first_ion_used) -> bool {
   size_t const n = LU->size1;
 
   for (size_t i = 0; i < n; i++) {
     const double u = gsl_matrix_get(LU, i, i);
     if (u == 0) {
-      const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element);
+      const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element, first_ion_used);
       if (is_nlte(element, ion, level)) {
         printout("NLTE disconnected level: Z=%d ionstage %d level %d\n", get_atomicnumber(element),
                  get_ionstage(element, ion), level);
@@ -682,7 +691,8 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
 // return true if the solution is successful, or false if the matrix is singular
 [[nodiscard]] auto nltepop_matrix_solve(const int element, const gsl_matrix *rate_matrix,
                                         const gsl_vector *balance_vector, gsl_vector *popvec,
-                                        const gsl_vector *pop_normfactor_vec, const int max_nlte_dimension) -> bool {
+                                        const gsl_vector *pop_normfactor_vec, const int max_nlte_dimension,
+                                        const int first_ion_used) -> bool {
   const size_t nlte_dimension = balance_vector->size;
   assert_always(pop_normfactor_vec->size == nlte_dimension);
   assert_always(rate_matrix->size1 == nlte_dimension);
@@ -708,7 +718,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   int s = 0;  // sign of the transformation
   gsl_linalg_LU_decomp(&rate_matrix_LU_decomp, &p, &s);
 
-  if (lumatrix_is_singular(&rate_matrix_LU_decomp, element)) {
+  if (lumatrix_is_singular(&rate_matrix_LU_decomp, element, first_ion_used)) {
     printout("ERROR: NLTE matrix is singular for element Z=%d!\n", get_atomicnumber(element));
     // abort();
     return false;
@@ -783,7 +793,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
     gsl_vector_const_view row_view = gsl_matrix_const_row(rate_matrix, row);
     gsl_blas_ddot(&row_view.vector, &x, &recovered_balance_vector_elem);
 
-    const auto [ion, level] = get_ion_level_of_nlte_vector_index(row, element);
+    const auto [ion, level] = get_ion_level_of_nlte_vector_index(row, element, first_ion_used);
     if (level == 0) {
       row_ground_state = row;
     }
@@ -793,67 +803,79 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
     //          row,get_ionstage(element,ion),level, gsl_vector_get(residual_vector,row),
     //          recovered_balance_vector_elem, gsl_vector_get(x,row),
     //          gsl_vector_get(popvec, row),
-    //          gsl_vector_get(x, row) / gsl_vector_get(x,get_nlte_vector_index(element,ion,0)));
+    //          gsl_vector_get(x, row) / gsl_vector_get(x,get_nlte_vector_index(element,ion,0, first_ion_used)));
 
     // Checking that groundpop is greater than MINPOP here - if it is then use LTE populations for element instead
     if (gsl_vector_get(popvec, row) < MINPOP && row == row_ground_state) {
       printout(
           "  WARNING: NLTE solver gave ground population less than MINPOP for index %zud (Z=%d ionstage %d level %d), "
           "pop = %g. "
-          "Returning nltepop_matrix_solve fail (using LTE pops instead)\n",
+          "Returning nltepop_matrix_solve fail \n",
           row, get_atomicnumber(element), get_ionstage(element, ion), level,
           gsl_vector_get(&x, row) * gsl_vector_get(pop_normfactor_vec, row));
 
-        return false;
+      return false;
     }
     if (gsl_vector_get(popvec, row) < 0.0) {
-      printout("  WARNING: NLTE solver gave negative population for index %zud (Z=%d ionstage %d level %d), pop = %g",
-               row, get_atomicnumber(element), get_ionstage(element, ion), level,
-               gsl_vector_get(&x, row) * gsl_vector_get(pop_normfactor_vec, row));
-      if (gsl_vector_get(popvec, row) < -1*MINPOP) {
-          printout(
-              "  WARNING: negative pop = %g less than -1*MINPOP (-%g) unlikely a rounding error to zero so returning "
-              "nltepop_matrix_solve fail (using LTE pops instead)\n", gsl_vector_get(popvec, row), MINPOP);
+      printout(
+          "  WARNING: NLTE solver gave negative population for index %zud (Z=%d ionstage %d level %d), pop = %g "
+          "(ground pop = %g)",
+          row, get_atomicnumber(element), get_ionstage(element, ion), level,
+          gsl_vector_get(&x, row) * gsl_vector_get(pop_normfactor_vec, row),
+          gsl_vector_get(&x, row_ground_state) * gsl_vector_get(pop_normfactor_vec, row_ground_state));
+      if (gsl_vector_get(popvec, row) < -1 * MINPOP) {
+        printout(
+            "  WARNING: negative pop = %g less than -1*MINPOP (-%g) unlikely a rounding error to zero so returning "
+            "nltepop_matrix_solve fail \n",
+            gsl_vector_get(popvec, row), MINPOP);
 
-      return false;
+        return false;
       }
       printout(
-              "  WARNING: negative pop = %g greater than -1*MINPOP (-%g) likely a rounding error to zero so continue "
-              "with NLTE pops \n", gsl_vector_get(popvec, row), MINPOP);
+          "  WARNING: negative pop = %g greater than -1*MINPOP (-%g) likely a rounding error to zero so continue "
+          "with NLTE pops \n",
+          gsl_vector_get(popvec, row), MINPOP);
+      gsl_vector_set(popvec, row,
+                     (gsl_vector_get(pop_normfactor_vec, row) / gsl_vector_get(pop_normfactor_vec, row_ground_state)) *
+                         gsl_vector_get(popvec, row_ground_state));
     }
     if (row != row_ground_state &&
         gsl_vector_get(popvec, row_ground_state) <
-        (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
-            printout("[debug] WARNING: pop inversion: (g_pop %g)/(e_pop %g) = %g is less than (g_sw %g)/(e_sw %g) = %g "
-            "for index %zud Z=%d ionstage %d level %d (factor %g inversion) - ",
-            gsl_vector_get(popvec, row_ground_state), gsl_vector_get(popvec, row),
-            gsl_vector_get(popvec, row_ground_state) / gsl_vector_get(popvec, row),
-            stat_weight(element, ion, 0), stat_weight(element, ion, level), stat_weight(element, ion, 0) / stat_weight(element, ion, level),
-            row, get_atomicnumber(element), get_ionstage(element, ion), level,
-            (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) / (gsl_vector_get(popvec, row_ground_state) / gsl_vector_get(popvec, row)));
+            (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
+      printout(
+          "[debug] WARNING: pop inversion: (g_pop %g)/(e_pop %g) = %g is less than (g_sw %g)/(e_sw %g) = %g "
+          "for index %zud Z=%d ionstage %d level %d (factor %g inversion) - ",
+          gsl_vector_get(popvec, row_ground_state), gsl_vector_get(popvec, row),
+          gsl_vector_get(popvec, row_ground_state) / gsl_vector_get(popvec, row), stat_weight(element, ion, 0),
+          stat_weight(element, ion, level), stat_weight(element, ion, 0) / stat_weight(element, ion, level), row,
+          get_atomicnumber(element), get_ionstage(element, ion), level,
+          (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) /
+              (gsl_vector_get(popvec, row_ground_state) / gsl_vector_get(popvec, row)));
 
-            if (gsl_vector_get(popvec, row_ground_state) * 10000. <
-                (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
-              printout(
-                  "large pop inversion (ground_pop * 10000 < ([g_gs / g_es] * excited_pop) - return matrix solve "
-                  "fail and use LTE pops for element \n");
-              return false;
-            }
-        if (gsl_vector_get(popvec, row_ground_state) * 10. < (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
-          printout("more substantial pop inversion (ground_pop * 10 < ([g_gs / g_es] * excited_pop) - "
-              "but continue with NLTE solution\n");
-        }
-        else {
-          printout("relatively small pop inversion (ground_pop * 10 > ([g_gs / g_es] * excited_pop) - "
-              "continue with NLTE solution\n");
-        }
+      if (gsl_vector_get(popvec, row_ground_state) * 10. <
+          (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
+        printout(
+            "large pop inversion (ground_pop * 10000 < ([g_gs / g_es] * excited_pop) - return matrix solve "
+            "fail and use LTE pops for element \n");
+        return false;
       }
+      if (gsl_vector_get(popvec, row_ground_state) * 5. <
+          (stat_weight(element, ion, 0) / stat_weight(element, ion, level)) * gsl_vector_get(popvec, row)) {
+        printout(
+            "more substantial pop inversion (ground_pop * 10 < ([g_gs / g_es] * excited_pop) - "
+            "but continue with NLTE solution\n");
+      } else {
+        printout(
+            "relatively small pop inversion (ground_pop * 10 > ([g_gs / g_es] * excited_pop) - "
+            "continue with NLTE solution\n");
+      }
+    }
   }
 
   return true;
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
 void solve_nlte_pops_element(const int element, const int nonemptymgi, const int timestep, const int nlte_iter)
 // solves the statistical balance equations to find NLTE level populations for all ions of an element
@@ -884,199 +906,301 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
   const auto sys_time_start_nltesolver = std::time(nullptr);
 
   const double t_mid = globals::timesteps[timestep].mid;
-  const int nions = get_nions(element);
-  const double nnelement = grid::get_elem_numberdens(nonemptymgi, element);
+  const int nions =
+      get_nions(element);  // Might need to change this if we want solver to work for sub-set of elements ions
+  const double nnelement = grid::get_elem_numberdens(
+      nonemptymgi, element);  // don't need to change this as we should only ever remove ions that have a very low
+                              // population - if they don't should just revert the entire element to LTE
 
   printout(
       "Solving for NLTE populations in cell %d at timestep %d NLTE iteration %d for element Z=%d (mass fraction %.2e, "
       "nnelement %.2e cm^-3)\n",
       modelgridindex, timestep, nlte_iter, atomic_number, grid::get_elem_abundance(nonemptymgi, element), nnelement);
-
-  const auto superlevel_partfunc = get_element_superlevelpartfuncs(nonemptymgi, element);
-  const int nlte_dimension = get_element_nlte_dimension(element);
-
-  // printout("NLTE: the vector dimension is %d", nlte_dimension);
-
-  const auto max_nlte_dimension = get_max_nlte_dimension();
-
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix;
-  vec_rate_matrix.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-  auto rate_matrix = gsl_matrix_view_array(vec_rate_matrix.data(), nlte_dimension, nlte_dimension).matrix;
-  gsl_matrix_set_all(&rate_matrix, 0.);
-
+  printout("Just before quantites are initilaised for while loop\n");
+  const auto superlevel_partfunc =
+      get_element_superlevelpartfuncs(nonemptymgi, element);  // Might also need to change this?
+  int nions_used = nions;
+  int first_ion_used = 0;
+  bool matrix_solve_satisfied_with_ion_list = false;
+  bool matrix_solve_success = false;
+  int nlte_dimension = get_element_nlte_dimension(
+      element, nions_used,
+      first_ion_used);  // Might need to change this if we want solver to work for sub-set of elements ions
   gsl_matrix rate_matrix_rad_bb;
   gsl_matrix rate_matrix_coll_bb;
   gsl_matrix rate_matrix_ntcoll_bb;
   gsl_matrix rate_matrix_rad_bf;
   gsl_matrix rate_matrix_coll_bf;
   gsl_matrix rate_matrix_ntcoll_bf;
+  gsl_vector popvec;
+  printout("after matrix and vectors are initialised\n");
+  // while (!matrix_solve_satisfied_with_ion_list)
+  {
+    printout("inside while loop\n");
+    // nlte_dimension = get_element_nlte_dimension(element, nions_used, first_ion_used);  // Might need to change this
+    // if we want solver to work for sub-set of elements ions
 
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix_rad_bb;
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix_coll_bb;
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix_ntcoll_bb;
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix_rad_bf;
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix_coll_bf;
-  THREADLOCALONHOST std::vector<double> vec_rate_matrix_ntcoll_bf;
-  if constexpr (individual_process_matrices) {
-    vec_rate_matrix_rad_bb.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-    rate_matrix_rad_bb = gsl_matrix_view_array(vec_rate_matrix_rad_bb.data(), nlte_dimension, nlte_dimension).matrix;
-    gsl_matrix_set_all(&rate_matrix_rad_bb, 0.);
+    // printout("NLTE: the vector dimension is %d", nlte_dimension);
 
-    vec_rate_matrix_coll_bb.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-    rate_matrix_coll_bb = gsl_matrix_view_array(vec_rate_matrix_coll_bb.data(), nlte_dimension, nlte_dimension).matrix;
-    gsl_matrix_set_all(&rate_matrix_coll_bb, 0.);
+    const auto max_nlte_dimension =
+        get_max_nlte_dimension(nions_used, first_ion_used);  // Might need to change this but think this follows from
+                                                             // get_element_nlte_dimension so maybe ok
 
-    vec_rate_matrix_ntcoll_bb.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-    rate_matrix_ntcoll_bb =
-        gsl_matrix_view_array(vec_rate_matrix_ntcoll_bb.data(), nlte_dimension, nlte_dimension).matrix;
-    gsl_matrix_set_all(&rate_matrix_ntcoll_bb, 0.);
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix;
+    vec_rate_matrix.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+    auto rate_matrix = gsl_matrix_view_array(vec_rate_matrix.data(), nlte_dimension, nlte_dimension).matrix;
+    gsl_matrix_set_all(&rate_matrix, 0.);
 
-    vec_rate_matrix_rad_bf.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-    rate_matrix_rad_bf = gsl_matrix_view_array(vec_rate_matrix_rad_bf.data(), nlte_dimension, nlte_dimension).matrix;
-    gsl_matrix_set_all(&rate_matrix_rad_bf, 0.);
+    printout("inside while loop line 940\n");
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix_rad_bb;
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix_coll_bb;
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix_ntcoll_bb;
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix_rad_bf;
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix_coll_bf;
+    THREADLOCALONHOST std::vector<double> vec_rate_matrix_ntcoll_bf;
+    printout("inside while loop line 947\n");
+    if constexpr (individual_process_matrices) {
+      printout("inside while loop line 949\n");
+      vec_rate_matrix_rad_bb.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+      printout("inside while loop line 949\n");
+      rate_matrix_rad_bb = gsl_matrix_view_array(vec_rate_matrix_rad_bb.data(), nlte_dimension, nlte_dimension).matrix;
+      printout("inside while loop line 949\n");
+      gsl_matrix_set_all(&rate_matrix_rad_bb, 0.);
+      printout("inside while loop line 949\n");
 
-    vec_rate_matrix_coll_bf.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-    rate_matrix_coll_bf = gsl_matrix_view_array(vec_rate_matrix_coll_bf.data(), nlte_dimension, nlte_dimension).matrix;
-    gsl_matrix_set_all(&rate_matrix_coll_bf, 0.);
+      vec_rate_matrix_coll_bb.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+      rate_matrix_coll_bb =
+          gsl_matrix_view_array(vec_rate_matrix_coll_bb.data(), nlte_dimension, nlte_dimension).matrix;
+      gsl_matrix_set_all(&rate_matrix_coll_bb, 0.);
 
-    vec_rate_matrix_ntcoll_bf.resize(max_nlte_dimension * max_nlte_dimension, 0.);
-    rate_matrix_ntcoll_bf =
-        gsl_matrix_view_array(vec_rate_matrix_ntcoll_bf.data(), nlte_dimension, nlte_dimension).matrix;
-    gsl_matrix_set_all(&rate_matrix_ntcoll_bf, 0.);
-  } else {
-    // if not individual_process_matrices, alias a single matrix for all transition types
-    // the "gsl_matrix" structs are independent, but the data is shared
-    rate_matrix_rad_bb = rate_matrix;
-    rate_matrix_coll_bb = rate_matrix;
-    rate_matrix_ntcoll_bb = rate_matrix;
-    rate_matrix_rad_bf = rate_matrix;
-    rate_matrix_coll_bf = rate_matrix;
-    rate_matrix_ntcoll_bf = rate_matrix;
-  }
+      vec_rate_matrix_ntcoll_bb.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+      rate_matrix_ntcoll_bb =
+          gsl_matrix_view_array(vec_rate_matrix_ntcoll_bb.data(), nlte_dimension, nlte_dimension).matrix;
+      gsl_matrix_set_all(&rate_matrix_ntcoll_bb, 0.);
 
-  // printout("  Adding rates for ion stages:");
-  const auto ions = std::ranges::iota_view{0, nions};
-  std::for_each(EXEC_PAR ions.begin(), ions.end(), [&](const auto ion) {
-    // const int ionstage = get_ionstage(element, ion);
-    // printout(" %d", ionstage);
+      vec_rate_matrix_rad_bf.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+      rate_matrix_rad_bf = gsl_matrix_view_array(vec_rate_matrix_rad_bf.data(), nlte_dimension, nlte_dimension).matrix;
+      gsl_matrix_set_all(&rate_matrix_rad_bf, 0.);
 
-    const int nlevels = get_nlevels(element, ion);
-    const int nlevels_nlte = get_nlevels_nlte(element, ion);  // does not count the ground state!
+      vec_rate_matrix_coll_bf.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+      rate_matrix_coll_bf =
+          gsl_matrix_view_array(vec_rate_matrix_coll_bf.data(), nlte_dimension, nlte_dimension).matrix;
+      gsl_matrix_set_all(&rate_matrix_coll_bf, 0.);
 
-    auto s_renorm = std::vector<double>(nlevels);
-    std::fill_n(s_renorm.begin(), nlevels_nlte + 1, 1.);
-
-    for (int level = (nlevels_nlte + 1); level < nlevels; level++) {
-      s_renorm[level] = superlevel_boltzmann(nonemptymgi, element, ion, level) / superlevel_partfunc[ion];
+      vec_rate_matrix_ntcoll_bf.resize(max_nlte_dimension * max_nlte_dimension, 0.);
+      rate_matrix_ntcoll_bf =
+          gsl_matrix_view_array(vec_rate_matrix_ntcoll_bf.data(), nlte_dimension, nlte_dimension).matrix;
+      gsl_matrix_set_all(&rate_matrix_ntcoll_bf, 0.);
+    } else {
+      printout("inside while loop line 978\n");
+      // if not individual_process_matrices, alias a single matrix for all transition types
+      // the "gsl_matrix" structs are independent, but the data is shared
+      rate_matrix_rad_bb = rate_matrix;
+      rate_matrix_coll_bb = rate_matrix;
+      rate_matrix_ntcoll_bb = rate_matrix;
+      rate_matrix_rad_bf = rate_matrix;
+      rate_matrix_coll_bf = rate_matrix;
+      rate_matrix_ntcoll_bf = rate_matrix;
     }
 
-    nltepop_matrix_add_boundbound(nonemptymgi, element, ion, t_mid, s_renorm, &rate_matrix_rad_bb, &rate_matrix_coll_bb,
-                                  &rate_matrix_ntcoll_bb);
+    // printout("  Adding rates for ion stages:");
+    printout("inside while loop line 990\n");
+    const auto ions = std::ranges::iota_view{first_ion_used, first_ion_used + nions_used};
+    std::for_each(EXEC_PAR ions.begin(), ions.end(), [&](const auto ion) {
+      printout("inside while loop line 993 ion = %d \n", ion);
+      // const int ionstage = get_ionstage(element, ion);
+      // printout(" %d", ionstage);
 
-    if (ion < (nions - 1)) {
-      // this is the slowest component
-      nltepop_matrix_add_ionisation(modelgridindex, element, ion, s_renorm, &rate_matrix_rad_bf, &rate_matrix_coll_bf);
-      if (NT_ON) {
-        nltepop_matrix_add_nt_ionisation(nonemptymgi, element, ion, s_renorm, &rate_matrix_ntcoll_bf);
-      }
-    }
-  });
-  // printout("\n");
+      const int nlevels = get_nlevels(element, ion);
+      const int nlevels_nlte = get_nlevels_nlte(element, ion);  // does not count the ground state!
 
-  if (individual_process_matrices) {
-    // sum the matrices for each transition type to get a total rate matrix
-    gsl_matrix_add(&rate_matrix, &rate_matrix_rad_bb);
-    gsl_matrix_add(&rate_matrix, &rate_matrix_coll_bb);
-    gsl_matrix_add(&rate_matrix, &rate_matrix_ntcoll_bb);
-    gsl_matrix_add(&rate_matrix, &rate_matrix_rad_bf);
-    gsl_matrix_add(&rate_matrix, &rate_matrix_coll_bf);
-    gsl_matrix_add(&rate_matrix, &rate_matrix_ntcoll_bf);
-  }
+      auto s_renorm = std::vector<double>(nlevels);
+      std::fill_n(s_renorm.begin(), nlevels_nlte + 1, 1.);
 
-  // replace the first row of the matrix and balance vector with the normalisation
-  // constraint on the total element population
-  gsl_vector_view first_row_view = gsl_matrix_row(&rate_matrix, 0);
-  gsl_vector_set_all(&first_row_view.vector, 1.0);
-
-  THREADLOCALONHOST std::vector<double> vec_balance_vector;
-  vec_balance_vector.resize(max_nlte_dimension, 0.);
-  auto balance_vector = gsl_vector_view_array(vec_balance_vector.data(), nlte_dimension).vector;
-  gsl_vector_set_all(&balance_vector, 0.);
-  // set first balance vector entry to the element population (all other entries will be zero)
-  gsl_vector_set(&balance_vector, 0, nnelement);
-
-  if (FORCE_SAHA_ION_BALANCE(atomic_number)) {
-    const auto ionfractions = calculate_ionfractions(element, nonemptymgi, grid::get_nne(nonemptymgi), true);
-    const int uppermost_ion = static_cast<int>(ionfractions.size() - 1);
-    for (int ion = 1; ion <= uppermost_ion; ion++) {
-      // replace matrix row for ion's ground state with sum of this ion's level populations is equal to the ion
-      // population
-      const double nnion = nnelement * ionfractions[ion];
-      const int index_ion_ground = get_nlte_vector_index(element, ion, 0);
-      const int index_ion_toplevel = get_nlte_vector_index(element, ion, get_nlevels(element, ion));
-      gsl_vector_view ion_ground_row_view = gsl_matrix_row(&rate_matrix, index_ion_ground);
-      gsl_vector_set_all(&ion_ground_row_view.vector, 0.);
-      for (int index = index_ion_ground; index <= index_ion_toplevel; index++) {
-        gsl_vector_set(&ion_ground_row_view.vector, index, 1.);
+      for (int level = (nlevels_nlte + 1); level < nlevels; level++) {
+        s_renorm[level] = superlevel_boltzmann(nonemptymgi, element, ion, level) / superlevel_partfunc[ion];
       }
 
-      gsl_vector_set(&balance_vector, get_nlte_vector_index(element, ion, index_ion_ground), nnion);
+      nltepop_matrix_add_boundbound(nonemptymgi, element, ion, t_mid, s_renorm, &rate_matrix_rad_bb,
+                                    &rate_matrix_coll_bb, &rate_matrix_ntcoll_bb,
+                                    first_ion_used);  // May need to change this
+
+      if (ion < (first_ion_used + nions_used - 1)) {
+        // this is the slowest component
+        nltepop_matrix_add_ionisation(modelgridindex, element, ion, s_renorm, &rate_matrix_rad_bf, &rate_matrix_coll_bf,
+                                      first_ion_used);
+        if (NT_ON) {
+          nltepop_matrix_add_nt_ionisation(nonemptymgi, element, ion, s_renorm, &rate_matrix_ntcoll_bf, first_ion_used);
+        }
+      }
+    });
+    // printout("\n");
+
+    if (individual_process_matrices) {
+      // sum the matrices for each transition type to get a total rate matrix
+      gsl_matrix_add(&rate_matrix, &rate_matrix_rad_bb);
+      gsl_matrix_add(&rate_matrix, &rate_matrix_coll_bb);
+      gsl_matrix_add(&rate_matrix, &rate_matrix_ntcoll_bb);
+      gsl_matrix_add(&rate_matrix, &rate_matrix_rad_bf);
+      gsl_matrix_add(&rate_matrix, &rate_matrix_coll_bf);
+      gsl_matrix_add(&rate_matrix, &rate_matrix_ntcoll_bf);
     }
-  }
 
-  // calculate the normalisation factors and apply them to the matrix
-  // columns and balance vector elements
-  THREADLOCALONHOST std::vector<double> vec_pop_norm_factor_vec;
-  vec_pop_norm_factor_vec.resize(max_nlte_dimension, 0.);
-  auto pop_norm_factor_vec = gsl_vector_view_array(vec_pop_norm_factor_vec.data(), nlte_dimension).vector;
-  gsl_vector_set_all(&pop_norm_factor_vec, 1.0);
+    // replace the first row of the matrix and balance vector with the normalisation
+    // constraint on the total element population
+    gsl_vector_view first_row_view = gsl_matrix_row(&rate_matrix, 0);
+    gsl_vector_set_all(&first_row_view.vector, 1.0);
 
-  nltepop_matrix_normalise(nonemptymgi, element, &rate_matrix, &pop_norm_factor_vec);
+    THREADLOCALONHOST std::vector<double> vec_balance_vector;
+    vec_balance_vector.resize(max_nlte_dimension, 0.);
+    auto balance_vector = gsl_vector_view_array(vec_balance_vector.data(), nlte_dimension).vector;
+    gsl_vector_set_all(&balance_vector, 0.);
+    // set first balance vector entry to the element population (all other entries will be zero)
+    gsl_vector_set(&balance_vector, 0, nnelement);
 
-  // printout("Rate matrix | balance vector:\n");
-  // for (int row = 0; row < nlte_dimension; row++)
-  // {
-  //   for (int column = 0; column < nlte_dimension; column++)
-  //   {
-  //     char str[15];
-  //     snprintf(str, 15, "%+.1e ", gsl_matrix_get(rate_matrix, row, column));
-  //     printout(str);
-  //   }
-  //   printout("| ");
-  //   char str[15];
-  //   snprintf(str, 15, "%+.1e\n", gsl_vector_get(balance_vector, row));
-  //   printout(str);
-  // }
-  // printout("\n");
+    if (FORCE_SAHA_ION_BALANCE(atomic_number)) {
+      const auto ionfractions = calculate_ionfractions(element, nonemptymgi, grid::get_nne(nonemptymgi), true);
+      const int uppermost_ion = static_cast<int>(ionfractions.size() - 1);
+      for (int ion = 1; ion <= uppermost_ion; ion++) {
+        // replace matrix row for ion's ground state with sum of this ion's level populations is equal to the ion
+        // population
+        const double nnion = nnelement * ionfractions[ion];
+        const int index_ion_ground = get_nlte_vector_index(element, ion, 0, first_ion_used);
+        const int index_ion_toplevel = get_nlte_vector_index(element, ion, get_nlevels(element, ion), first_ion_used);
+        gsl_vector_view ion_ground_row_view = gsl_matrix_row(&rate_matrix, index_ion_ground);
+        gsl_vector_set_all(&ion_ground_row_view.vector, 0.);
+        for (int index = index_ion_ground; index <= index_ion_toplevel; index++) {
+          gsl_vector_set(&ion_ground_row_view.vector, index, 1.);
+        }
 
-  // eliminate barely-interacting levels from the NLTE matrix by removing
-  // their interactions and setting their normalised populations (probably departure coeff) to 1.0
-  // filter_nlte_matrix(element, rate_matrix, balance_vector, pop_norm_factor_vec);
+        gsl_vector_set(&balance_vector, get_nlte_vector_index(element, ion, index_ion_ground, first_ion_used), nnion);
+      }
+    }
 
-  // the true population densities
-  THREADLOCALONHOST std::vector<double> vec_pop;
-  vec_pop.resize(max_nlte_dimension, 0.);
-  auto popvec = gsl_vector_view_array(vec_pop.data(), nlte_dimension).vector;
+    // calculate the normalisation factors and apply them to the matrix
+    // columns and balance vector elements
+    THREADLOCALONHOST std::vector<double> vec_pop_norm_factor_vec;
+    vec_pop_norm_factor_vec.resize(max_nlte_dimension, 0.);
+    auto pop_norm_factor_vec = gsl_vector_view_array(vec_pop_norm_factor_vec.data(), nlte_dimension).vector;
+    gsl_vector_set_all(&pop_norm_factor_vec, 1.0);
 
-  const bool matrix_solve_success =
-      nltepop_matrix_solve(element, &rate_matrix, &balance_vector, &popvec, &pop_norm_factor_vec, max_nlte_dimension);
+    nltepop_matrix_normalise(nonemptymgi, element, &rate_matrix, &pop_norm_factor_vec, first_ion_used);
+
+    // printout("Rate matrix | balance vector:\n");
+    // for (int row = 0; row < nlte_dimension; row++)
+    // {
+    //   for (int column = 0; column < nlte_dimension; column++)
+    //   {
+    //     char str[15];
+    //     snprintf(str, 15, "%+.1e ", gsl_matrix_get(rate_matrix, row, column));
+    //     printout(str);
+    //   }
+    //   printout("| ");
+    //   char str[15];
+    //   snprintf(str, 15, "%+.1e\n", gsl_vector_get(balance_vector, row));
+    //   printout(str);
+    // }
+    // printout("\n");
+
+    // eliminate barely-interacting levels from the NLTE matrix by removing
+    // their interactions and setting their normalised populations (probably departure coeff) to 1.0
+    // filter_nlte_matrix(element, rate_matrix, balance_vector, pop_norm_factor_vec, first_ion_used);
+
+    // the true population densities
+    THREADLOCALONHOST std::vector<double> vec_pop;
+    vec_pop.resize(max_nlte_dimension, 0.);
+    popvec = gsl_vector_view_array(vec_pop.data(), nlte_dimension).vector;
+
+    matrix_solve_success = nltepop_matrix_solve(element, &rate_matrix, &balance_vector, &popvec, &pop_norm_factor_vec,
+                                                max_nlte_dimension, first_ion_used);
+
+    if (matrix_solve_success) {
+      matrix_solve_satisfied_with_ion_list = true;
+    } else {
+      if (gsl_vector_get(&popvec, get_nlte_vector_index(element, first_ion_used + nions_used - 1, 0, first_ion_used)) <
+          100) {
+        printout(
+            "  WARNING: NLTE matrix solution failed for element Z=%d using ion range of ionstage=%d to ionstage %d, "
+            "removing top ionstage  "
+            "and attempting to resolve nlte rate matrix \n",
+            atomic_number, get_ionstage(element, first_ion_used),
+            get_ionstage(element, first_ion_used + nions_used - 1));
+        nions_used = nions_used - 1;
+
+      } else if (gsl_vector_get(&popvec, get_nlte_vector_index(element, first_ion_used, 0, first_ion_used)) < 100) {
+        printout(
+            "  WARNING: NLTE matrix solution failed for element Z=%d using ion range of ionstage=%d to ionstage %d, "
+            "removing bottom ionstage  "
+            "and attempting to resolve nlte rate matrix \n",
+            atomic_number, get_ionstage(element, first_ion_used), get_ionstage(element, first_ion_used));
+        nions_used = nions_used - 1;
+        first_ion_used++;
+      } else {
+        matrix_solve_satisfied_with_ion_list = true;
+      }
+
+      if (!matrix_solve_satisfied_with_ion_list) {
+        nlte_dimension = get_element_nlte_dimension(element, nions_used, first_ion_used);
+        // Might need to change this if we want solver to work for sub-set of elements ions
+        // printout that we are reducing the number of ions used
+        // printout(
+        //     "  WARNING: NLTE matrix solution failed for element Z=%d with %d ions, reducing to %d ions starting from
+        //     ion " "stage %d\n", atomic_number, nions, nions_used, get_ionstage(element, first_ion_used));}
+      }
+    }
+    // assert_always(get_atomicnumber(element) < 26);
+    }
 
   if (!matrix_solve_success) {
     printout(
-        "WARNING: Can't solve for NLTE populations in cell %d at timestep %d for element Z=%d due to singular matrix. "
-        ", negative population or large population inversion. Attempting to use LTE solution instead\n",
+        "  WARNING: Can't solve for NLTE populations in cell %d at timestep %d for element Z=%d due to singular "
+        "matrix, "
+        "negative population or large population inversion and unable to recover solution by reducing ion range. "
+        "Attempting to use LTE solution instead\n",
         modelgridindex, timestep, atomic_number);
     set_element_pops_lte(nonemptymgi, element);
+    // assert_always(get_atomicnumber(element) < 26);
   } else {
     // check calculated NLTE populations are valid
+    // assert_always(get_atomicnumber(element) < 26);
+
     for (int index = 0; index < nlte_dimension; index++) {
       assert_always(std::isfinite(gsl_vector_get(&popvec, index)));
       assert_always(gsl_vector_get(&popvec, index) >= 0.);
     }
-
+    // assert_always(get_atomicnumber(element) < 26);
+    // also change this loop to loop over all ions but set to zero if not in the ion list
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels_nlte = get_nlevels_nlte(element, ion);
-      const int index_gs = get_nlte_vector_index(element, ion, 0);
+      const int index_gs = get_nlte_vector_index(element, ion, 0, first_ion_used);
+
+      if (ion < first_ion_used || ion >= (first_ion_used + nions_used)) {
+        printout(
+            "  WARNING: element %d ionstage %d removed from NLTE rate matrix solution. Setting levelpop for ion to "
+            "zero \n",
+            element, get_ionstage(element, ion));
+        for (int level = 0; level <= nlevels_nlte; level++) {
+          // const int index = get_nlte_vector_index(element, ion, level, first_ion_used);
+          set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level, 0);
+        }
+
+        if (ion_has_superlevel(element, ion))  // a superlevel exists
+        {
+          // const int index_sl = get_nlte_vector_index(element, ion, nlevels_nlte + 1, first_ion_used);
+          printout(
+              "  WARNING: element %d ionstage %d removed from NLTE rate matrix solution. Setting superlevel pop for "
+              "ion to zero \n",
+              element, get_ionstage(element, ion));
+          set_nlte_superlevelpop_over_rho(nonemptymgi, element, ion, 0);
+        }
+        printout(
+            "  WARNING: element %d ionstage %d removed from NLTE rate matrix solution. Setting ground level pop for "
+            "ion to zero \n",
+            element, get_ionstage(element, ion));
+        grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                           get_uniqueionindex(element, ion)] = 0;
+      // assert_always(get_atomicnumber(element) < 26);
+      }
       // const int ionstage = get_ionstage(element, ion);
       // printout("  [ionstage %d]\n", ionstage);
       //
@@ -1087,30 +1211,31 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
 
       // store the NLTE level populations
       // double solution_ion_pop = 0.;
-      for (int level = 1; level <= nlevels_nlte; level++) {
-        const int index = get_nlte_vector_index(element, ion, level);
-        set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level,
-                                   gsl_vector_get(&popvec, index) / grid::get_rho(nonemptymgi));
-        // solution_ion_pop += gsl_vector_get(popvec, index);
+      else {
+        for (int level = 1; level <= nlevels_nlte; level++) {
+          const int index = get_nlte_vector_index(element, ion, level, first_ion_used);
+          set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level,
+                                     gsl_vector_get(&popvec, index) / grid::get_rho(nonemptymgi));
+          // solution_ion_pop += gsl_vector_get(popvec, index);
+        }
+
+        // store the superlevel population if there is one
+        if (ion_has_superlevel(element, ion))  // a superlevel exists
+        {
+          const int index_sl = get_nlte_vector_index(element, ion, nlevels_nlte + 1, first_ion_used);
+          set_nlte_superlevelpop_over_rho(
+              nonemptymgi, element, ion,
+              gsl_vector_get(&popvec, index_sl) / grid::get_rho(nonemptymgi) / superlevel_partfunc[ion]);
+        }
+
+        // store the ground level population
+        grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
+                                           get_uniqueionindex(element, ion)] = gsl_vector_get(&popvec, index_gs);
+        // solution_ion_pop += gsl_vector_get(popvec, index_gs);
+        printout("just before calculate_cellpartfuncts\n");
+        calculate_cellpartfuncts(nonemptymgi, element);
       }
-
-      // store the superlevel population if there is one
-      if (ion_has_superlevel(element, ion))  // a superlevel exists
-      {
-        const int index_sl = get_nlte_vector_index(element, ion, nlevels_nlte + 1);
-        set_nlte_superlevelpop_over_rho(
-            nonemptymgi, element, ion,
-            gsl_vector_get(&popvec, index_sl) / grid::get_rho(nonemptymgi) / superlevel_partfunc[ion]);
-      }
-
-      // store the ground level population
-      grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                         get_uniqueionindex(element, ion)] = gsl_vector_get(&popvec, index_gs);
-      // solution_ion_pop += gsl_vector_get(popvec, index_gs);
-
-      calculate_cellpartfuncts(nonemptymgi, element);
     }
-
     const double elem_pop_matrix = gsl_blas_dasum(&popvec);
     const double elem_pop_error_percent = fabs((nnelement / elem_pop_matrix) - 1) * 100;
     if (elem_pop_error_percent > 1.0) {
@@ -1126,16 +1251,14 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
     {
       print_element_rates_summary(element, modelgridindex, timestep, nlte_iter, &popvec, &rate_matrix_rad_bb,
                                   &rate_matrix_coll_bb, &rate_matrix_ntcoll_bb, &rate_matrix_rad_bf,
-                                  &rate_matrix_coll_bf, &rate_matrix_ntcoll_bf);
+                                  &rate_matrix_coll_bf, &rate_matrix_ntcoll_bf, first_ion_used, nions_used);
     }
-
     const bool print_detailed_level_stats = false;
 
     // if ((atomic_number == 26) && ((timestep % 5) == 0) && (nlte_iter == 0))
     // {
     //   print_detailed_level_stats = true;
     // }
-
     if (individual_process_matrices && print_detailed_level_stats) {
       const int ionstage = 2;
       const int ion = ionstage - get_ionstage(element, 0);
@@ -1143,23 +1266,23 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
       for (int level = 0; level < get_nlevels_nlte(element, ion); level++) {
         print_level_rates(modelgridindex, timestep, element, ion, level, &popvec, &rate_matrix_rad_bb,
                           &rate_matrix_coll_bb, &rate_matrix_ntcoll_bb, &rate_matrix_rad_bf, &rate_matrix_coll_bf,
-                          &rate_matrix_ntcoll_bf);
+                          &rate_matrix_ntcoll_bf, first_ion_used);
       }
 
       if (ion_has_superlevel(element, ion)) {
         const int slindex = get_nlevels_nlte(element, ion) + 1;
         print_level_rates(modelgridindex, timestep, element, ion, slindex, &popvec, &rate_matrix_rad_bb,
                           &rate_matrix_coll_bb, &rate_matrix_ntcoll_bb, &rate_matrix_rad_bf, &rate_matrix_coll_bf,
-                          &rate_matrix_ntcoll_bf);
+                          &rate_matrix_ntcoll_bf, first_ion_used);
       }
     }
   }
-
   const int duration_nltesolver = std::time(nullptr) - sys_time_start_nltesolver;
   if (duration_nltesolver > 2) {
     printout("NLTE population solver call for Z=%d took %d seconds\n", get_atomicnumber(element), duration_nltesolver);
   }
-}
+  // assert_always(get_atomicnumber(element) < 26);
+  }
 
 // Get a Boltzman factor for a level within the super level (combined Non-LTE level)
 __host__ __device__ auto superlevel_boltzmann(const int nonemptymgi, const int element, const int ion, const int level)

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -649,9 +649,9 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   calculate_cellpartfuncts(nonemptymgi, element);
   // Recall find_uppermost_ion with force_lte = true so uppermost ion used in set_groundlevelpops
   // is reset based on LTE phi factors instead of coming from NLTE phi factors
-  const double nne_hi = grid::get_rho(nonemptymgi) / MH;
+  // const double nne_hi = grid::get_rho(nonemptymgi) / MH;
   const bool force_lte = true;
-  const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, nne_hi, force_lte);
+  const int uppermost_ion = find_uppermost_ion(nonemptymgi, element, force_lte);
   grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
   set_groundlevelpops(nonemptymgi, element, grid::get_nne(nonemptymgi), true);
 }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -641,7 +641,9 @@ void read_collion_data() {
   printout("Stored %zu of %d input shell cross sections\n", colliondata.size(), colliondatacount);
   for (int element = 0; element < get_nelements(); element++) {
     const int Z = get_atomicnumber(element);
-    for (int ion = 0; ion < get_nions(element); ion++) {
+    // change this so the top ionisation stage is removed from the loop - doesn't make sense
+    // to claculate ionisation for top ionisation stage
+    for (int ion = 0; ion < get_nions(element) - 1; ion++) {
       const int ionstage = get_ionstage(element, ion);
       const bool any_data_matched = std::ranges::any_of(colliondata, [Z, ionstage](const collionrow &collionrow) {
         return collionrow.Z == Z && collionrow.ionstage == ionstage;

--- a/rpkt.h
+++ b/rpkt.h
@@ -120,7 +120,7 @@ constexpr auto closest_transition(const double nu_cmf, const int next_trans, con
 inline auto keep_this_cont(int element, const int ion, const int level, const int nonemptymgi, const float nnetot)
     -> bool {
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {
-    return grid::get_elem_abundance(nonemptymgi, element) > 0;
+    return grid::get_elem_abundance(nonemptymgi, element) > 0; // dupliicate condition below to test this. 
   }
   return ((get_nnion(nonemptymgi, element, ion) / nnetot > 1.e-6) || (level == 0));
 }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -730,6 +730,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
         solve_nlte_pops_element(element, nonemptymgi, nts, nlte_iter);
         calculate_cellpartfuncts(nonemptymgi, element);
       }
+    // assert_always(get_atomicnumber(element) < 26);
     }
     const int duration_solve_nltepops = std::time(nullptr) - sys_time_start_nltepops;
 


### PR DESCRIPTION
Add more robust checks on the populations in the NLTE solver and safer treatment of what populations should be used instead if the NLTE solution is not sensible (e.g. convert to LTE). In particular:

 -Previously when the NLTE population was negative for a level it was directly replaced with the LTE level population. This resulted in cases where the negative excited population was replaced with a value much greater than the NLTE ground pop resulting in extremely large partition function values which in some cases then overflowed the float limit. Additionally, negative NLTE ground populations were just replaced with the LTE value. However, if the ground population is negative this means the entire solution for that ion is unlikely to be sensible. If the NLTE ground population is negative now therefore revert to using LTE populations for the element. 
 -There were previously no checks on population inversions so have also added checks such that if the solver predicts a    large population inversion the level populations of the element are set to their LTE values - large population inversions can also lead to partition function values which overflow the float limit causing the code to fail. 

This pull request provides a temporary solution to problems that can occur when the NLTE solver does not produce a temporary solution. The plan is to add functionality in the future so that when the NLTE solver fails to a produce a sensible solution for an individual ion that specific ion can be set to LTE with the NLTE solver called again for the element with that ion excluded. 