### PR TITLE
Fix DO_TITER option

### DIFF
--- a/input.cc
+++ b/input.cc
@@ -1619,7 +1619,7 @@ void read_atomicdata() {
 
 // read input.txt, atomic data, and ejecta model
 void input(int rank) {
-  globals::n_titer = 1;
+  globals::n_titer = (globals::timestep < -1) ? 3 : 1;
   globals::lte_iteration = false;
 
   printout("[info] input: do n_titer %d iterations per timestep\n", globals::n_titer);

--- a/radfield.cc
+++ b/radfield.cc
@@ -636,8 +636,8 @@ void initialise_prev_titer_photoionestimators() {
 #ifdef DO_TITER
   std::ranges::fill(globals::ffheatingestimator_save, -1.);
   std::ranges::fill(globals::colheatingestimator_save, -1.);
-  std::ranges::fill(globals::J_reduced_save, -1.);
-  std::ranges::fill(globals::nuJ_reduced_save, -1.);
+  std::ranges::fill(J_reduced_save, -1.);
+  std::ranges::fill(nuJ_reduced_save, -1.);
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -881,9 +881,9 @@ auto main(int argc, char *argv[]) -> int {
     MPI_Barrier(MPI_COMM_WORLD);
 
     // titer example: Do 3 iterations on timestep 0-6
-    // globals::n_titer = (nts < 6) ? 3: 1;
+    // globals::n_titer = (globals::timestep < 6) ? 3 : 1;
 
-    globals::n_titer = 1;
+    globals::n_titer = (globals::timestep < -1) ? 3 : 1;
     globals::lte_iteration = (globals::timestep < globals::num_lte_timesteps);
     assert_always(globals::num_lte_timesteps > 0);  // The first time step must solve the ionisation balance in LTE
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -823,11 +823,11 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
       if constexpr (USE_LUT_BFHEATING) {
         globals::bfheatingestimator[ionestimindex] *= estimator_normfactor;
 #ifdef DO_TITER
-        if (bfheatingestimator_save[ionestimindex] >= 0) {
+        if (globals::bfheatingestimator_save[ionestimindex] >= 0) {
           globals::bfheatingestimator[ionestimindex] =
-              (globals::bfheatingestimator[ionestimindex] + bfheatingestimator_save[ionestimindex]) / 2;
+              (globals::bfheatingestimator[ionestimindex] + globals::bfheatingestimator_save[ionestimindex]) / 2;
         }
-        bfheatingestimator_save[ionestimindex] = globals::bfheatingestimator[ionestimindex];
+        globals::bfheatingestimator_save[ionestimindex] = globals::bfheatingestimator[ionestimindex];
 #endif
         // Now convert bfheatingestimator into the bfheating renormalisation coefficient used in
         // get_bfheating in the remaining part of update_grid. Later on it's reset and new


### PR DESCRIPTION
In the current ``develop`` branch, enabling the ``DO_TITER`` does not seem to work. Superficially, this is a compile issue, but I'm not sure if there are some deeper issues.

So far I've been able to fix the compile issues and get it to run with 3 iterations for timesteps after the first timestep (i.e. setting ``globals::n_titer = (globals::timestep > 1) ? 3 : 1;``), but my test setup crashes later for some other reason I haven't been able to figure out. Somebody more knowledgable than me may need to run some verification tests to make sure this works as intended.