### PR TITLE
Add initial support for dielectronic recombination

### DIFF
--- a/atomic.h
+++ b/atomic.h
@@ -317,9 +317,17 @@ inline auto get_includedions() -> int {
   return globals::elements[element].ions[ion].nlevels_excited_nlte;
 }
 
+// Returns the number of autoionising levels for an ion
+[[nodiscard]] inline auto get_nlevels_autoion(const int element, const int ion) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  return globals::elements[element].ions[ion].nlevels_autoion;
+}
+
 // ion has NLTE levels, but this one is not NLTE => is in the superlevel
 [[nodiscard]] inline auto level_isinsuperlevel(const int element, const int ion, const int level) -> bool {
-  return (!is_nlte(element, ion, level) && level != 0 && (get_nlevels_excited_nlte(element, ion) > 0));
+  return (!is_nlte(element, ion, level) && level != 0 && (get_nlevels_excited_nlte(element, ion) > 0) &&
+          (level < (get_nlevels(element, ion) - get_nlevels_autoion(element, ion))));
 }
 
 [[nodiscard]] inline auto get_nlevels_groundterm(const int element, const int ion) -> int {
@@ -359,7 +367,7 @@ inline auto get_includedions() -> int {
 [[nodiscard]] inline auto ion_has_superlevel(const int element, const int ion) -> bool {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
-  return (get_nlevels(element, ion) > get_nlevels_excited_nlte(element, ion) + 1);
+  return (get_nlevels(element, ion) > (get_nlevels_excited_nlte(element, ion) + get_nlevels_autoion(element, ion) + 1));
 }
 
 // the number of downward bound-bound transitions from the specified level
@@ -401,6 +409,46 @@ inline auto get_includedions() -> int {
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
   return get_nuptrans(get_uniquelevelindex(element, ion, level));
+}
+
+// the number of downward autoionization transitions from the specified level
+[[nodiscard]] inline auto get_nautoiondowntrans(const int uniquelevelindex) -> int {
+  return globals::alllevels.nautoiondowntrans[uniquelevelindex];
+}
+
+[[nodiscard]] inline auto get_nautoiondowntrans(const int element, const int ion, const int level) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return get_nautoiondowntrans(get_uniquelevelindex(element, ion, level));
+}
+
+// the number of upward autoionization transitions from the specified level
+[[nodiscard]] inline auto get_nautoionuptrans(const int uniquelevelindex) -> int {
+  return globals::alllevels.nautoionuptrans[uniquelevelindex];
+}
+
+[[nodiscard]] inline auto get_nautoionuptrans(const int element, const int ion, const int level) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return globals::alllevels.nautoionuptrans[get_uniquelevelindex(element, ion, level)];
+}
+
+// the number of autoion transitions from the specified level
+inline void set_nautoiondowntrans(const int element, const int ion, const int level, const int nautoiondowntrans) {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  globals::alllevels.nautoiondowntrans[get_uniquelevelindex(element, ion, level)] = nautoiondowntrans;
+}
+
+// the number of autoion transitions from the specified level
+inline void set_nautoionuptrans(const int element, const int ion, const int level, const int nautoionuptrans) {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  globals::alllevels.nautoionuptrans[get_uniquelevelindex(element, ion, level)] = nautoionuptrans;
 }
 
 [[nodiscard]] inline auto get_phixtargetindex(const int uniquelevelindex, const int upperionlevel) -> int {

--- a/globals.h
+++ b/globals.h
@@ -96,6 +96,7 @@ struct Ion {
   int first_nlte{-1};  // index into nlte_pops array of a grid cell
   int nlevels_ionising{0};  // Number of levels which have a bf-continuum
   int maxrecombininglevel{-1};  // level index of the highest level with a non-zero recombination rate
+  int nlevels_autoion{0};  // Number of levels that can autoionise
   int nlevels_groundterm{0};
   int coolingoffset{-1};
   int ncoolingterms{0};
@@ -229,6 +230,17 @@ struct AllTransitions {
 };
 inline AllTransitions alltrans;
 
+struct LevelAutoion {
+  float autoion_A;  // Autoionization A-value
+  int elementindex;  // index (not atomic number) for the element involved
+  int lowerionindex;
+  int lowerlevelindex;  // this will be for a level index of the lower ion
+  int upperionindex;
+  int upperlevelindex;  // this will be for a level index of the upper ion.
+                        // Note: level of the lower ion should also be at higher energy than of the higher ion
+};
+inline std::span<LevelAutoion> allautoion;
+
 inline std::span<const int> allphixstargets_levelindex;  // index of upper ion level after photoionisation
 inline std::span<const double>
     allphixstargets_probability;  // fraction of phixs cross section leading to associated final level
@@ -246,6 +258,15 @@ struct AllLevels {
 
   // Number of up transitions from each level
   std::span<const int> nuptrans;
+
+  // Number of autoionizing transition from this level
+  std::span<int> nautoiondowntrans;
+
+  // Number of di-el captures up from this level
+  std::span<int> nautoionuptrans;
+
+  // index into globals::allautoion for first autoion from this level
+  std::span<int> allautoion_start;
 
   std::span<int> closestgroundlevelcont;
 

--- a/input.cc
+++ b/input.cc
@@ -836,6 +836,102 @@ void setup_phixs_list() {
   printout("[info] bound-free estimators track bfestimcount %d photoionisation transitions\n", globals::bfestimcount);
 }
 
+void read_autoion_data() {
+  // read in autoionisation rate data
+  if (!std::filesystem::exists("autoion.txt")) {
+    return;
+  }
+
+  std::vector<globals::LevelAutoion> temp_allautoion;
+
+  printout("Reading autoion.txt for autoionization data.\n");
+  auto autoionfile = fstream_required("autoion.txt", std::ios::in);
+  std::string autoionline;
+  int Z = -1;
+  int upperionstage = -1;
+  int upperlevel_in = -1;
+  int lowerionstage = -1;
+  int lowerlevel_in = -1;
+  double autoion_A = -1;
+  while (get_noncommentline(autoionfile, autoionline)) {
+    assert_always(std::istringstream(autoionline) >> Z >> upperionstage >> upperlevel_in >> lowerionstage >>
+                  lowerlevel_in >> autoion_A);
+
+    assert_always(Z > 0);
+    assert_always(upperionstage >= 2);
+    assert_always(lowerionstage >= 1);
+
+    const int element = get_elementindex(Z);
+
+    if (element >= 0 && get_nions(element) > 0) {
+      // translate readin ionstages to ion indices
+
+      const int upperion = upperionstage - get_ionstage(element, 0);
+      const int lowerion = lowerionstage - get_ionstage(element, 0);
+      const int lowerlevel = lowerlevel_in - groundstate_index_in;
+      const int upperlevel = upperlevel_in - groundstate_index_in;
+
+      assert_always(upperion >= 0 && upperion < get_nions(element));
+      assert_always(lowerion >= 0 && lowerion < get_nions(element));
+      assert_always(lowerlevel >= 0 && lowerlevel < get_nlevels(element, lowerion));
+      assert_always(upperlevel >= 0 && upperlevel < get_nlevels(element, upperion));
+
+      // store only for ions that are part of the current model atom
+      if (lowerion >= 0 && upperion < get_nions(element)) {
+        printout("Got to noting data for Z %d upperion %d upperlvl %d lowerion %d lowerlvl %d with A %g\n", Z, upperion,
+                 upperlevel, lowerion, lowerlevel, autoion_A);
+
+        const int nautoiondowntrans = get_nautoiondowntrans(element, lowerion, lowerlevel) + 1;
+        set_nautoiondowntrans(element, lowerion, lowerlevel, nautoiondowntrans);
+
+        const int nautoionuptrans = get_nautoionuptrans(element, upperion, upperlevel) + 1;
+        set_nautoionuptrans(element, upperion, upperlevel, nautoionuptrans);
+
+        if (globals::alllevels.allautoion_start[get_uniquelevelindex(element, lowerion, lowerlevel)] < 0) {
+          assert_always(nautoiondowntrans == 1);
+          assert_always(nautoionuptrans == 1);
+          // this is the first autoionizing transition for this level, so set the start index
+          globals::alllevels.allautoion_start[get_uniquelevelindex(element, lowerion, lowerlevel)] =
+              static_cast<int>(temp_allautoion.size());
+        }
+
+        temp_allautoion.push_back({.autoion_A = static_cast<float>(autoion_A),
+                                   .elementindex = element,
+                                   .lowerionindex = lowerion,
+                                   .lowerlevelindex = lowerlevel,
+                                   .upperionindex = upperion,
+                                   .upperlevelindex = upperlevel});
+      }
+    }
+  }
+
+  globals::allautoion = MPI_shared_malloc_span<globals::LevelAutoion>(temp_allautoion.size());
+  if (globals::rank_in_node == 0) {
+    std::copy_n(temp_allautoion.cbegin(), temp_allautoion.size(), globals::allautoion.data());
+  }
+  MPI_Barrier(globals::mpi_comm_node);
+
+  // Plan is that autoionizing levels will be explicitly included in the NLTE population solver, but that their level
+  // populations do not need to be accurately known - so if the ion has a superlevel already, then we will try to attach
+  // the autoionizing level populations to that for all purposes outside the NLTE solber. For this, the ions need to
+  // know how many autoionizing levels they have. So count those up now.
+
+  int checkautoall = 0;
+  for (int element = 0; element < get_nelements(); element++) {
+    const int nions = get_nions(element);
+    for (int ion = 0; ion < nions; ion++) {
+      const int nlevels = get_nlevels(element, ion);
+      int nauto = 0;
+      for (int level = 0; level < nlevels; level++) {
+        nauto += get_nautoiondowntrans(element, ion, level);
+      }
+      globals::elements[element].ions[ion].nlevels_autoion = nauto;
+      checkautoall += nauto;
+    }
+  }
+  assert_always(checkautoall == std::ssize(temp_allautoion));
+}
+
 void read_phixs_data() {
   globals::nbfcontinua_ground = 0;
   globals::nbfcontinua = 0;
@@ -1204,12 +1300,18 @@ void read_atomicdata_files() {
   auto alllevels_nuptrans = MPI_shared_malloc_span<int>(nlevels);
   auto alllevels_epsilon = MPI_shared_malloc_span<double>(nlevels);
   auto alllevels_statweight = MPI_shared_malloc_span<float>(nlevels);
+  globals::alllevels.allautoion_start = MPI_shared_malloc_span<int>(nlevels);
+  globals::alllevels.nautoiondowntrans = MPI_shared_malloc_span<int>(nlevels);
+  globals::alllevels.nautoionuptrans = MPI_shared_malloc_span<int>(nlevels);
   globals::alllevels.closestgroundlevelcont = MPI_shared_malloc_span<int>(nlevels);
   globals::alllevels.phixsstart = MPI_shared_malloc_span<int>(nlevels);
   globals::alllevels.nphixstargets = MPI_shared_malloc_span<int>(nlevels);
   globals::alllevels.phixstargetstart = MPI_shared_malloc_span<int>(nlevels);
   globals::alllevels.bflist_start = MPI_shared_malloc_span<int>(nlevels);
   if (globals::rank_in_node == 0) {
+    std::ranges::fill(globals::alllevels.nautoiondowntrans, 0);
+    std::ranges::fill(globals::alllevels.nautoionuptrans, 0);
+    std::ranges::fill(globals::alllevels.allautoion_start, -1);
     std::ranges::fill(globals::alllevels.phixsstart, -1);
     std::ranges::fill(globals::alllevels.nphixstargets, 0);
     std::ranges::fill(globals::alllevels.phixstargetstart, -1);
@@ -1343,6 +1445,7 @@ void read_atomicdata_files() {
     }
   }
 
+  read_autoion_data();
   read_phixs_data();
 }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -54,6 +54,7 @@ struct RateMatrices {
   std::vector<double> vec_rate_matrix_rad_bf;
   std::vector<double> vec_rate_matrix_coll_bf;
   std::vector<double> vec_rate_matrix_ntcoll_bf;
+  std::vector<double> vec_rate_matrix_autoion;
 
   gsl_matrix rad_bb{};
   gsl_matrix coll_bb{};
@@ -61,6 +62,7 @@ struct RateMatrices {
   gsl_matrix rad_bf{};
   gsl_matrix coll_bf{};
   gsl_matrix ntcoll_bf{};
+  gsl_matrix autoion{};
 
   explicit RateMatrices(int max_nlte_dimension_in) : max_nlte_dimension(max_nlte_dimension_in) {
     // allocation of the maximum required size is done once,
@@ -73,6 +75,7 @@ struct RateMatrices {
     resize_exactly(vec_rate_matrix_rad_bf, max_dim_square);
     resize_exactly(vec_rate_matrix_coll_bf, max_dim_square);
     resize_exactly(vec_rate_matrix_ntcoll_bf, max_dim_square);
+    resize_exactly(vec_rate_matrix_autoion, max_dim_square);
   }
 
   void set_used_dimension(int nlte_dimension) {
@@ -84,6 +87,7 @@ struct RateMatrices {
     std::fill_n(vec_rate_matrix_rad_bf.data(), used_nlte_dimension * used_nlte_dimension, 0.);
     std::fill_n(vec_rate_matrix_coll_bf.data(), used_nlte_dimension * used_nlte_dimension, 0.);
     std::fill_n(vec_rate_matrix_ntcoll_bf.data(), used_nlte_dimension * used_nlte_dimension, 0.);
+    std::fill_n(vec_rate_matrix_autoion.data(), used_nlte_dimension * used_nlte_dimension, 0.);
 
     rad_bb = gsl_matrix_view_array(vec_rate_matrix_rad_bb.data(), used_nlte_dimension, used_nlte_dimension).matrix;
     coll_bb = gsl_matrix_view_array(vec_rate_matrix_coll_bb.data(), used_nlte_dimension, used_nlte_dimension).matrix;
@@ -93,13 +97,15 @@ struct RateMatrices {
     coll_bf = gsl_matrix_view_array(vec_rate_matrix_coll_bf.data(), used_nlte_dimension, used_nlte_dimension).matrix;
     ntcoll_bf =
         gsl_matrix_view_array(vec_rate_matrix_ntcoll_bf.data(), used_nlte_dimension, used_nlte_dimension).matrix;
+    autoion = gsl_matrix_view_array(vec_rate_matrix_autoion.data(), used_nlte_dimension, used_nlte_dimension).matrix;
   }
 
   [[nodiscard]] auto get_summed_rate_matrix() -> gsl_matrix {
     // sum the matrices for each transition type to get a total rate matrix
     for (int i = 0; i < used_nlte_dimension * used_nlte_dimension; i++) {
       vec_rate_matrix[i] = vec_rate_matrix_rad_bb[i] + vec_rate_matrix_coll_bb[i] + vec_rate_matrix_ntcoll_bb[i] +
-                           vec_rate_matrix_rad_bf[i] + vec_rate_matrix_coll_bf[i] + vec_rate_matrix_ntcoll_bf[i];
+                           vec_rate_matrix_rad_bf[i] + vec_rate_matrix_coll_bf[i] + vec_rate_matrix_ntcoll_bf[i] +
+                           vec_rate_matrix_autoion[i];
     }
 
     return gsl_matrix_view_array(vec_rate_matrix.data(), used_nlte_dimension, used_nlte_dimension).matrix;
@@ -111,10 +117,19 @@ auto get_nlte_vector_index(const int element, const int ion, const int level, co
   // have to convert from nlte_pops index to nlte_vector index
   // the difference is that nlte vectors apply to a single element and include ground states
   // The (+ ion) term accounts for the ground state population indices that are not counted in the NLTE array
+  int offset_autoion = 0;
+  for (int dion = first_ion_used; dion < ion; dion++) {
+    offset_autoion += get_nlevels_autoion(element, dion);
+  }
   assert_testmodeonly(first_ion_used >= 0);
   assert_testmodeonly(first_ion_used < get_nions(element));
   const int gs_index = globals::elements[element].ions[ion].first_nlte -
-                       globals::elements[element].ions[first_ion_used].first_nlte + (ion - first_ion_used);
+                       globals::elements[element].ions[first_ion_used].first_nlte + (ion - first_ion_used) +
+                       offset_autoion;
+  const int first_autoion = get_nlevels(element, ion) - get_nlevels_autoion(element, ion);
+  if (ion_has_superlevel(element, ion) && level > (first_autoion - 1)) {
+    return (gs_index + get_nlevels_excited_nlte(element, ion) + level - first_autoion + 2);
+  }
   // add in level or superlevel number
   const int level_index =
       gs_index + (is_nlte(element, ion, level) ? level : (get_nlevels_excited_nlte(element, ion) + 1));
@@ -390,8 +405,9 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
   resize_exactly(superlevel_partfuncs, get_nions(element));
   for (int ion = 0; ion < get_nions(element); ion++) {
     superlevel_partfuncs[ion] = std::ranges::fold_left(
-        std::views::iota(get_nlevels_excited_nlte(element, ion) + 1, get_nlevels(element, ion)), 0.0,
-        [&](double sum, int level) { return sum + superlevel_boltzmann(nonemptymgi, element, ion, level); });
+        std::views::iota(get_nlevels_excited_nlte(element, ion) + 1,
+                         get_nlevels(element, ion) - get_nlevels_autoion(element, ion)),
+        0.0, [&](double sum, int level) { return sum + superlevel_boltzmann(nonemptymgi, element, ion, level); });
   }
 
   return superlevel_partfuncs;
@@ -406,9 +422,16 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
   assert_testmodeonly((first_ion_used + nions_used - 1) < get_nions(element));
   int nlte_dimension = 0;
   for (int ion = first_ion_used; ion < (first_ion_used + nions_used); ion++) {
-    nlte_dimension += 1 + get_nlevels_excited_nlte(element, ion);
+    // add super level if it exists
     if (ion_has_superlevel(element, ion)) {
-      nlte_dimension++;
+      nlte_dimension += get_nlevels_excited_nlte(element, ion) + get_nlevels_autoion(element, ion) + 2;
+      // printout("Here 1: For element %d ion %d adding %d to nlte_dimension. \n", element, ion, nlevels_nlte +
+      // get_nlevels_autoion(element, ion) + 2); printout("checks: %d %d\n", nlevels_nlte, get_nlevels_autoion(element,
+      // ion)); if it has a superlevel then need + 2 for ground state and super and to add autionising levels
+    } else {  // if it doesn't have a superlevel
+      nlte_dimension += get_nlevels(element, ion);
+      // printout("Here 2: For element %d ion %d adding %d to nlte_dimension. \n", element, ion,
+      // get_nlevels(element,ion));
     }
   }
 
@@ -603,6 +626,59 @@ void nltepop_matrix_add_nt_ionisation(const int nonemptymgi, const int element, 
   }
 }
 
+void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element, const int ion,
+                                       const std::vector<double> &s_renorm, RateMatrices &rate_matrices,
+                                       const int first_ion_used, const int nions_used) {
+  // Autoionization and inverse (i.e. collisional capture part of di-el)
+  const auto nlte_dimension = rate_matrices.used_nlte_dimension;
+  const int max_ion_used = first_ion_used + nions_used - 1;
+  assert_always(ion < max_ion_used);  // can't ionise top ion stage
+  const auto T_e = grid::get_Te(nonemptymgi);
+  const float nne = grid::get_nne(nonemptymgi);
+  const int nlevels = get_nlevels(element, ion);
+  for (int level = 0; level < nlevels; level++) {
+    const int level_index = get_nlte_vector_index(element, ion, level, first_ion_used);
+    const double epsilon_level = epsilon(element, ion, level);
+    const double statweight = stat_weight(element, ion, level);
+
+    const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+    const int nautoiondowntrans = get_nautoiondowntrans(uniquelevelindex);
+    for (int i = 0; i < nautoiondowntrans; i++) {
+      // autoionization (which is a de-excitation propcess)
+      const auto &autoiontransition = globals::allautoion[globals::alllevels.allautoion_start[uniquelevelindex] + i];
+      const double A_a = autoiontransition.autoion_A;
+      const int target_ion = autoiontransition.upperionindex;
+      const int target_level = autoiontransition.upperlevelindex;
+
+      const double epsilon_trans = epsilon_level - epsilon(element, target_ion, target_level);
+
+      double R = A_a * s_renorm[level];
+
+      const int upper_index = level_index;
+      const int lower_index = get_nlte_vector_index(element, target_ion, target_level, first_ion_used);
+
+      rate_matrices.vec_rate_matrix_autoion[(upper_index * nlte_dimension) + upper_index] -= R;
+      rate_matrices.vec_rate_matrix_autoion[(lower_index * nlte_dimension) + upper_index] += R;
+      if ((R < 0)) {
+        printout("  WARNING: Negative autoionization rate from ionstage %d level %d to level %d\n",
+                 get_ionstage(element, ion), level, target_level);
+      }
+
+      // capture (which is an excitation process, and the first part of di-electronic recomb)
+      R = nne * A_a * statweight / stat_weight(element, target_ion, target_level) * SAHACONST * pow(T_e, -1.5) *
+          exp(-1. * epsilon_trans / KB / T_e);
+      // renorm??
+
+      rate_matrices.vec_rate_matrix_autoion[(lower_index * nlte_dimension) + lower_index] -= R;
+      rate_matrices.vec_rate_matrix_autoion[(upper_index * nlte_dimension) + lower_index] += R;
+      if ((R < 0)) {
+        printout("  WARNING: Negative autoionization rate from ionstage %d level %d to level %d\n",
+                 get_ionstage(element, ion), level, target_level);
+      }
+    }
+  }
+}
+
 void nltepop_matrix_normalise(const int nonemptymgi, const int element, gsl_matrix *rate_matrix,
                               std::span<double> pop_norm_factors, const int first_ion_used, const int nions_used) {
   const size_t nlte_dimension = rate_matrix->size1;
@@ -617,7 +693,9 @@ void nltepop_matrix_normalise(const int nonemptymgi, const int element, gsl_matr
     if (level_isinsuperlevel(element, ion, level)) {
       // levels in the superlevel get combined together
       for (int dummylevel = level + 1; dummylevel < get_nlevels(element, ion); dummylevel++) {
-        pop_norm_factors[column] += calculate_levelpop_boltzmann(nonemptymgi, element, ion, dummylevel);
+        if (level_isinsuperlevel(element, ion, dummylevel)) {
+          pop_norm_factors[column] += calculate_levelpop_boltzmann(nonemptymgi, element, ion, dummylevel);
+        }
       }
     }
 
@@ -965,6 +1043,8 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
           nltepop_matrix_add_nt_ionisation(nonemptymgi, element, ion, s_renorm, rate_matrices, first_ion_used,
                                            nions_used);
         }
+        nltepop_matrix_add_autoionisation(nonemptymgi, element, ion, s_renorm, rate_matrices, first_ion_used,
+                                          nions_used);
       }
     });
 
@@ -1315,7 +1395,9 @@ void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
           nnlevellte = 0;
           nlte_file << -1 << ' ';
           for (int level_sl = nlevels_excited_nlte + 1; level_sl < get_nlevels(element, ion); level_sl++) {
-            nnlevellte += calculate_levelpop_boltzmann(nonemptymgi, element, ion, level_sl);
+            if (level_isinsuperlevel(element, ion, level_sl)) {
+              nnlevellte += calculate_levelpop_boltzmann(nonemptymgi, element, ion, level_sl);
+            }
           }
 
           nnlevelnlte = slpopfactor * superlevel_partfuncs[ion];

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -157,6 +157,11 @@ auto columnindex_from_emissiontype(const int et) -> int {
     // bb-emission
     const int element = globals::linelist[et].elementindex;
     const int ion = globals::linelist[et].ionindex;
+    if ((element == 41) && (ion == 2)) {
+      printout(" elements[element].ions[ion].ionpot %g elements[element].anumber %d \n celvl %d %d\n: ",
+               globals::elements[element].ions[ion].ionpot / EV, globals::elements[element].anumber,
+               globals::linelist[et].lowerlevelindex, globals::linelist[et].upperlevelindex);
+    }
     return (element * get_max_nions()) + ion;
   }
   if (et == EMTYPE_FREEFREE) {


### PR DESCRIPTION
Partially addresses #219

This is for implementing dielectronic recombination into ARTIS.

Current status (5th Dec 2024):

- Draft infrastructure to store autoionization data for levels. 
- Autoionization and capture into resonances implemented into nlte population solver
- Preliminary testing for Si ions in 1 zone model appears to run and give roughly correct effect
- Pushing to GitHub to keep a safe copy! But this is not in a state yet to actually merge (so please don't anyone do that!)
- File attached here is the format proposed for supplying a list of autoionization processes. Format is pretty simple: list of Z upper_ion upper_level lower_ion lower_level A_auto

Still to do (5th Dec 2024):

- Need to figure out how to handle with superlevels.
- Likely don't actually want the autoionizing levels to take up space in the stored populations (i.e. should probably include them in the solver, but not include them in the stores). Not yet implemented.
- Lower priority: need to implement into the macro atom (that likely required some more infrastructure stuff added)
- Lower priority still: need to implement into the heating/cooling
- Need to properly test

**NOTE: I think that the superevel renorm factors currently in the code may be wrong for ionization processes. Need to check - but should discuss with Luke and see if we can fix. Don't think that actually will affect anything, but we should either fix or remove and abort.**



[autoion.txt](https://github.com/user-attachments/files/18027641/autoion.txt)
