### PR TITLE
Pass LevelTransition to [col/rad]_excitation_ratecoeff

### DIFF
--- a/kpkt.cc
+++ b/kpkt.cc
@@ -95,7 +95,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
         const int upper = uptranslist[ii].targetlevelindex;
         const double epsilon_trans = epsilon(element, ion, upper) - epsilon_current;
         const double C = nnlevel *
-                         col_excitation_ratecoeff(T_e, nne, element, ion, level, ii, epsilon_trans, statweight) *
+                         col_excitation_ratecoeff(T_e, nne, element, ion, uptranslist[ii], epsilon_trans, statweight) *
                          epsilon_trans;
         C_ion += C;
         if constexpr (!update_cooling_contrib_list) {
@@ -599,7 +599,7 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
       // printout("    excitation to level %d possible\n",upper);
       const double epsilon_trans = epsilon(element, ion, tmpupper) - epsilon_current;
       const double C = nnlevel *
-                       col_excitation_ratecoeff(T_e, nne, element, ion, level, ii, epsilon_trans, statweight) *
+                       col_excitation_ratecoeff(T_e, nne, element, ion, uptranslist[ii], epsilon_trans, statweight) *
                        epsilon_trans;
       contrib += C;
       if (contrib > rndcool_ion_process) {

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -89,7 +89,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
     const double R =
         rad_excitation_ratecoeff(nonemptymgi, element, ion, level, i, epsilon_trans, nnlevel, uptrans.lineindex, t_mid);
-    const double C = col_excitation_ratecoeff(T_e, nne, element, ion, level, i, epsilon_trans, statweight);
+    const double C = col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, statweight);
     const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, uptrans.lineindex);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
@@ -902,10 +902,9 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
 
 // multiply by lower level population to get a rate per second
 
-auto col_excitation_ratecoeff(const float T_e, const float nne, const int element, const int ion, const int lower,
-                              const int uptransindex, const double epsilon_trans, const double lowerstatweight)
+auto col_excitation_ratecoeff(const float T_e, const float nne, const int element, const int ion,
+                              const LevelTransition &uptr, const double epsilon_trans, const double lowerstatweight)
     -> double {
-  const auto &uptr = get_uptranslist(element, ion, lower)[uptransindex];
   const double coll_strength = uptr.coll_str;
   const double eoverkt = epsilon_trans / (KB * T_e);
 

--- a/macroatom.h
+++ b/macroatom.h
@@ -32,7 +32,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, int element, int ion,
                                               int upper, const LevelTransition &downtransition) -> double;
 
