### PR TITLE
Use reference instead of pointer to Phixslist in Rpkt_continuum_absorptioncoeffs and replace spans with vectors

### DIFF
--- a/rpkt.cc
+++ b/rpkt.cc
@@ -617,23 +617,8 @@ auto do_rpkt_step(Packet &pkt, const double t2) -> bool {
 
   MacroAtomState pktmastate{};
 
-  THREADLOCALONHOST Rpkt_continuum_absorptioncoeffs chi_rpkt_cont{
-      .nu = NAN,
-      .total = NAN,
-      .ffescat = NAN,
-      .ffheat = NAN,
-      .bf = NAN,
-      .nonemptymgi = -1,
-      .timestep = -1,
-      .phixslist = {
-          .groundcont_gamma_contr = std::vector<double>(globals::nbfcontinua_ground),
-          .chi_bf_sum = std::vector<double>(globals::nbfcontinua),
-          .gamma_contr = std::vector<double>(globals::bfestimcount),
-          .allcontend = 1,
-          .allcontbegin = 0,
-          .bfestimend = 1,
-          .bfestimbegin = 0,
-      }};
+  THREADLOCALONHOST auto chi_rpkt_cont =
+      Rpkt_continuum_absorptioncoeffs{globals::nbfcontinua_ground, globals::nbfcontinua, globals::bfestimcount};
 
   // Assign optical depth to next physical event
   const double zrand = rng_uniform_pos();

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -588,7 +588,6 @@ void update_estimators(const double e_cmf, const double nu_cmf, const double dis
   atomicadd(globals::ffheatingestimator[nonemptymgi], distance_e_cmf * chi_rpkt_cont.ffheat);
 
   if constexpr (USE_LUT_PHOTOION || USE_LUT_BFHEATING) {
-    const auto &phixslist = chi_rpkt_cont.phixslist;
     for (int i = 0; i < globals::nbfcontinua_ground; i++) {
       const double nu_edge = globals::groundcont[i].nu_edge;
       if (nu_cmf <= nu_edge) {
@@ -599,12 +598,12 @@ void update_estimators(const double e_cmf, const double nu_cmf, const double dis
 
       if constexpr (USE_LUT_PHOTOION) {
         atomicadd(globals::gammaestimator[ionestimindex],
-                  phixslist.groundcont_gamma_contr[i] * (distance_e_cmf / nu_cmf));
+                  chi_rpkt_cont.phixslist.groundcont_gamma_contr[i] * (distance_e_cmf / nu_cmf));
       }
 
       if constexpr (USE_LUT_BFHEATING) {
         atomicadd(globals::bfheatingestimator[ionestimindex],
-                  phixslist.groundcont_gamma_contr[i] * distance_e_cmf * (1. - nu_edge / nu_cmf));
+                  chi_rpkt_cont.phixslist.groundcont_gamma_contr[i] * distance_e_cmf * (1. - nu_edge / nu_cmf));
       }
     }
   }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <ctime>
 #include <limits>
-#include <memory>
 #include <span>
 #include <tuple>
 #include <vector>
@@ -618,10 +617,6 @@ auto do_rpkt_step(Packet &pkt, const double t2) -> bool {
 
   MacroAtomState pktmastate{};
 
-  THREADLOCALONHOST auto groundcont_gamma_contr = std::make_unique<double[]>(globals::nbfcontinua_ground);
-  THREADLOCALONHOST auto chi_bf_sum = std::make_unique<double[]>(globals::nbfcontinua);
-  THREADLOCALONHOST auto gamma_contr = std::make_unique<double[]>(globals::bfestimcount);
-
   THREADLOCALONHOST Rpkt_continuum_absorptioncoeffs chi_rpkt_cont{
       .nu = NAN,
       .total = NAN,
@@ -631,9 +626,9 @@ auto do_rpkt_step(Packet &pkt, const double t2) -> bool {
       .nonemptymgi = -1,
       .timestep = -1,
       .phixslist = {
-          .groundcont_gamma_contr = std::span(groundcont_gamma_contr.get(), globals::nbfcontinua_ground),
-          .chi_bf_sum = std::span(chi_bf_sum.get(), globals::nbfcontinua),
-          .gamma_contr = std::span(gamma_contr.get(), globals::bfestimcount),
+          .groundcont_gamma_contr = std::vector<double>(globals::nbfcontinua_ground),
+          .chi_bf_sum = std::vector<double>(globals::nbfcontinua),
+          .gamma_contr = std::vector<double>(globals::bfestimcount),
           .allcontend = 1,
           .allcontbegin = 0,
           .bfestimend = 1,

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -946,21 +946,16 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
 
 void allocate_expansionopacities() {
   const auto nonempty_npts_model = grid::get_nonempty_npts_model();
-  float *expansionopacities_data{};
-  double *expansionopacity_planck_cumulative_data{};
 
-  std::tie(expansionopacities_data, win_expansionopacities) =
-      MPI_shared_malloc_keepwin<float>(nonempty_npts_model * expopac_nbins);
+  assert_always(expansionopacities.data() == nullptr);
+  std::tie(expansionopacities, win_expansionopacities) =
+      MPI_shared_malloc_keepwin_span<float>(nonempty_npts_model * expopac_nbins);
 
+  assert_always(expansionopacity_planck_cumulative.data() == nullptr);
   if constexpr (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY >= 0.) {
-    std::tie(expansionopacity_planck_cumulative_data, win_expansionopacity_planck_cumulative) =
-        MPI_shared_malloc_keepwin<double>(nonempty_npts_model * expopac_nbins);
+    std::tie(expansionopacity_planck_cumulative, win_expansionopacity_planck_cumulative) =
+        MPI_shared_malloc_keepwin_span<double>(nonempty_npts_model * expopac_nbins);
   }
-
-  expansionopacities = std::span(expansionopacities_data, nonempty_npts_model * expopac_nbins);
-  expansionopacity_planck_cumulative =
-      std::span(expansionopacity_planck_cumulative_data,
-                expansionopacity_planck_cumulative_data == nullptr ? 0 : nonempty_npts_model * expopac_nbins);
 }
 
 // return a randomly chosen frequency with a distribution of Planck function times the expansion opacity

--- a/rpkt.h
+++ b/rpkt.h
@@ -3,7 +3,6 @@
 
 #include <cstddef>
 #include <ctime>
-#include <span>
 #include <vector>
 
 #include "globals.h"
@@ -12,9 +11,9 @@
 #include "sn3d.h"
 
 struct Phixslist {
-  std::span<double> groundcont_gamma_contr;  // for either USE_LUT_PHOTOION = true or USE_LUT_BFHEATING = true
-  std::span<double> chi_bf_sum;
-  std::span<double> gamma_contr;  // needed for DETAILED_BF_ESTIMATORS_ON
+  std::vector<double> groundcont_gamma_contr;  // for either USE_LUT_PHOTOION = true or USE_LUT_BFHEATING = true
+  std::vector<double> chi_bf_sum;
+  std::vector<double> gamma_contr;  // needed for DETAILED_BF_ESTIMATORS_ON
   int allcontend{-1};
   int allcontbegin{0};
   int bfestimend{-1};

--- a/rpkt.h
+++ b/rpkt.h
@@ -12,7 +12,7 @@
 #include "sn3d.h"
 
 struct Phixslist {
-  std::span<double> groundcont_gamma_contr;  // for either USE_LUT_PHOTOION = true or !USE_LUT_BFHEATING = false
+  std::span<double> groundcont_gamma_contr;  // for either USE_LUT_PHOTOION = true or USE_LUT_BFHEATING = true
   std::span<double> chi_bf_sum;
   std::span<double> gamma_contr;  // needed for DETAILED_BF_ESTIMATORS_ON
   int allcontend{-1};
@@ -29,7 +29,7 @@ struct Rpkt_continuum_absorptioncoeffs {
   double bf{0.};
   int nonemptymgi{-1};
   int timestep{-1};
-  Phixslist *phixslist{nullptr};
+  Phixslist phixslist{};
 };
 
 #include "artisoptions.h"

--- a/rpkt.h
+++ b/rpkt.h
@@ -23,7 +23,8 @@ struct Phixslist {
   int bfestimbegin{0};
 };
 
-struct Rpkt_continuum_absorptioncoeffs {
+class Rpkt_continuum_absorptioncoeffs {
+ public:
   double nu{-1.};  // frequency at which opacity was calculated
   double total{0.};
   double ffescat{0.};
@@ -32,6 +33,15 @@ struct Rpkt_continuum_absorptioncoeffs {
   int nonemptymgi{-1};
   int timestep{-1};
   Phixslist phixslist{};
+
+  constexpr Rpkt_continuum_absorptioncoeffs(const int nbfcontinua_ground, const int nbfcontinua,
+                                            const int bfestimcount) {
+    resize_exactly(phixslist.groundcont_gamma_contr, nbfcontinua_ground);
+    resize_exactly(phixslist.chi_bf_sum, nbfcontinua);
+    resize_exactly(phixslist.gamma_contr, bfestimcount);
+  }
+
+  constexpr Rpkt_continuum_absorptioncoeffs() = default;
 };
 
 void do_rpkt(Packet &pkt, double t2);

--- a/rpkt.h
+++ b/rpkt.h
@@ -5,6 +5,9 @@
 #include <ctime>
 #include <vector>
 
+#include "artisoptions.h"
+#include "atomic.h"
+#include "constants.h"
 #include "globals.h"
 #include "ltepop.h"
 #include "packet.h"
@@ -30,10 +33,6 @@ struct Rpkt_continuum_absorptioncoeffs {
   int timestep{-1};
   Phixslist phixslist{};
 };
-
-#include "artisoptions.h"
-#include "atomic.h"
-#include "constants.h"
 
 void do_rpkt(Packet &pkt, double t2);
 void emit_rpkt(Packet &pkt);

--- a/sn3d.h
+++ b/sn3d.h
@@ -365,7 +365,7 @@ template <typename T>
 }
 
 template <typename T>
-void resize_exactly(std::vector<T> &vec, const ptrdiff_t size) {
+constexpr void resize_exactly(std::vector<T> &vec, const ptrdiff_t size) {
   // just resizing can (only with libstdc++?) allocate a larger capacity than needed
   vec.reserve(size);
   vec.resize(size);

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -250,7 +250,7 @@ auto rlc_emiss_vpkt(const Packet &pkt, const double t_current, const double t_ar
   // compute the optical depth to boundary
 
   mgi = grid::get_propcell_modelgridindex(vpkt.where);
-  Rpkt_continuum_absorptioncoeffs chi_vpkt_cont{};
+  THREADLOCALONHOST Rpkt_continuum_absorptioncoeffs chi_vpkt_cont{};
 
   while (!end_packet) {
     // distance to the next cell

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -250,7 +250,7 @@ auto rlc_emiss_vpkt(const Packet &pkt, const double t_current, const double t_ar
   // compute the optical depth to boundary
 
   mgi = grid::get_propcell_modelgridindex(vpkt.where);
-  THREADLOCALONHOST Rpkt_continuum_absorptioncoeffs chi_vpkt_cont{};
+  THREADLOCALONHOST auto chi_vpkt_cont = Rpkt_continuum_absorptioncoeffs{};
 
   while (!end_packet) {
     // distance to the next cell


### PR DESCRIPTION
Simplifies the code and avoids risk of null-pointer issues.