-[[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, int element, int ion, int lower, int uptransindex,
+[[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, int element, int ion, const LevelTransition &uptrans,
                                             double epsilon_trans, double lowerstatweight) -> double;
 
 #endif  // MACROATOM_H

--- a/macroatom.h
+++ b/macroatom.h
@@ -13,9 +13,9 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                               float A_ul, double upperstatweight, double nnlevelupper, double t_current)
     -> double;
 
-[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int element, int ion, int lower, int uptransindex,
-                                            double epsilon_trans, double nnlevel_lower, int lineindex, double t_current)
-    -> double;
+[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int element, int ion, int lower,
+                                            const LevelTransition &uptrans, double epsilon_trans, double nnlevel_lower,
+                                            int lineindex, double t_current) -> double;
 
 [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upperionlevel,
                                                int lowerionlevel, int nonemptymgi) -> double;

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -484,19 +484,19 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     const auto *const leveluptranslist = get_uptranslist(element, ion, level);
     const auto nuptransindices = std::ranges::iota_view{0, nuptrans};
     std::for_each(nuptransindices.begin(), nuptransindices.end(), [&](const auto i) {
-      const int lineindex = leveluptranslist[i].lineindex;
-      const int upper = leveluptranslist[i].targetlevelindex;
+      const auto &uptrans = leveluptranslist[i];
+      const int lineindex = uptrans.lineindex;
+      const int upper = uptrans.targetlevelindex;
       const double epsilon_trans = epsilon(element, ion, upper) - epsilon_level;
 
-      const double R =
-          rad_excitation_ratecoeff(nonemptymgi, element, ion, level, i, epsilon_trans, nnlevel, lineindex, t_mid) *
-          s_renorm[level];
+      const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
+                                                lineindex, t_mid) *
+                       s_renorm[level];
       assert_always(R >= 0);
       assert_always(std::isfinite(R));
 
       const double C =
-          col_excitation_ratecoeff(T_e, nne, element, ion, leveluptranslist[i], epsilon_trans, statweight) *
-          s_renorm[level];
+          col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, statweight) * s_renorm[level];
       assert_always(C >= 0);
       assert_always(std::isfinite(C));
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -495,7 +495,8 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       assert_always(std::isfinite(R));
 
       const double C =
-          col_excitation_ratecoeff(T_e, nne, element, ion, level, i, epsilon_trans, statweight) * s_renorm[level];
+          col_excitation_ratecoeff(T_e, nne, element, ion, leveluptranslist[i], epsilon_trans, statweight) *
+          s_renorm[level];
       assert_always(C >= 0);
       assert_always(std::isfinite(C));
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1725,16 +1725,17 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
         const double epsilon_trans = epsilon(element, ion, upper) - epsilon(element, ion, lower);
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
+        const auto uptrans = get_uptranslist(element, ion, lower)[uptransindex];
 
         const double t_mid = globals::timesteps[timestep].mid;
         const double radexc_ratecoeff = rad_excitation_ratecoeff(nonemptymgi, element, ion, lower, uptransindex,
                                                                  epsilon_trans, nnlevel_lower, lineindex, t_mid);
 
-        const double collexc_ratecoeff = col_excitation_ratecoeff(T_e, nne, element, ion, lower, uptransindex,
-                                                                  epsilon_trans, stat_weight(element, ion, lower));
+        const double collexc_ratecoeff =
+            col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, stat_weight(element, ion, lower));
 
         const double exc_ratecoeff = radexc_ratecoeff + collexc_ratecoeff + ntcollexc_ratecoeff;
-        const auto coll_str = get_uptranslist(element, ion, lower)[uptransindex].coll_str;
+        const auto coll_str = uptrans.coll_str;
 
         printout(
             "    frac_deposition %.3e Z=%2d ionstage %d lower %4d upper %4d rad_exc %.1e coll_exc %.1e nt_exc %.1e "

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1504,9 +1504,9 @@ auto select_nt_ionization(const int nonemptymgi) -> std::tuple<int, int> {
 
 auto get_uptransindex(const int element, const int ion, const int lower, const int upper) {
   const int nuptrans = get_nuptrans(element, ion, lower);
-  const auto *const leveluptrans = get_uptranslist(element, ion, lower);
+  const auto *const leveluptranslist = get_uptranslist(element, ion, lower);
   for (int t = 0; t < nuptrans; t++) {
-    if (upper == leveluptrans[t].targetlevelindex) {
+    if (upper == leveluptranslist[t].targetlevelindex) {
       return t;
     }
   }
@@ -1725,10 +1725,10 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
         const double epsilon_trans = epsilon(element, ion, upper) - epsilon(element, ion, lower);
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
-        const auto uptrans = get_uptranslist(element, ion, lower)[uptransindex];
+        const auto &uptrans = get_uptranslist(element, ion, lower)[uptransindex];
 
         const double t_mid = globals::timesteps[timestep].mid;
-        const double radexc_ratecoeff = rad_excitation_ratecoeff(nonemptymgi, element, ion, lower, uptransindex,
+        const double radexc_ratecoeff = rad_excitation_ratecoeff(nonemptymgi, element, ion, lower, uptrans,
                                                                  epsilon_trans, nnlevel_lower, lineindex, t_mid);
 
         const double collexc_ratecoeff =

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -541,13 +541,14 @@ auto get_approx_shell_occupancies(const int nbound, const int ioncharge) {
 }
 
 auto get_shell_occupancies(const int nbound, const int ioncharge) {
-  assert_always(nbound > 0);
-  assert_always(ioncharge >= 0);
-  const int Z = nbound + ioncharge;
+  assert_testmodeonly(nbound > 0);
+  assert_testmodeonly(ioncharge >= 0);
 
   if constexpr (!NT_WORKFUNCTION_USE_SHELL_OCCUPANCY_FILE) {
     return get_approx_shell_occupancies(nbound, ioncharge);
   }
+
+  const int Z = nbound + ioncharge;
 
   const auto &element_shells_q_neutral = elements_shells_q.at(Z - 1);
   const size_t shellcount = std::min(element_shells_q_neutral.size(), elements_electron_binding[Z - 1].size());


### PR DESCRIPTION
~2-3% speedup of CI jobs. No change for normal fast-math mode on Apple M1.