### PR TITLE
Perf: Refactor levels and transitions to structures of arrays and use more uniquelevelindicies

### DIFF
--- a/atomic.h
+++ b/atomic.h
@@ -102,9 +102,6 @@ __host__ __device__ inline auto get_nphixstargets(const int uniquelevelindex) ->
 
 // Returns the number of target states for photoionization of (element,ion,level).
 __host__ __device__ inline auto get_nphixstargets(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
   const auto nphixstargets = get_nphixstargets(get_uniquelevelindex(element, ion, level));
   assert_testmodeonly(nphixstargets == 0 ||
                       ((ion < (get_nions(element) - 1)) && (level < get_nlevels_ionising(element, ion))));
@@ -112,16 +109,27 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 }
 
 // Return the level index of a target state for photoionization of (element,ion,level).
-[[nodiscard]] __host__ __device__ inline auto get_phixsupperlevel(const int element, const int ion, const int level,
+[[nodiscard]] __host__ __device__ inline auto get_phixsupperlevel(const int uniquelevelindex,
                                                                   const int phixstargetindex) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
   assert_testmodeonly(phixstargetindex >= 0);
-  assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
-  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
 
   return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].levelindex;
+}
+
+// Return the level index of a target state for photoionization of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto get_phixsupperlevel(const int element, const int ion, const int level,
+                                                                  const int phixstargetindex) -> int {
+  return get_phixsupperlevel(get_uniquelevelindex(element, ion, level), phixstargetindex);
+}
+
+// Return the probability of a target state for photoionization of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto get_phixsprobability(const int uniquelevelindex,
+                                                                   const int phixstargetindex) -> double {
+  assert_testmodeonly(phixstargetindex >= 0);
+  assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
+
+  return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].probability;
 }
 
 // Return the probability of a target state for photoionization of (element,ion,level).
@@ -130,11 +138,8 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  assert_testmodeonly(phixstargetindex >= 0);
-  assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
-  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
 
-  return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].probability;
+  return get_phixsprobability(get_uniquelevelindex(element, ion, level), phixstargetindex);
 }
 
 // Return the number of bf-continua associated with ion ion of element element.
@@ -144,10 +149,15 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   return globals::elements[element].ions[ion].maxrecombininglevel;
 }
 
-inline __host__ __device__ auto get_phixs_table(const int element, const int ion, const int level) -> float * {
-  const auto phixsstart = globals::alllevels_phixsstart[get_uniquelevelindex(element, ion, level)];
+[[nodiscard]] inline __host__ __device__ auto get_phixs_table(const int uniquelevelindexl) -> float * {
+  const auto phixsstart = globals::alllevels_phixsstart[uniquelevelindexl];
   assert_testmodeonly(phixsstart >= 0);
   return globals::allphixs.data() + (phixsstart * globals::NPHIXSPOINTS);
+}
+
+[[nodiscard]] inline __host__ __device__ auto get_phixs_table(const int element, const int ion, const int level)
+    -> float * {
+  return get_phixs_table(get_uniquelevelindex(element, ion, level));
 }
 
 // Calculate the photoionisation cross-section at frequency nu out of the atomic data.

--- a/atomic.h
+++ b/atomic.h
@@ -496,9 +496,10 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
-  const int upperlevel = get_phixsupperlevel(element, ion, level, phixstargetindex);
-  const double E_threshold = epsilon(element, ion + 1, upperlevel) - epsilon(element, ion, level);
+  const int uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
+  const int upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex);
+  const double E_threshold = epsilon(element, ion + 1, upperlevel) - epsilon(uniquelevelindex);
   return E_threshold;
 }
 

--- a/atomic.h
+++ b/atomic.h
@@ -437,8 +437,12 @@ inline auto get_includedions() -> int {
   return get_nuptrans(get_uniquelevelindex(element, ion, level));
 }
 
+[[nodiscard]] inline auto get_uptranslist(const int uniquelevelindex) -> LevelTransition * {
+  return globals::alltrans.data() + get_alltrans_startup(uniquelevelindex);
+}
+
 [[nodiscard]] inline auto get_uptranslist(const int element, const int ion, const int level) -> LevelTransition * {
-  return globals::alltrans.data() + get_alltrans_startup(get_uniquelevelindex(element, ion, level));
+  return get_uptranslist(get_uniquelevelindex(element, ion, level));
 }
 
 [[nodiscard]] inline auto get_uptransspan(const int element, const int ion, const int level)

--- a/atomic.h
+++ b/atomic.h
@@ -67,6 +67,15 @@ __host__ __device__ inline auto get_nlevels(const int element, const int ion) ->
   return globals::elements[element].ions[ion].nlevels;
 }
 
+// Return the energy of (element,ion,level).
+
+[[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return get_ion_levels(element, ion)[level].epsilon;
+}
+
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
 [[nodiscard]] __host__ __device__ inline auto get_ionstage(const int element, const int ion) -> int {
   assert_testmodeonly(element < get_nelements());
@@ -114,6 +123,15 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
 
   return globals::allphixstargets[get_ion_levels(element, ion)[level].phixstargetstart + phixstargetindex].probability;
+}
+
+// Return the statistical weight of (element,ion,level).
+
+[[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return get_ion_levels(element, ion)[level].stat_weight;
 }
 
 // Return the number of bf-continua associated with ion ion of element element.
@@ -178,56 +196,6 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
   return sigma_bf;
 }
 
-// return the number of ions of all elements combined
-inline auto get_includedlevels() -> int { return includedlevels; }
-
-// Get an index for level of an ionstage of an element that is unique across every ion of every element
-[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-
-  return uniquelevelindex;
-}
-
-// inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index
-[[nodiscard]] inline auto get_levelfromuniquelevelindex(const int uniquelevelindex) -> std::tuple<int, int, int> {
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-  for (int element = 0; element < get_nelements(); element++) {
-    const int nions = get_nions(element);
-    for (int ion = 0; ion < nions; ion++) {
-      if (get_nlevels(element, ion) == 0) {
-        continue;
-      }
-      const int level = uniquelevelindex - globals::elements[element].ions[ion].uniquelevelindexstart;
-      if (level >= 0 && level < get_nlevels(element, ion)) {
-        assert_testmodeonly(get_uniquelevelindex(element, ion, level) == uniquelevelindex);
-        return {element, ion, level};
-      }
-    }
-  }
-  assert_always(false);  // uniquelevelindex too high to be valid
-  return {-1, -1, -1};
-}
-
-// Return the statistical weight of (element,ion,level).
-[[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  return globals::alllevels_statweight[get_uniquelevelindex(element, ion, level)];
-}
-
-// Return the energy of (element,ion,level).
-[[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  return globals::alllevels_epsilon[get_uniquelevelindex(element, ion, level)];
-}
-
 [[nodiscard]] inline auto get_tau_sobolev(const int nonemptymgi, const int lineindex, const double t_current)
     -> double {
   const auto &line = globals::linelist[lineindex];
@@ -256,9 +224,7 @@ inline auto get_includedlevels() -> int { return includedlevels; }
 
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
-                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
+  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 
   const double n_u = get_levelpop(nonemptymgi, element, ion, upper);
   return std::max((B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current, 0.);
@@ -310,6 +276,9 @@ inline auto get_includedions() -> int {
   assert_testmodeonly(includedions > 0);
   return includedions;
 }
+
+// return the number of ions of all elements combined
+inline auto get_includedlevels() -> int { return includedlevels; }
 
 // get a number greater than or equal to nions(element) for all elements
 [[nodiscard]] inline auto get_max_nions() -> int { return maxnions; }
@@ -374,6 +343,37 @@ inline auto get_includedions() -> int {
   }
   assert_always(false);  // allionsindex too high to be valid
   return {-1, -1};
+}
+
+// Get an index for level of an ionstage of an element that is unique across every ion of every element
+[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+
+  return uniquelevelindex;
+}
+
+// inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index
+[[nodiscard]] inline auto get_levelfromuniquelevelindex(const int uniquelevelindex) -> std::tuple<int, int, int> {
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+  for (int element = 0; element < get_nelements(); element++) {
+    const int nions = get_nions(element);
+    for (int ion = 0; ion < nions; ion++) {
+      if (get_nlevels(element, ion) == 0) {
+        continue;
+      }
+      const int level = uniquelevelindex - globals::elements[element].ions[ion].uniquelevelindexstart;
+      if (level >= 0 && level < get_nlevels(element, ion)) {
+        assert_testmodeonly(get_uniquelevelindex(element, ion, level) == uniquelevelindex);
+        return {element, ion, level};
+      }
+    }
+  }
+  assert_always(false);  // uniquelevelindex too high to be valid
+  return {-1, -1, -1};
 }
 
 [[nodiscard]] inline auto ion_has_superlevel(const int element, const int ion) -> bool {

--- a/atomic.h
+++ b/atomic.h
@@ -256,7 +256,9 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
-  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double B_lu =
+      stat_weight(ionuniquelevelindexstart + upper) / stat_weight(ionuniquelevelindexstart + lower) * B_ul;
 
   return std::max(B_lu * n_l * HCLIGHTOVERFOURPI * t_current, 0.);
 }

--- a/atomic.h
+++ b/atomic.h
@@ -251,12 +251,12 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   const int ion = line.ionindex;
   const int lower = line.lowerlevelindex;
   const int upper = line.upperlevelindex;
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
 
-  const double n_l = get_levelpop(nonemptymgi, element, ion, lower);
+  const double n_l = get_levelpop(nonemptymgi, ionuniquelevelindexstart + lower);
 
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   const double B_lu =
       stat_weight(ionuniquelevelindexstart + upper) / stat_weight(ionuniquelevelindexstart + lower) * B_ul;
 
@@ -270,15 +270,15 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   const int lower = line.lowerlevelindex;
   const int upper = line.upperlevelindex;
 
-  const double n_l = get_levelpop(nonemptymgi, element, ion, lower);
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double n_l = get_levelpop(nonemptymgi, ionuniquelevelindexstart + lower);
 
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   const double B_lu =
       stat_weight(ionuniquelevelindexstart + upper) / stat_weight(ionuniquelevelindexstart + lower) * B_ul;
 
-  const double n_u = get_levelpop(nonemptymgi, element, ion, upper);
+  const double n_u = get_levelpop(nonemptymgi, ionuniquelevelindexstart + upper);
   return std::max((B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current, 0.);
 }
 

--- a/atomic.h
+++ b/atomic.h
@@ -473,7 +473,8 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
 }
 
 // Return the emissiontype index of the continuum associated to the given level. Will be negative and ordered by
-// element/ion/level/phixstargetindex
+// element/ion/level/phixstargetindex. (NOTE! this is not an index into globals::allcont, which is ordered by ascending
+// nu_edge)
 [[nodiscard]] inline auto get_emtype_continuum(const int element, const int ion, const int level,
                                                const int upperionlevel) -> int {
   const int phixstargetindex = get_phixtargetindex(element, ion, level, upperionlevel);

--- a/atomic.h
+++ b/atomic.h
@@ -405,7 +405,7 @@ inline auto get_includedions() -> int {
 
 // the number of downward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_ndowntrans(const int uniquelevelindex) -> int {
-  return globals::alllevels_alltrans_startdown[uniquelevelindex];
+  return globals::alllevels_ndowntrans[uniquelevelindex];
 }
 
 // the number of downward bound-bound transitions from the specified level

--- a/atomic.h
+++ b/atomic.h
@@ -72,15 +72,6 @@ __host__ __device__ inline auto get_nlevels(const int element, const int ion) ->
   return uniquelevelindex;
 }
 
-[[nodiscard]] inline auto get_ion_levels(const int element, const int ion) -> EnergyLevel * {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(globals::elements[element].ions[ion].uniquelevelindexstart >= 0);
-  assert_testmodeonly(std::ssize(globals::alllevels) > (globals::elements[element].ions[ion].uniquelevelindexstart +
-                                                        globals::elements[element].ions[ion].nlevels - 1));
-  return globals::alllevels.data() + globals::elements[element].ions[ion].uniquelevelindexstart;
-}
-
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
 [[nodiscard]] __host__ __device__ inline auto get_ionstage(const int element, const int ion) -> int {
   assert_testmodeonly(element < get_nelements());
@@ -407,16 +398,35 @@ inline auto get_includedions() -> int {
   return (get_nlevels(element, ion) > get_nlevels_nlte(element, ion) + 1);
 }
 
+[[nodiscard]] constexpr auto get_alltrans_startup(const int uniquelevelindex) -> int {
+  // index into globals::alltrans for first up transition from this level
+  return globals::alllevels_alltrans_startdown[uniquelevelindex] + globals::alllevels_ndowntrans[uniquelevelindex];
+}
+
+// the number of downward bound-bound transitions from the specified level
+[[nodiscard]] inline auto get_ndowntrans(const int uniquelevelindex) -> int {
+  return globals::alllevels_alltrans_startdown[uniquelevelindex];
+}
+
 // the number of downward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_ndowntrans(const int element, const int ion, const int level) -> int {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  return get_ion_levels(element, ion)[level].ndowntrans;
+  return get_ndowntrans(get_uniquelevelindex(element, ion, level));
+}
+
+[[nodiscard]] inline auto get_downtranslist(const int uniquelevelindex) -> LevelTransition * {
+  return globals::alltrans.data() + globals::alllevels_alltrans_startdown[uniquelevelindex];
 }
 
 [[nodiscard]] inline auto get_downtranslist(const int element, const int ion, const int level) -> LevelTransition * {
-  return globals::alltrans.data() + get_ion_levels(element, ion)[level].alltrans_startdown;
+  return get_downtranslist(get_uniquelevelindex(element, ion, level));
+}
+
+// the number of upward bound-bound transitions from the specified level
+[[nodiscard]] inline auto get_nuptrans(const int uniquelevelindex) -> int {
+  return globals::alllevels_nuptrans[uniquelevelindex];
 }
 
 // the number of upward bound-bound transitions from the specified level
@@ -424,16 +434,16 @@ inline auto get_includedions() -> int {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  return get_ion_levels(element, ion)[level].nuptrans;
+  return get_nuptrans(get_uniquelevelindex(element, ion, level));
 }
 
 [[nodiscard]] inline auto get_uptranslist(const int element, const int ion, const int level) -> LevelTransition * {
-  return globals::alltrans.data() + get_ion_levels(element, ion)[level].alltrans_startup();
+  return globals::alltrans.data() + get_alltrans_startup(get_uniquelevelindex(element, ion, level));
 }
 
 [[nodiscard]] inline auto get_uptransspan(const int element, const int ion, const int level)
     -> std::span<const LevelTransition> {
-  return globals::alltrans.subspan(get_ion_levels(element, ion)[level].alltrans_startup(),
+  return globals::alltrans.subspan(get_alltrans_startup(get_uniquelevelindex(element, ion, level)),
                                    get_nuptrans(element, ion, level));
 }
 
@@ -442,7 +452,7 @@ inline void set_ndowntrans(const int element, const int ion, const int level, co
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  get_ion_levels(element, ion)[level].ndowntrans = ndowntrans;
+  globals::alllevels_ndowntrans[get_uniquelevelindex(element, ion, level)] = ndowntrans;
 }
 
 // the number of upward bound-bound transitions from the specified level
@@ -450,7 +460,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  get_ion_levels(element, ion)[level].nuptrans = nuptrans;
+  globals::alllevels_nuptrans[get_uniquelevelindex(element, ion, level)] = nuptrans;
 }
 
 [[nodiscard]] inline auto get_phixtargetindex(const int element, const int ion, const int level,

--- a/atomic.h
+++ b/atomic.h
@@ -457,11 +457,10 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   globals::alllevels.nuptrans[get_uniquelevelindex(element, ion, level)] = nuptrans;
 }
 
-[[nodiscard]] inline auto get_phixtargetindex(const int element, const int ion, const int level,
-                                              const int upperionlevel) -> int {
-  const auto nphixstargets = get_nphixstargets(element, ion, level);
+[[nodiscard]] inline auto get_phixtargetindex(const int uniquelevelindex, const int upperionlevel) -> int {
+  const auto nphixstargets = get_nphixstargets(uniquelevelindex);
   for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-    if (upperionlevel == get_phixsupperlevel(element, ion, level, phixstargetindex)) {
+    if (upperionlevel == get_phixsupperlevel(uniquelevelindex, phixstargetindex)) {
       return phixstargetindex;
     }
   }
@@ -477,8 +476,9 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
 // nu_edge)
 [[nodiscard]] inline auto get_emtype_continuum(const int element, const int ion, const int level,
                                                const int upperionlevel) -> int {
-  const int phixstargetindex = get_phixtargetindex(element, ion, level, upperionlevel);
-  return -1 - globals::alllevels.cont_index[get_uniquelevelindex(element, ion, level)] - phixstargetindex;
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  const int phixstargetindex = get_phixtargetindex(uniquelevelindex, upperionlevel);
+  return -1 - globals::alllevels.cont_index[uniquelevelindex] - phixstargetindex;
 }
 
 // Return the photionisation threshold energy [erg]

--- a/atomic.h
+++ b/atomic.h
@@ -67,15 +67,6 @@ __host__ __device__ inline auto get_nlevels(const int element, const int ion) ->
   return globals::elements[element].ions[ion].nlevels;
 }
 
-// Return the energy of (element,ion,level).
-
-[[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  return get_ion_levels(element, ion)[level].epsilon;
-}
-
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
 [[nodiscard]] __host__ __device__ inline auto get_ionstage(const int element, const int ion) -> int {
   assert_testmodeonly(element < get_nelements());
@@ -123,15 +114,6 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
 
   return globals::allphixstargets[get_ion_levels(element, ion)[level].phixstargetstart + phixstargetindex].probability;
-}
-
-// Return the statistical weight of (element,ion,level).
-
-[[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  return get_ion_levels(element, ion)[level].stat_weight;
 }
 
 // Return the number of bf-continua associated with ion ion of element element.
@@ -196,6 +178,56 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
   return sigma_bf;
 }
 
+// return the number of ions of all elements combined
+inline auto get_includedlevels() -> int { return includedlevels; }
+
+// Get an index for level of an ionstage of an element that is unique across every ion of every element
+[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+
+  return uniquelevelindex;
+}
+
+// inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index
+[[nodiscard]] inline auto get_levelfromuniquelevelindex(const int uniquelevelindex) -> std::tuple<int, int, int> {
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+  for (int element = 0; element < get_nelements(); element++) {
+    const int nions = get_nions(element);
+    for (int ion = 0; ion < nions; ion++) {
+      if (get_nlevels(element, ion) == 0) {
+        continue;
+      }
+      const int level = uniquelevelindex - globals::elements[element].ions[ion].uniquelevelindexstart;
+      if (level >= 0 && level < get_nlevels(element, ion)) {
+        assert_testmodeonly(get_uniquelevelindex(element, ion, level) == uniquelevelindex);
+        return {element, ion, level};
+      }
+    }
+  }
+  assert_always(false);  // uniquelevelindex too high to be valid
+  return {-1, -1, -1};
+}
+
+// Return the statistical weight of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return globals::alllevels_statweight[get_uniquelevelindex(element, ion, level)];
+}
+
+// Return the energy of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return globals::alllevels_epsilon[get_uniquelevelindex(element, ion, level)];
+}
+
 [[nodiscard]] inline auto get_tau_sobolev(const int nonemptymgi, const int lineindex, const double t_current)
     -> double {
   const auto &line = globals::linelist[lineindex];
@@ -224,7 +256,9 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
 
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
-  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
+                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
 
   const double n_u = get_levelpop(nonemptymgi, element, ion, upper);
   return std::max((B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current, 0.);
@@ -276,9 +310,6 @@ inline auto get_includedions() -> int {
   assert_testmodeonly(includedions > 0);
   return includedions;
 }
-
-// return the number of ions of all elements combined
-inline auto get_includedlevels() -> int { return includedlevels; }
 
 // get a number greater than or equal to nions(element) for all elements
 [[nodiscard]] inline auto get_max_nions() -> int { return maxnions; }
@@ -343,37 +374,6 @@ inline auto get_includedlevels() -> int { return includedlevels; }
   }
   assert_always(false);  // allionsindex too high to be valid
   return {-1, -1};
-}
-
-// Get an index for level of an ionstage of an element that is unique across every ion of every element
-[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-
-  return uniquelevelindex;
-}
-
-// inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index
-[[nodiscard]] inline auto get_levelfromuniquelevelindex(const int uniquelevelindex) -> std::tuple<int, int, int> {
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-  for (int element = 0; element < get_nelements(); element++) {
-    const int nions = get_nions(element);
-    for (int ion = 0; ion < nions; ion++) {
-      if (get_nlevels(element, ion) == 0) {
-        continue;
-      }
-      const int level = uniquelevelindex - globals::elements[element].ions[ion].uniquelevelindexstart;
-      if (level >= 0 && level < get_nlevels(element, ion)) {
-        assert_testmodeonly(get_uniquelevelindex(element, ion, level) == uniquelevelindex);
-        return {element, ion, level};
-      }
-    }
-  }
-  assert_always(false);  // uniquelevelindex too high to be valid
-  return {-1, -1, -1};
 }
 
 [[nodiscard]] inline auto ion_has_superlevel(const int element, const int ion) -> bool {

--- a/atomic.h
+++ b/atomic.h
@@ -96,11 +96,16 @@ __host__ __device__ inline auto get_nlevels(const int element, const int ion) ->
 }
 
 // Returns the number of target states for photoionization of (element,ion,level).
+__host__ __device__ inline auto get_nphixstargets(const int uniquelevelindex) -> int {
+  return globals::alllevels_nphixstargets[uniquelevelindex];
+}
+
+// Returns the number of target states for photoionization of (element,ion,level).
 __host__ __device__ inline auto get_nphixstargets(const int element, const int ion, const int level) -> int {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  const auto nphixstargets = get_ion_levels(element, ion)[level].nphixstargets;
+  const auto nphixstargets = get_nphixstargets(get_uniquelevelindex(element, ion, level));
   assert_testmodeonly(nphixstargets == 0 ||
                       ((ion < (get_nions(element) - 1)) && (level < get_nlevels_ionising(element, ion))));
   return nphixstargets;

--- a/atomic.h
+++ b/atomic.h
@@ -428,23 +428,6 @@ inline auto get_includedions() -> int {
   return get_alltrans_startup(uniquelevelindex);
 }
 
-[[nodiscard]] inline auto get_downtranslist(const int uniquelevelindex) -> LevelTransition * {
-  return globals::alltrans.data() + get_alltrans_startdown(uniquelevelindex);
-}
-
-[[nodiscard]] inline auto get_downtranslist(const int element, const int ion, const int level) -> LevelTransition * {
-  return get_downtranslist(get_uniquelevelindex(element, ion, level));
-}
-
-[[nodiscard]] inline auto get_downtransspan(const int uniquelevelindex) -> std::span<const LevelTransition> {
-  return globals::alltrans.subspan(get_alltrans_startdown(uniquelevelindex), get_ndowntrans(uniquelevelindex));
-}
-
-[[nodiscard]] inline auto get_downtransspan(const int element, const int ion, const int level)
-    -> std::span<const LevelTransition> {
-  return get_downtransspan(get_uniquelevelindex(element, ion, level));
-}
-
 // the number of upward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_nuptrans(const int uniquelevelindex) -> int {
   return globals::alllevels.nuptrans[uniquelevelindex];
@@ -456,23 +439,6 @@ inline auto get_includedions() -> int {
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
   return get_nuptrans(get_uniquelevelindex(element, ion, level));
-}
-
-[[nodiscard]] inline auto get_uptranslist(const int uniquelevelindex) -> LevelTransition * {
-  return globals::alltrans.data() + get_alltrans_startup(uniquelevelindex);
-}
-
-[[nodiscard]] inline auto get_uptranslist(const int element, const int ion, const int level) -> LevelTransition * {
-  return get_uptranslist(get_uniquelevelindex(element, ion, level));
-}
-
-[[nodiscard]] inline auto get_uptransspan(const int uniquelevelindex) -> std::span<const LevelTransition> {
-  return globals::alltrans.subspan(get_alltrans_startup(uniquelevelindex), get_nuptrans(uniquelevelindex));
-}
-
-[[nodiscard]] inline auto get_uptransspan(const int element, const int ion, const int level)
-    -> std::span<const LevelTransition> {
-  return get_uptransspan(get_uniquelevelindex(element, ion, level));
 }
 
 // the number of downward bound-bound transitions from the specified level

--- a/atomic.h
+++ b/atomic.h
@@ -424,6 +424,16 @@ inline auto get_includedions() -> int {
   return get_downtranslist(get_uniquelevelindex(element, ion, level));
 }
 
+[[nodiscard]] inline auto get_downtransspan(const int uniquelevelindex) -> std::span<const LevelTransition> {
+  return globals::alltrans.subspan(globals::alllevels_alltrans_startdown[uniquelevelindex],
+                                   get_ndowntrans(uniquelevelindex));
+}
+
+[[nodiscard]] inline auto get_downtransspan(const int element, const int ion, const int level)
+    -> std::span<const LevelTransition> {
+  return get_downtransspan(get_uniquelevelindex(element, ion, level));
+}
+
 // the number of upward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_nuptrans(const int uniquelevelindex) -> int {
   return globals::alllevels_nuptrans[uniquelevelindex];

--- a/atomic.h
+++ b/atomic.h
@@ -455,10 +455,13 @@ inline auto get_includedions() -> int {
   return get_uptranslist(get_uniquelevelindex(element, ion, level));
 }
 
+[[nodiscard]] inline auto get_uptransspan(const int uniquelevelindex) -> std::span<const LevelTransition> {
+  return globals::alltrans.subspan(get_alltrans_startup(uniquelevelindex), get_nuptrans(uniquelevelindex));
+}
+
 [[nodiscard]] inline auto get_uptransspan(const int element, const int ion, const int level)
     -> std::span<const LevelTransition> {
-  return globals::alltrans.subspan(get_alltrans_startup(get_uniquelevelindex(element, ion, level)),
-                                   get_nuptrans(element, ion, level));
+  return get_uptransspan(get_uniquelevelindex(element, ion, level));
 }
 
 // the number of downward bound-bound transitions from the specified level

--- a/atomic.h
+++ b/atomic.h
@@ -225,11 +225,15 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
 }
 
 // Return the energy of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto epsilon(const int uniquelevelindex) -> double {
+  return globals::alllevels_epsilon[uniquelevelindex];
+}
+
 [[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  return globals::alllevels_epsilon[get_uniquelevelindex(element, ion, level)];
+  return epsilon(get_uniquelevelindex(element, ion, level));
 }
 
 [[nodiscard]] inline auto get_tau_sobolev(const int nonemptymgi, const int lineindex, const double t_current)

--- a/atomic.h
+++ b/atomic.h
@@ -206,9 +206,8 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
 
   const double n_l = get_levelpop(nonemptymgi, element, ion, lower);
 
-  const double nu_trans = (epsilon(element, ion, upper) - epsilon(element, ion, lower)) / H;
   const double A_ul = line.einstein_A;
-  const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
+  const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
   const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 
   return std::max(B_lu * n_l * HCLIGHTOVERFOURPI * t_current, 0.);

--- a/atomic.h
+++ b/atomic.h
@@ -114,8 +114,9 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(level < get_nlevels(element, ion));
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
 
-  return globals::allphixstargets[get_ion_levels(element, ion)[level].phixstargetstart + phixstargetindex].levelindex;
+  return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].levelindex;
 }
 
 // Return the probability of a target state for photoionization of (element,ion,level).
@@ -126,8 +127,9 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(level < get_nlevels(element, ion));
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
 
-  return globals::allphixstargets[get_ion_levels(element, ion)[level].phixstargetstart + phixstargetindex].probability;
+  return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].probability;
 }
 
 // Return the number of bf-continua associated with ion ion of element element.

--- a/atomic.h
+++ b/atomic.h
@@ -31,6 +31,9 @@ inline std::array<bool, 3> phixs_file_version_exists;
 
 constexpr std::array<const char *, 3> phixsdata_filenames = {"version0ignore", "phixsdata.txt", "phixsdata_v2.txt"};
 
+// return the number of ions of all elements combined
+inline auto get_includedlevels() -> int { return includedlevels; }
+
 [[nodiscard]] __host__ __device__ inline auto get_nelements() -> int {
   return static_cast<int>(globals::elements.size());
 }
@@ -51,6 +54,24 @@ inline auto get_nions(const int element) -> int {
   return globals::elements[element].nions;
 }
 
+// Return the number of levels associated with a specific ion given its elementindex and ionindex.
+__host__ __device__ inline auto get_nlevels(const int element, const int ion) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  return globals::elements[element].ions[ion].nlevels;
+}
+
+// Get an index for level of an ionstage of an element that is unique across every ion of every element
+[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+
+  return uniquelevelindex;
+}
+
 [[nodiscard]] inline auto get_ion_levels(const int element, const int ion) -> EnergyLevel * {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
@@ -58,13 +79,6 @@ inline auto get_nions(const int element) -> int {
   assert_testmodeonly(std::ssize(globals::alllevels) > (globals::elements[element].ions[ion].uniquelevelindexstart +
                                                         globals::elements[element].ions[ion].nlevels - 1));
   return globals::alllevels.data() + globals::elements[element].ions[ion].uniquelevelindexstart;
-}
-
-// Return the number of levels associated with a specific ion given its elementindex and ionindex.
-__host__ __device__ inline auto get_nlevels(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  return globals::elements[element].ions[ion].nlevels;
 }
 
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
@@ -124,7 +138,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 }
 
 inline __host__ __device__ auto get_phixs_table(const int element, const int ion, const int level) -> float * {
-  const auto phixsstart = get_ion_levels(element, ion)[level].phixsstart;
+  const auto phixsstart = globals::alllevels_phixsstart[get_uniquelevelindex(element, ion, level)];
   assert_testmodeonly(phixsstart >= 0);
   return globals::allphixs.data() + (phixsstart * globals::NPHIXSPOINTS);
 }
@@ -176,20 +190,6 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
   }
 
   return sigma_bf;
-}
-
-// return the number of ions of all elements combined
-inline auto get_includedlevels() -> int { return includedlevels; }
-
-// Get an index for level of an ionstage of an element that is unique across every ion of every element
-[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-
-  return uniquelevelindex;
 }
 
 // inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index

--- a/atomic.h
+++ b/atomic.h
@@ -400,11 +400,6 @@ inline auto get_includedions() -> int {
   return (get_nlevels(element, ion) > get_nlevels_nlte(element, ion) + 1);
 }
 
-[[nodiscard]] constexpr auto get_alltrans_startup(const int uniquelevelindex) -> int {
-  // index into globals::alltrans for first up transition from this level
-  return globals::alllevels.alltrans_startdown[uniquelevelindex] + globals::alllevels.ndowntrans[uniquelevelindex];
-}
-
 // the number of downward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_ndowntrans(const int uniquelevelindex) -> int {
   return globals::alllevels.ndowntrans[uniquelevelindex];
@@ -418,8 +413,23 @@ inline auto get_includedions() -> int {
   return get_ndowntrans(get_uniquelevelindex(element, ion, level));
 }
 
+// index into globals::alltrans for first down transition from this level
+[[nodiscard]] inline auto get_alltrans_startdown(const int uniquelevelindex) -> int {
+  return globals::alllevels.alltrans_startdown[uniquelevelindex];
+}
+
+// index into globals::alltrans for first up transition from this level
+[[nodiscard]] inline auto get_alltrans_startup(const int uniquelevelindex) -> int {
+  return get_alltrans_startdown(uniquelevelindex) + get_ndowntrans(uniquelevelindex);
+}
+
+[[nodiscard]] inline auto get_alltrans_startup(const int element, const int ion, const int level) -> int {
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  return get_alltrans_startup(uniquelevelindex);
+}
+
 [[nodiscard]] inline auto get_downtranslist(const int uniquelevelindex) -> LevelTransition * {
-  return globals::alltrans.data() + globals::alllevels.alltrans_startdown[uniquelevelindex];
+  return globals::alltrans.data() + get_alltrans_startdown(uniquelevelindex);
 }
 
 [[nodiscard]] inline auto get_downtranslist(const int element, const int ion, const int level) -> LevelTransition * {
@@ -427,8 +437,7 @@ inline auto get_includedions() -> int {
 }
 
 [[nodiscard]] inline auto get_downtransspan(const int uniquelevelindex) -> std::span<const LevelTransition> {
-  return globals::alltrans.subspan(globals::alllevels.alltrans_startdown[uniquelevelindex],
-                                   get_ndowntrans(uniquelevelindex));
+  return globals::alltrans.subspan(get_alltrans_startdown(uniquelevelindex), get_ndowntrans(uniquelevelindex));
 }
 
 [[nodiscard]] inline auto get_downtransspan(const int element, const int ion, const int level)

--- a/atomic.h
+++ b/atomic.h
@@ -488,13 +488,18 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   return E_threshold;
 }
 
-[[nodiscard]] inline auto get_bflutindex(const int temperatureindex, const int element, const int ion, const int level,
+[[nodiscard]] inline auto get_bflutindex(const int temperatureindex, const int uniquelevelindex,
                                          const int phixstargetindex) -> int {
-  const int contindex = globals::alllevels_cont_index[get_uniquelevelindex(element, ion, level)] + phixstargetindex;
+  const int contindex = globals::alllevels_cont_index[uniquelevelindex] + phixstargetindex;
   const int bflutindex = (temperatureindex * globals::nbfcontinua) + contindex;
   assert_testmodeonly(bflutindex >= 0);
   assert_testmodeonly(bflutindex <= TABLESIZE * globals::nbfcontinua);
   return bflutindex;
+}
+
+[[nodiscard]] inline auto get_bflutindex(const int temperatureindex, const int element, const int ion, const int level,
+                                         const int phixstargetindex) -> int {
+  return get_bflutindex(temperatureindex, get_uniquelevelindex(element, ion, level), phixstargetindex);
 }
 
 #endif  // ATOMIC_H

--- a/atomic.h
+++ b/atomic.h
@@ -99,13 +99,18 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   return nphixstargets;
 }
 
-// Return the level index of a target state for photoionization of (element,ion,level).
-[[nodiscard]] __host__ __device__ inline auto get_phixsupperlevel(const int uniquelevelindex,
-                                                                  const int phixstargetindex) -> int {
+// Return the index into the allphixstargets arrays for a target state for photoionization of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto get_allphixstargetindex(const int uniquelevelindex,
+                                                                      const int phixstargetindex) -> int {
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
 
-  return globals::allphixstargets_levelindex[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex];
+  return globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex;
+}
+// Return the level index of a target state for photoionization of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto get_phixsupperlevel(const int uniquelevelindex,
+                                                                  const int phixstargetindex) -> int {
+  return globals::allphixstargets_levelindex[get_allphixstargetindex(uniquelevelindex, phixstargetindex)];
 }
 
 // Return the level index of a target state for photoionization of (element,ion,level).
@@ -117,10 +122,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 // Return the probability of a target state for photoionization of (element,ion,level).
 [[nodiscard]] __host__ __device__ inline auto get_phixsprobability(const int uniquelevelindex,
                                                                    const int phixstargetindex) -> double {
-  assert_testmodeonly(phixstargetindex >= 0);
-  assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
-
-  return globals::allphixstargets_probability[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex];
+  return globals::allphixstargets_probability[get_allphixstargetindex(uniquelevelindex, phixstargetindex)];
 }
 
 // Return the probability of a target state for photoionization of (element,ion,level).

--- a/atomic.h
+++ b/atomic.h
@@ -105,7 +105,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
 
-  return globals::allphixstargets[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex].levelindex;
+  return globals::allphixstargets_levelindex[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex];
 }
 
 // Return the level index of a target state for photoionization of (element,ion,level).
@@ -120,7 +120,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
 
-  return globals::allphixstargets[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex].probability;
+  return globals::allphixstargets_probability[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex];
 }
 
 // Return the probability of a target state for photoionization of (element,ion,level).

--- a/atomic.h
+++ b/atomic.h
@@ -452,7 +452,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
 [[nodiscard]] inline auto get_emtype_continuum(const int element, const int ion, const int level,
                                                const int upperionlevel) -> int {
   const int phixstargetindex = get_phixtargetindex(element, ion, level, upperionlevel);
-  return -1 - get_ion_levels(element, ion)[level].cont_index - phixstargetindex;
+  return -1 - globals::alllevels_cont_index[get_uniquelevelindex(element, ion, level)] - phixstargetindex;
 }
 
 // Returns the energy of (element,ion,level).
@@ -467,11 +467,10 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   return E_threshold;
 }
 
-[[nodiscard]] inline auto get_bflutindex(const int tempindex, const int element, const int ion, const int level,
+[[nodiscard]] inline auto get_bflutindex(const int temperatureindex, const int element, const int ion, const int level,
                                          const int phixstargetindex) -> int {
-  const int contindex = get_ion_levels(element, ion)[level].cont_index + phixstargetindex;
-
-  const int bflutindex = (tempindex * globals::nbfcontinua) + contindex;
+  const int contindex = globals::alllevels_cont_index[get_uniquelevelindex(element, ion, level)] + phixstargetindex;
+  const int bflutindex = (temperatureindex * globals::nbfcontinua) + contindex;
   assert_testmodeonly(bflutindex >= 0);
   assert_testmodeonly(bflutindex <= TABLESIZE * globals::nbfcontinua);
   return bflutindex;

--- a/atomic.h
+++ b/atomic.h
@@ -211,13 +211,17 @@ inline auto get_includedlevels() -> int { return includedlevels; }
   assert_always(false);  // uniquelevelindex too high to be valid
   return {-1, -1, -1};
 }
+// Return the statistical weight of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto stat_weight(const int uniquelevelindex) -> double {
+  return globals::alllevels_statweight[uniquelevelindex];
+}
 
 // Return the statistical weight of (element,ion,level).
 [[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  return globals::alllevels_statweight[get_uniquelevelindex(element, ion, level)];
+  return stat_weight(get_uniquelevelindex(element, ion, level));
 }
 
 // Return the energy of (element,ion,level).
@@ -257,8 +261,8 @@ inline auto get_includedlevels() -> int { return includedlevels; }
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
-                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
+  const double B_lu =
+      stat_weight(ionuniquelevelindexstart + upper) / stat_weight(ionuniquelevelindexstart + lower) * B_ul;
 
   const double n_u = get_levelpop(nonemptymgi, element, ion, upper);
   return std::max((B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current, 0.);

--- a/atomic.h
+++ b/atomic.h
@@ -497,7 +497,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   return -1;
 }
 
-// Returns the emissiontype index of the continuum associated to the given level. Will be negative and ordered by
+// Return the emissiontype index of the continuum associated to the given level. Will be negative and ordered by
 // element/ion/level/phixstargetindex
 [[nodiscard]] inline auto get_emtype_continuum(const int element, const int ion, const int level,
                                                const int upperionlevel) -> int {
@@ -505,7 +505,16 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   return -1 - globals::alllevels.cont_index[get_uniquelevelindex(element, ion, level)] - phixstargetindex;
 }
 
-// Returns the energy of (element,ion,level).
+// Return the photionisation threshold energy [erg]
+[[nodiscard]] inline auto get_phixs_threshold(const int uniquelevelindex, const int phixstargetindex) -> double {
+  assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
+  const int upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex);
+  const auto [element, ion, _] = get_levelfromuniquelevelindex(uniquelevelindex);
+  const double E_threshold = epsilon(element, ion + 1, upperlevel) - epsilon(uniquelevelindex);
+  return E_threshold;
+}
+
+// Return the photionisation threshold energy [erg]
 [[nodiscard]] inline auto get_phixs_threshold(const int element, const int ion, const int level,
                                               const int phixstargetindex) -> double {
   assert_testmodeonly(element < get_nelements());

--- a/atomic.h
+++ b/atomic.h
@@ -88,7 +88,7 @@ __host__ __device__ inline auto get_nlevels(const int element, const int ion) ->
 
 // Returns the number of target states for photoionization of (element,ion,level).
 __host__ __device__ inline auto get_nphixstargets(const int uniquelevelindex) -> int {
-  return globals::alllevels_nphixstargets[uniquelevelindex];
+  return globals::alllevels.nphixstargets[uniquelevelindex];
 }
 
 // Returns the number of target states for photoionization of (element,ion,level).
@@ -105,7 +105,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
 
-  return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].levelindex;
+  return globals::allphixstargets[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex].levelindex;
 }
 
 // Return the level index of a target state for photoionization of (element,ion,level).
@@ -120,7 +120,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex >= 0);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
 
-  return globals::allphixstargets[globals::alllevels_phixstargetstart[uniquelevelindex] + phixstargetindex].probability;
+  return globals::allphixstargets[globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex].probability;
 }
 
 // Return the probability of a target state for photoionization of (element,ion,level).
@@ -141,7 +141,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 }
 
 [[nodiscard]] inline __host__ __device__ auto get_phixs_table(const int uniquelevelindexl) -> float * {
-  const auto phixsstart = globals::alllevels_phixsstart[uniquelevelindexl];
+  const auto phixsstart = globals::alllevels.phixsstart[uniquelevelindexl];
   assert_testmodeonly(phixsstart >= 0);
   return globals::allphixs.data() + (phixsstart * globals::NPHIXSPOINTS);
 }
@@ -221,7 +221,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 }
 // Return the statistical weight of (element,ion,level).
 [[nodiscard]] __host__ __device__ inline auto stat_weight(const int uniquelevelindex) -> double {
-  return globals::alllevels_statweight[uniquelevelindex];
+  return globals::alllevels.statweight[uniquelevelindex];
 }
 
 // Return the statistical weight of (element,ion,level).
@@ -234,7 +234,7 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
 
 // Return the energy of (element,ion,level).
 [[nodiscard]] __host__ __device__ inline auto epsilon(const int uniquelevelindex) -> double {
-  return globals::alllevels_epsilon[uniquelevelindex];
+  return globals::alllevels.epsilon[uniquelevelindex];
 }
 
 [[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
@@ -400,12 +400,12 @@ inline auto get_includedions() -> int {
 
 [[nodiscard]] constexpr auto get_alltrans_startup(const int uniquelevelindex) -> int {
   // index into globals::alltrans for first up transition from this level
-  return globals::alllevels_alltrans_startdown[uniquelevelindex] + globals::alllevels_ndowntrans[uniquelevelindex];
+  return globals::alllevels.alltrans_startdown[uniquelevelindex] + globals::alllevels.ndowntrans[uniquelevelindex];
 }
 
 // the number of downward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_ndowntrans(const int uniquelevelindex) -> int {
-  return globals::alllevels_ndowntrans[uniquelevelindex];
+  return globals::alllevels.ndowntrans[uniquelevelindex];
 }
 
 // the number of downward bound-bound transitions from the specified level
@@ -417,7 +417,7 @@ inline auto get_includedions() -> int {
 }
 
 [[nodiscard]] inline auto get_downtranslist(const int uniquelevelindex) -> LevelTransition * {
-  return globals::alltrans.data() + globals::alllevels_alltrans_startdown[uniquelevelindex];
+  return globals::alltrans.data() + globals::alllevels.alltrans_startdown[uniquelevelindex];
 }
 
 [[nodiscard]] inline auto get_downtranslist(const int element, const int ion, const int level) -> LevelTransition * {
@@ -425,7 +425,7 @@ inline auto get_includedions() -> int {
 }
 
 [[nodiscard]] inline auto get_downtransspan(const int uniquelevelindex) -> std::span<const LevelTransition> {
-  return globals::alltrans.subspan(globals::alllevels_alltrans_startdown[uniquelevelindex],
+  return globals::alltrans.subspan(globals::alllevels.alltrans_startdown[uniquelevelindex],
                                    get_ndowntrans(uniquelevelindex));
 }
 
@@ -436,7 +436,7 @@ inline auto get_includedions() -> int {
 
 // the number of upward bound-bound transitions from the specified level
 [[nodiscard]] inline auto get_nuptrans(const int uniquelevelindex) -> int {
-  return globals::alllevels_nuptrans[uniquelevelindex];
+  return globals::alllevels.nuptrans[uniquelevelindex];
 }
 
 // the number of upward bound-bound transitions from the specified level
@@ -469,7 +469,7 @@ inline void set_ndowntrans(const int element, const int ion, const int level, co
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  globals::alllevels_ndowntrans[get_uniquelevelindex(element, ion, level)] = ndowntrans;
+  globals::alllevels.ndowntrans[get_uniquelevelindex(element, ion, level)] = ndowntrans;
 }
 
 // the number of upward bound-bound transitions from the specified level
@@ -477,7 +477,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
-  globals::alllevels_nuptrans[get_uniquelevelindex(element, ion, level)] = nuptrans;
+  globals::alllevels.nuptrans[get_uniquelevelindex(element, ion, level)] = nuptrans;
 }
 
 [[nodiscard]] inline auto get_phixtargetindex(const int element, const int ion, const int level,
@@ -500,7 +500,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
 [[nodiscard]] inline auto get_emtype_continuum(const int element, const int ion, const int level,
                                                const int upperionlevel) -> int {
   const int phixstargetindex = get_phixtargetindex(element, ion, level, upperionlevel);
-  return -1 - globals::alllevels_cont_index[get_uniquelevelindex(element, ion, level)] - phixstargetindex;
+  return -1 - globals::alllevels.cont_index[get_uniquelevelindex(element, ion, level)] - phixstargetindex;
 }
 
 // Returns the energy of (element,ion,level).
@@ -517,7 +517,7 @@ inline void set_nuptrans(const int element, const int ion, const int level, cons
 
 [[nodiscard]] inline auto get_bflutindex(const int temperatureindex, const int uniquelevelindex,
                                          const int phixstargetindex) -> int {
-  const int contindex = globals::alllevels_cont_index[uniquelevelindex] + phixstargetindex;
+  const int contindex = globals::alllevels.cont_index[uniquelevelindex] + phixstargetindex;
   const int bflutindex = (temperatureindex * globals::nbfcontinua) + contindex;
   assert_testmodeonly(bflutindex >= 0);
   assert_testmodeonly(bflutindex <= TABLESIZE * globals::nbfcontinua);

--- a/atomic.h
+++ b/atomic.h
@@ -67,15 +67,6 @@ __host__ __device__ inline auto get_nlevels(const int element, const int ion) ->
   return globals::elements[element].ions[ion].nlevels;
 }
 
-// Return the energy of (element,ion,level).
-
-[[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  return get_ion_levels(element, ion)[level].epsilon;
-}
-
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
 [[nodiscard]] __host__ __device__ inline auto get_ionstage(const int element, const int ion) -> int {
   assert_testmodeonly(element < get_nelements());
@@ -123,15 +114,6 @@ __host__ __device__ inline auto get_nphixstargets(const int element, const int i
   assert_testmodeonly(phixstargetindex < get_nphixstargets(element, ion, level));
 
   return globals::allphixstargets[get_ion_levels(element, ion)[level].phixstargetstart + phixstargetindex].probability;
-}
-
-// Return the statistical weight of (element,ion,level).
-
-[[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  return get_ion_levels(element, ion)[level].stat_weight;
 }
 
 // Return the number of bf-continua associated with ion ion of element element.
@@ -229,6 +211,23 @@ inline auto get_includedlevels() -> int { return includedlevels; }
   assert_always(false);  // uniquelevelindex too high to be valid
   return {-1, -1, -1};
 }
+
+// Return the statistical weight of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto stat_weight(const int element, const int ion, const int level) -> double {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return globals::alllevels_statweight[get_uniquelevelindex(element, ion, level)];
+}
+
+// Return the energy of (element,ion,level).
+[[nodiscard]] __host__ __device__ inline auto epsilon(const int element, const int ion, const int level) -> double {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  return globals::alllevels_epsilon[get_uniquelevelindex(element, ion, level)];
+}
+
 [[nodiscard]] inline auto get_tau_sobolev(const int nonemptymgi, const int lineindex, const double t_current)
     -> double {
   const auto &line = globals::linelist[lineindex];
@@ -257,7 +256,9 @@ inline auto get_includedlevels() -> int { return includedlevels; }
 
   const double A_ul = line.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * A_ul;
-  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
+                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
 
   const double n_u = get_levelpop(nonemptymgi, element, ion, upper);
   return std::max((B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current, 0.);

--- a/atomic.h
+++ b/atomic.h
@@ -196,6 +196,39 @@ inline __host__ __device__ auto get_phixs_table(const int element, const int ion
   return sigma_bf;
 }
 
+// return the number of ions of all elements combined
+inline auto get_includedlevels() -> int { return includedlevels; }
+
+// Get an index for level of an ionstage of an element that is unique across every ion of every element
+[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
+  assert_testmodeonly(element < get_nelements());
+  assert_testmodeonly(ion < get_nions(element));
+  assert_testmodeonly(level < get_nlevels(element, ion));
+  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+
+  return uniquelevelindex;
+}
+
+// inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index
+[[nodiscard]] inline auto get_levelfromuniquelevelindex(const int uniquelevelindex) -> std::tuple<int, int, int> {
+  assert_testmodeonly(uniquelevelindex < get_includedlevels());
+  for (int element = 0; element < get_nelements(); element++) {
+    const int nions = get_nions(element);
+    for (int ion = 0; ion < nions; ion++) {
+      if (get_nlevels(element, ion) == 0) {
+        continue;
+      }
+      const int level = uniquelevelindex - globals::elements[element].ions[ion].uniquelevelindexstart;
+      if (level >= 0 && level < get_nlevels(element, ion)) {
+        assert_testmodeonly(get_uniquelevelindex(element, ion, level) == uniquelevelindex);
+        return {element, ion, level};
+      }
+    }
+  }
+  assert_always(false);  // uniquelevelindex too high to be valid
+  return {-1, -1, -1};
+}
 [[nodiscard]] inline auto get_tau_sobolev(const int nonemptymgi, const int lineindex, const double t_current)
     -> double {
   const auto &line = globals::linelist[lineindex];
@@ -277,9 +310,6 @@ inline auto get_includedions() -> int {
   return includedions;
 }
 
-// return the number of ions of all elements combined
-inline auto get_includedlevels() -> int { return includedlevels; }
-
 // get a number greater than or equal to nions(element) for all elements
 [[nodiscard]] inline auto get_max_nions() -> int { return maxnions; }
 
@@ -343,37 +373,6 @@ inline auto get_includedlevels() -> int { return includedlevels; }
   }
   assert_always(false);  // allionsindex too high to be valid
   return {-1, -1};
-}
-
-// Get an index for level of an ionstage of an element that is unique across every ion of every element
-[[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
-  const auto uniquelevelindex = globals::elements[element].ions[ion].uniquelevelindexstart + level;
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-
-  return uniquelevelindex;
-}
-
-// inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index
-[[nodiscard]] inline auto get_levelfromuniquelevelindex(const int uniquelevelindex) -> std::tuple<int, int, int> {
-  assert_testmodeonly(uniquelevelindex < get_includedlevels());
-  for (int element = 0; element < get_nelements(); element++) {
-    const int nions = get_nions(element);
-    for (int ion = 0; ion < nions; ion++) {
-      if (get_nlevels(element, ion) == 0) {
-        continue;
-      }
-      const int level = uniquelevelindex - globals::elements[element].ions[ion].uniquelevelindexstart;
-      if (level >= 0 && level < get_nlevels(element, ion)) {
-        assert_testmodeonly(get_uniquelevelindex(element, ion, level) == uniquelevelindex);
-        return {element, ion, level};
-      }
-    }
-  }
-  assert_always(false);  // uniquelevelindex too high to be valid
-  return {-1, -1, -1};
 }
 
 [[nodiscard]] inline auto ion_has_superlevel(const int element, const int ion) -> bool {

--- a/exspec.cc
+++ b/exspec.cc
@@ -232,7 +232,7 @@ auto main(int argc, char *argv[]) -> int {  // NOLINT(misc-unused-parameters)
 
   Spectra gamma_spectra;
 
-  time_init();
+  setup_timesteps();
 
   const int amax = ((grid::get_model_type() == GridType::SPHERICAL1D)) ? 0 : MABINS;
   // a is the escape direction angle bin

--- a/globals.h
+++ b/globals.h
@@ -275,7 +275,7 @@ inline std::span<double> alllevels_epsilon;
 inline std::span<float> alllevels_statweight;
 inline std::span<int> alllevels_closestgroundlevelcont;
 
-// index into globals::allphixstargets
+// index into globals::allphixs for photoionisation cross-sections
 inline std::span<int> alllevels_phixsstart;
 
 // index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index into

--- a/globals.h
+++ b/globals.h
@@ -193,7 +193,7 @@ struct CellCache {
   std::vector<bool> ch_keep_this_cont;
   double chi_ff_nnionpart{-1};
   int nonemptymgi{-1};  // Identifies the cell the data is valid for.
-  std::vector<CellCachePhixsTargets> chphixstargetsblock;  // photoionisation targets for all levels
+  std::vector<CellCachePhixsTargets> challphixstargets;  // photoionisation targets for all levels
   std::vector<double> chtransblock;  // cumulative transition rates for all levels
 };
 

--- a/globals.h
+++ b/globals.h
@@ -176,6 +176,7 @@ struct CellCache {
   int nonemptymgi{-1};  // Identifies the cell the data is valid for.
   std::vector<double> allphixstargets_corrphotoioncoeff;
   std::vector<double> allphixstargets_stimrecombcoeff;
+  std::vector<double> alpha_sp_E_integrals;  // size is size(allphisxtargets) * NPHIXSPOINTS
   std::vector<double> chtransblock;  // cumulative transition rates for all levels
 };
 

--- a/globals.h
+++ b/globals.h
@@ -284,6 +284,7 @@ struct AllLevels {
 
   // index into globals::alltrans for first down transition from each level
   std::span<int> alltrans_startdown;
+
   // Number of down transitions from each level
   std::span<int> ndowntrans;
 

--- a/globals.h
+++ b/globals.h
@@ -88,9 +88,6 @@ struct EnergyLevelInput {
   int nphixstargets{0};  // number of target levels for photoionisation
   float stat_weight{0.};  // statistical weight of this level
   int phixstargetstart{-1};  // index into globals::allphixstargets
-  int cont_index{-1};  // index of the bound-free continuum (for first target) sorted by
-                       // element/ion/level/phixstargetindex
-                       // (not an index into the nu_edge-sorted allcont list!)
   int closestgroundlevelcont{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
@@ -105,7 +102,6 @@ struct EnergyLevel {
   int nuptrans{0};
   int nphixstargets{0};
   int phixstargetstart{-1};
-  int cont_index{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
     // index into globals::alltrans for first up transition from this level
@@ -278,7 +274,13 @@ inline std::span<EnergyLevel> alllevels;
 inline std::span<double> alllevels_epsilon;
 inline std::span<float> alllevels_statweight;
 inline std::span<int> alllevels_closestgroundlevelcont;
+
+// index into globals::allphixstargets
 inline std::span<int> alllevels_phixsstart;
+
+// index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index into
+// the nu_edge-sorted allcont list!)
+inline std::span<int> alllevels_cont_index;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -261,6 +261,8 @@ inline std::span<float> allphixs{};
 inline std::span<LevelTransition> alltrans{};
 inline std::vector<PhotoionTarget> allphixstargets;
 inline std::span<EnergyLevel> alllevels;
+inline std::span<double> alllevels_epsilon;
+inline std::span<float> alllevels_statweight;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -86,7 +86,6 @@ struct EnergyLevelInput {
   int nuptrans{0};  // Number of up transitions to this level
   int nphixstargets{0};  // number of target levels for photoionisation
   float stat_weight{0.};  // statistical weight of this level
-  int closestgroundlevelcont{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
     // index into globals::alltrans for first up transition from this level

--- a/globals.h
+++ b/globals.h
@@ -261,8 +261,6 @@ inline std::span<float> allphixs{};
 inline std::span<LevelTransition> alltrans{};
 inline std::vector<PhotoionTarget> allphixstargets;
 inline std::span<EnergyLevel> alllevels;
-inline std::span<double> alllevels_epsilon;
-inline std::span<float> alllevels_statweight;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -169,7 +169,6 @@ enum ma_action {
 
 struct CellCacheLevels {
   std::array<double, MA_ACTION_COUNT> processrates;
-  CellCachePhixsTargets *chphixstargets;
   double population;
   double *sum_epstrans_rad_deexc;
   double *sum_internal_down_same;

--- a/globals.h
+++ b/globals.h
@@ -103,7 +103,6 @@ struct EnergyLevel {
   int alltrans_startdown{};
   int ndowntrans{0};
   int nuptrans{0};
-  int phixsstart{-1};
   int nphixstargets{0};
   int phixstargetstart{-1};
   int cont_index{-1};
@@ -279,6 +278,7 @@ inline std::span<EnergyLevel> alllevels;
 inline std::span<double> alllevels_epsilon;
 inline std::span<float> alllevels_statweight;
 inline std::span<int> alllevels_closestgroundlevelcont;
+inline std::span<int> alllevels_phixsstart;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -243,8 +243,8 @@ struct AllTransitions {
 };
 inline AllTransitions alltrans;
 
-inline std::vector<int> allphixstargets_levelindex;  // index of upper ion level after photoionisation
-inline std::vector<double>
+inline std::span<int> allphixstargets_levelindex;  // index of upper ion level after photoionisation
+inline std::span<double>
     allphixstargets_probability;  // fraction of phixs cross section leading to associated final level
 
 struct AllLevels {

--- a/globals.h
+++ b/globals.h
@@ -127,19 +127,6 @@ struct GSLIntegrationParas {
   const float *photoion_xs;
 };
 
-template <bool separatestimrecomb>
-struct chphixstargets {
-  double corrphotoioncoeff;
-};
-
-template <>
-struct chphixstargets<true> {
-  double corrphotoioncoeff;
-  double separatestimrecomb;
-};
-
-using CellCachePhixsTargets = chphixstargets<SEPARATE_STIMRECOMB>;
-
 enum ma_action {
   // Radiative deexcitation rate from this level.
   MA_ACTION_RADDEEXC = 0,
@@ -187,7 +174,8 @@ struct CellCache {
   std::vector<bool> ch_keep_this_cont;
   double chi_ff_nnionpart{-1};
   int nonemptymgi{-1};  // Identifies the cell the data is valid for.
-  std::vector<CellCachePhixsTargets> challphixstargets;  // photoionisation targets for all levels
+  std::vector<double> allphixstargets_corrphotoioncoeff;
+  std::vector<double> allphixstargets_stimrecombcoeff;
   std::vector<double> chtransblock;  // cumulative transition rates for all levels
 };
 

--- a/globals.h
+++ b/globals.h
@@ -107,7 +107,6 @@ struct EnergyLevel {
   int nphixstargets{0};
   int phixstargetstart{-1};
   int cont_index{-1};
-  int closestgroundlevelcont{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
     // index into globals::alltrans for first up transition from this level
@@ -279,6 +278,7 @@ inline std::vector<PhotoionTarget> allphixstargets;
 inline std::span<EnergyLevel> alllevels;
 inline std::span<double> alllevels_epsilon;
 inline std::span<float> alllevels_statweight;
+inline std::span<int> alllevels_closestgroundlevelcont;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -254,31 +254,36 @@ inline std::span<float> allphixs{};
 inline std::span<LevelTransition> alltrans{};
 inline std::vector<PhotoionTarget> allphixstargets;
 
-inline std::span<double> alllevels_epsilon;
-inline std::span<float> alllevels_statweight;
-inline std::span<int> alllevels_closestgroundlevelcont;
+struct AllLevels {
+  // all of these arrays are indexed by uniquelevelindex, which can be derived from the element, ion, level
 
-// index to start of photoionisation cross-sections table in global::allphixs
-inline std::span<int> alllevels_phixsstart;
+  std::span<double> epsilon;
+  std::span<float> statweight;
+  std::span<int> closestgroundlevelcont;
 
-// number of target levels for photoionisation
-inline std::span<int> alllevels_nphixstargets;
+  // index to start of photoionisation cross-sections table in global::allphixs
+  std::span<int> phixsstart;
 
-// index into globals::allphixstargets for the first target level
-inline std::span<int> alllevels_phixstargetstart;
+  // number of target levels for photoionisation
+  std::span<int> nphixstargets;
 
-// index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index into
-// the nu_edge-sorted allcont list!)
-inline std::span<int> alllevels_cont_index;
+  // index into globals::allphixstargets for the first target level
+  std::span<int> phixstargetstart;
 
-// index into globals::alltrans for first down transition from each level
-inline std::span<int> alllevels_alltrans_startdown;
+  // index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index
+  // into the nu_edge-sorted allcont list!)
+  std::span<int> cont_index;
 
-// Number of down transitions from each level
-inline std::span<int> alllevels_ndowntrans;
+  // index into globals::alltrans for first down transition from each level
+  std::span<int> alltrans_startdown;
+  // Number of down transitions from each level
+  std::span<int> ndowntrans;
 
-// Number of up transitions from each level
-inline std::span<int> alllevels_nuptrans;
+  // Number of up transitions from each level
+  std::span<int> nuptrans;
+};
+
+inline AllLevels alllevels{};
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -84,7 +84,6 @@ struct EnergyLevelInput {
   int alltrans_startdown{};  // index into globals::alltrans for first down transition from this level
   int ndowntrans{0};  // Number of down transitions from this level
   int nuptrans{0};  // Number of up transitions to this level
-  int nphixstargets{0};  // number of target levels for photoionisation
   float stat_weight{0.};  // statistical weight of this level
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
@@ -97,7 +96,6 @@ struct EnergyLevel {
   int alltrans_startdown{};
   int ndowntrans{0};
   int nuptrans{0};
-  int nphixstargets{0};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
     // index into globals::alltrans for first up transition from this level
@@ -273,6 +271,9 @@ inline std::span<int> alllevels_closestgroundlevelcont;
 
 // index to start of photoionisation cross-sections table in global::allphixs
 inline std::span<int> alllevels_phixsstart;
+
+// number of target levels for photoionisation
+inline std::span<int> alllevels_nphixstargets;
 
 // index into globals::allphixstargets for the first target level
 inline std::span<int> alllevels_phixstargetstart;

--- a/globals.h
+++ b/globals.h
@@ -74,11 +74,6 @@ struct LevelTransition {
   bool forbidden;
 };
 
-struct PhotoionTarget {
-  double probability;  // fraction of phixs cross section leading to this final level
-  int levelindex;  // index of upper ion level after photoionisation
-};
-
 struct EnergyLevelInput {
   double epsilon{-1};  // Excitation energy of this level relative to the neutral ground level.
   int alltrans_startdown{};  // index into globals::alltrans for first down transition from this level
@@ -260,7 +255,9 @@ struct AllTransitions {
 };
 inline AllTransitions alltrans;
 
-inline std::vector<PhotoionTarget> allphixstargets;
+inline std::vector<int> allphixstargets_levelindex;  // index of upper ion level after photoionisation
+inline std::vector<double>
+    allphixstargets_probability;  // fraction of phixs cross section leading to associated final level
 
 struct AllLevels {
   // all of these arrays are indexed by uniquelevelindex, which can be derived from the element, ion, level

--- a/globals.h
+++ b/globals.h
@@ -250,7 +250,16 @@ inline int opacity_case{};  // 0 grey, 1 for Fe-grp dependence.
 inline std::vector<float> ion_alpha_sp;  // alpha_sp for each ion and temperature table value
 
 inline std::span<float> allphixs{};
-inline std::span<LevelTransition> alltrans{};
+struct AllTransitions {
+  std::span<int> lineindex;
+  std::span<int> targetlevelindex;
+  std::span<float> einstein_A;
+  std::span<float> coll_str;
+  std::span<float> osc_strength;
+  std::span<bool> forbidden;
+};
+inline AllTransitions alltrans;
+
 inline std::vector<PhotoionTarget> allphixstargets;
 
 struct AllLevels {

--- a/globals.h
+++ b/globals.h
@@ -92,17 +92,6 @@ struct EnergyLevelInput {
   }
 };
 
-struct EnergyLevel {
-  int alltrans_startdown{};
-  int ndowntrans{0};
-  int nuptrans{0};
-
-  [[nodiscard]] constexpr auto alltrans_startup() const -> int {
-    // index into globals::alltrans for first up transition from this level
-    return alltrans_startdown + ndowntrans;
-  }
-};
-
 struct Ion {
   int ionstage{-1};  // Which ionisation stage: XI=0, XII=1, XIII=2, ...
   int nlevels{0};  // Number of levels for this ionisation stage
@@ -264,7 +253,7 @@ inline std::vector<float> ion_alpha_sp;  // alpha_sp for each ion and temperatur
 inline std::span<float> allphixs{};
 inline std::span<LevelTransition> alltrans{};
 inline std::vector<PhotoionTarget> allphixstargets;
-inline std::span<EnergyLevel> alllevels;
+
 inline std::span<double> alllevels_epsilon;
 inline std::span<float> alllevels_statweight;
 inline std::span<int> alllevels_closestgroundlevelcont;
@@ -281,6 +270,15 @@ inline std::span<int> alllevels_phixstargetstart;
 // index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index into
 // the nu_edge-sorted allcont list!)
 inline std::span<int> alllevels_cont_index;
+
+// index into globals::alltrans for first down transition from each level
+inline std::span<int> alllevels_alltrans_startdown;
+
+// Number of down transitions from each level
+inline std::span<int> alllevels_ndowntrans;
+
+// Number of up transitions from each level
+inline std::span<int> alllevels_nuptrans;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -176,7 +176,6 @@ struct CellCache {
   int nonemptymgi{-1};  // Identifies the cell the data is valid for.
   std::vector<double> allphixstargets_corrphotoioncoeff;
   std::vector<double> allphixstargets_stimrecombcoeff;
-  std::vector<double> alpha_sp_E_integrals;  // size is size(allphisxtargets) * NPHIXSPOINTS
   std::vector<double> chtransblock;  // cumulative transition rates for all levels
 };
 

--- a/globals.h
+++ b/globals.h
@@ -262,7 +262,7 @@ inline std::span<LevelTransition> alltrans{};
 inline std::vector<PhotoionTarget> allphixstargets;
 inline std::span<EnergyLevel> alllevels;
 inline std::span<double> alllevels_epsilon;
-inline std::span<double> alllevels_statweight;
+inline std::span<float> alllevels_statweight;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -79,7 +79,7 @@ struct PhotoionTarget {
   int levelindex;  // index of upper ion level after photoionisation
 };
 
-struct EnergyLevel {
+struct EnergyLevelInput {
   double epsilon{-1};  // Excitation energy of this level relative to the neutral ground level.
   int alltrans_startdown{};  // index into globals::alltrans for first down transition from this level
   int ndowntrans{0};  // Number of down transitions from this level
@@ -91,6 +91,22 @@ struct EnergyLevel {
   int cont_index{-1};  // index of the bound-free continuum (for first target) sorted by
                        // element/ion/level/phixstargetindex
                        // (not an index into the nu_edge-sorted allcont list!)
+  int closestgroundlevelcont{-1};
+
+  [[nodiscard]] constexpr auto alltrans_startup() const -> int {
+    // index into globals::alltrans for first up transition from this level
+    return alltrans_startdown + ndowntrans;
+  }
+};
+
+struct EnergyLevel {
+  int alltrans_startdown{};
+  int ndowntrans{0};
+  int nuptrans{0};
+  int phixsstart{-1};
+  int nphixstargets{0};
+  int phixstargetstart{-1};
+  int cont_index{-1};
   int closestgroundlevelcont{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {

--- a/globals.h
+++ b/globals.h
@@ -262,7 +262,7 @@ inline std::span<LevelTransition> alltrans{};
 inline std::vector<PhotoionTarget> allphixstargets;
 inline std::span<EnergyLevel> alllevels;
 inline std::span<double> alllevels_epsilon;
-inline std::span<float> alllevels_statweight;
+inline std::span<double> alllevels_statweight;
 
 inline std::vector<Element> elements;
 

--- a/globals.h
+++ b/globals.h
@@ -84,7 +84,6 @@ struct EnergyLevelInput {
   int alltrans_startdown{};  // index into globals::alltrans for first down transition from this level
   int ndowntrans{0};  // Number of down transitions from this level
   int nuptrans{0};  // Number of up transitions to this level
-  int phixsstart{-1};  // index to start of photoionisation cross-sections table in global::allphixs
   int nphixstargets{0};  // number of target levels for photoionisation
   float stat_weight{0.};  // statistical weight of this level
   int closestgroundlevelcont{-1};
@@ -273,7 +272,7 @@ inline std::span<double> alllevels_epsilon;
 inline std::span<float> alllevels_statweight;
 inline std::span<int> alllevels_closestgroundlevelcont;
 
-// index into globals::allphixs for photoionisation cross-sections
+// index to start of photoionisation cross-sections table in global::allphixs
 inline std::span<int> alllevels_phixsstart;
 
 // index into globals::allphixstargets for the first target level

--- a/globals.h
+++ b/globals.h
@@ -87,7 +87,6 @@ struct EnergyLevelInput {
   int phixsstart{-1};  // index to start of photoionisation cross-sections table in global::allphixs
   int nphixstargets{0};  // number of target levels for photoionisation
   float stat_weight{0.};  // statistical weight of this level
-  int phixstargetstart{-1};  // index into globals::allphixstargets
   int closestgroundlevelcont{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
@@ -101,7 +100,6 @@ struct EnergyLevel {
   int ndowntrans{0};
   int nuptrans{0};
   int nphixstargets{0};
-  int phixstargetstart{-1};
 
   [[nodiscard]] constexpr auto alltrans_startup() const -> int {
     // index into globals::alltrans for first up transition from this level
@@ -277,6 +275,9 @@ inline std::span<int> alllevels_closestgroundlevelcont;
 
 // index into globals::allphixs for photoionisation cross-sections
 inline std::span<int> alllevels_phixsstart;
+
+// index into globals::allphixstargets for the first target level
+inline std::span<int> alllevels_phixstargetstart;
 
 // index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index into
 // the nu_edge-sorted allcont list!)

--- a/globals.h
+++ b/globals.h
@@ -168,11 +168,11 @@ enum ma_action {
 };
 
 struct CellCacheLevels {
-  std::array<double, MA_ACTION_COUNT> processrates;
-  double population;
-  double *sum_epstrans_rad_deexc;
-  double *sum_internal_down_same;
-  double *sum_internal_up_same;
+  std::array<double, MA_ACTION_COUNT> processrates{-1.};
+  double population{NAN};
+  double *sum_epstrans_rad_deexc{nullptr};
+  double *sum_internal_down_same{nullptr};
+  double *sum_internal_up_same{nullptr};
 };
 
 struct CellCacheIons {

--- a/grid.cc
+++ b/grid.cc
@@ -1019,7 +1019,7 @@ void setup_nstart_ndo() {
         rank++;
         ranks_nstart[rank] = mgi;
         ranks_nstart_nonempty[rank] = get_next_nonemptymgi(mgi);
-        assert_always(ranks_nstart_nonempty[rank] >= 0);
+        assert_always(ranks_nstart_nonempty[rank] >= 0 || rank >= get_nonempty_npts_model());
       }
 
       ranks_ndo[rank]++;

--- a/grid.cc
+++ b/grid.cc
@@ -49,8 +49,6 @@ struct ModelGridCellInput {
   float initenergyq = 0.;  // q: energy in the model at tmin to use with USE_MODEL_INITIAL_ENERGY [erg/g]
 };
 
-std::array<char, 3> coordlabel{'?', '?', '?'};
-
 std::array<int, 3> ncoordgrid{};  // propagation grid dimensions
 
 GridType model_type = GridType::CARTESIAN3D;
@@ -61,11 +59,11 @@ double t_model = -1.;  // time at which densities in input model are correct.
 std::vector<double> vout_model{};
 std::array<int, 3> ncoord_model{};  // the model.txt input grid dimensions
 
-double min_den;  // minimum model density
+double min_den{-1.};  // minimum model density
 
-double mfegroup = 0.;  // Total mass of Fe group elements in ejecta
+double mfegroup{0.};  // Total mass of Fe group elements in ejecta
 
-int first_cellindex = -1;  // auto-determine first cell index in model.txt (usually 1 or 0)
+int first_cellindex{-1};  // auto-determine first cell index in model.txt (usually 1 or 0)
 
 // Initial co-ordinates of inner most corner of cell.
 std::vector<Vec3d> propcell_pos_min{};
@@ -108,6 +106,19 @@ consteval auto get_ndim(const GridType gridtype) -> int {
       return -1;
   }
 }
+
+constexpr auto coordlabel = [] -> std::array<char, 3> {
+  if (GRID_TYPE == GridType::CARTESIAN3D) {
+    return {'X', 'Y', 'Z'};
+  }
+  if (GRID_TYPE == GridType::CYLINDRICAL2D) {
+    return {'r', 'z', '_'};
+  }
+  if (GRID_TYPE == GridType::SPHERICAL1D) {
+    return {'r', '_', '_'};
+  }
+  assert_always(false)
+}();
 
 void set_rho_tmin(const int modelgridindex, const float x) { modelgrid_input[modelgridindex].rhoinit = x; }
 
@@ -525,7 +536,7 @@ void map_modeltogrid_direct() {
   }
 }
 
-void abundances_read() {
+void read_abundances() {
   // barrier to make sure node master has set values in node shared memory
   MPI_Barrier(MPI_COMM_WORLD);
   printout("reading abundances.txt...");
@@ -1066,7 +1077,6 @@ void setup_grid_cartesian_3d() {
   ngrid = ncoordgrid[0] * ncoordgrid[1] * ncoordgrid[2];
   resize_exactly(propcell_pos_min, ngrid);
 
-  coordlabel = {'X', 'Y', 'Z'};
   std::array<int, 3> nxyz = {0, 0, 0};
   for (int n = 0; n < ngrid; n++) {
     for (int axis = 0; axis < 3; axis++) {
@@ -1090,7 +1100,6 @@ void setup_grid_cartesian_3d() {
 
 void setup_grid_spherical_1d() {
   assert_always(get_model_type() == GridType::SPHERICAL1D);
-  coordlabel = {'r', '_', '_'};
 
   ncoordgrid = {get_npts_model(), 1, 1};
 
@@ -1111,7 +1120,6 @@ void setup_grid_cylindrical_2d() {
   assert_always(vmax_corner < CLIGHT);
 
   assert_always(get_model_type() == GridType::CYLINDRICAL2D);
-  coordlabel = {'r', 'z', '_'};
 
   ncoordgrid = ncoord_model;
 
@@ -2198,7 +2206,7 @@ auto get_ndo_nonempty(const int rank) -> int {
 }
 
 // Initialise the propagation grid cells and associate them with modelgrid cells
-void grid_init(const int my_rank) {
+void init_grid(const int my_rank) {
   // The cells will be ordered by x then y, then z. Call a routine that
   // sets up the initial positions and widths of the cells.
 
@@ -2253,17 +2261,17 @@ void grid_init(const int my_rank) {
   if (globals::my_rank == 0) {
     auto grid_file = std::fstream("grid.out", std::ios::out);
     assert_always(grid_file.is_open());
-    for (int n = 0; n < ngrid; n++) {
-      const int mgi = get_propcell_modelgridindex(n);
+    for (int cellindex = 0; cellindex < ngrid; cellindex++) {
+      const int mgi = get_propcell_modelgridindex(cellindex);
       if (mgi != get_npts_model()) {
-        grid_file << n << " " << mgi << "\n";  // write only non-empty cells to grid file
+        grid_file << cellindex << " " << mgi << "\n";  // write only non-empty cells to grid file
       }
     }
   }
 
   allocate_nonemptymodelcells();
   calculate_kappagrey();
-  abundances_read();
+  read_abundances();
 
   const int ndo_nonempty = grid::get_ndo_nonempty(my_rank);
 

--- a/grid.cc
+++ b/grid.cc
@@ -1479,7 +1479,7 @@ __host__ __device__ auto get_initial_radial_pos_sum(const int modelgridindex) ->
   return modelgrid_input[modelgridindex].initial_radial_pos_sum;
 }
 
-auto get_elem_abundance(int nonemptymgi, int element) -> float
+auto get_elem_abundance(const int nonemptymgi, const int element) -> float
 // mass fraction of an element (all isotopes combined)
 {
   const auto massfrac = elem_massfracs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_nelements()) + element];

--- a/grid.cc
+++ b/grid.cc
@@ -479,7 +479,7 @@ void allocate_nonemptymodelcells() {
 }
 
 void map_1dmodelto3dgrid()
-// Map 1D spherical model grid onto propagation grid
+// Map 1D spherical model grid onto 3D Cartesian propagation grid
 {
   for (int cellindex = 0; cellindex < ngrid; cellindex++) {
     const double cellvmid = get_cellradialposmid(cellindex) / globals::tmin;
@@ -498,7 +498,7 @@ void map_1dmodelto3dgrid()
 }
 
 void map_2dmodelto3dgrid()
-// Map 2D cylindrical model onto propagation grid
+// Map 2D cylindrical model onto 3D Cartesia propagation grid
 {
   for (int cellindex = 0; cellindex < ngrid; cellindex++) {
     // map to 3D Cartesian grid
@@ -527,7 +527,7 @@ void map_2dmodelto3dgrid()
   }
 }
 
-// mgi and cellindex are interchangeable in this mode (except for empty cells that associated with mgi ==
+// mgi and cellindex are interchangeable in this mode (except for empty cells that are associated with mgi ==
 // get_npts_model())
 void map_modeltogrid_direct() {
   for (int cellindex = 0; cellindex < ngrid; cellindex++) {

--- a/grid.h
+++ b/grid.h
@@ -79,7 +79,7 @@ void set_Te(int nonemptymgi, float Te);
 void set_TR(int nonemptymgi, float TR);
 void set_TJ(int nonemptymgi, float TJ);
 void set_W(int nonemptymgi, float W);
-void grid_init(int my_rank);
+void init_grid(int my_rank);
 [[nodiscard]] auto get_modelinitnucmassfrac(int modelgridindex, int nucindex) -> float;
 [[nodiscard]] auto get_stable_initabund(int nonemptymgi, int element) -> float;
 [[nodiscard]] auto get_element_meanweight(int nonemptymgi, int element) -> float;

--- a/input.cc
+++ b/input.cc
@@ -1168,7 +1168,9 @@ void read_atomicdata_files() {
   }
 
   // create a shared level list and copy data across, freeing the local copy
-  globals::alllevels = MPI_shared_malloc_span<EnergyLevel>(temp_alllevels.size());
+  globals::alllevels_alltrans_startdown = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels_ndowntrans = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels_nuptrans = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
@@ -1183,11 +1185,9 @@ void read_atomicdata_files() {
     std::ranges::fill(globals::alllevels_cont_index, -1);
     std::ranges::fill(globals::alllevels_closestgroundlevelcont, -1);
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
-      globals::alllevels[i] = {
-          .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
-          .ndowntrans = temp_alllevels[i].ndowntrans,
-          .nuptrans = temp_alllevels[i].nuptrans,
-      };
+      globals::alllevels_alltrans_startdown[i] = temp_alllevels[i].alltrans_startdown;
+      globals::alllevels_ndowntrans[i] = temp_alllevels[i].ndowntrans;
+      globals::alllevels_nuptrans[i] = temp_alllevels[i].nuptrans;
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
     }

--- a/input.cc
+++ b/input.cc
@@ -1116,6 +1116,8 @@ void read_atomicdata_files() {
   }
   printout("nbfcheck %d\n", nbfcheck);
 
+  update_includedionslevels_maxnions();
+
   // Save the linecounters value to the global variable containing the number of lines
   globals::nlines = lineindex;
   printout("nlines %d\n", globals::nlines);
@@ -1279,8 +1281,6 @@ void read_atomicdata_files() {
   }
 
   read_phixs_data();
-
-  update_includedionslevels_maxnions();
 }
 
 void setup_cellcache() {

--- a/input.cc
+++ b/input.cc
@@ -1345,7 +1345,6 @@ void setup_cellcache() {
     }
 
     int alllevelindex = 0;
-    int allphixstargetindex = 0;
     int chtransindex = 0;
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);
@@ -1362,11 +1361,11 @@ void setup_cellcache() {
         alllevelindex += nlevels;
 
         for (int level = 0; level < nlevels; level++) {
-          const int nphixstargets = get_nphixstargets(element, ion, level);
+          const int allphixstargetindex =
+              globals::alllevels.phixstargetstart[get_uniquelevelindex(element, ion, level)];
           chion.chlevels[level].chphixstargets =
               chphixsblocksize > 0 ? &globals::cellcache[cellcachenum].chphixstargetsblock[allphixstargetindex]
                                    : nullptr;
-          allphixstargetindex += nphixstargets;
         }
 
         for (int level = 0; level < nlevels; level++) {

--- a/input.cc
+++ b/input.cc
@@ -151,7 +151,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   globals::alllevels.phixsstart[lowerionlower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
   tmpallphixs.resize(tmpallphixs.size() + globals::NPHIXSPOINTS);
 
-  auto *levelphixstable = &tmpallphixs[tmpphixsstart];
+  const auto levelphixstable = std::span{tmpallphixs}.subspan(tmpphixsstart, globals::NPHIXSPOINTS);
   if (phixs_file_version == 1) {
     assert_always(get_nphixstargets(element, lowerion, lowerlevel) == 1);
     assert_always(get_phixsupperlevel(element, lowerion, lowerlevel, 0) == 0);

--- a/input.cc
+++ b/input.cc
@@ -85,7 +85,6 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
                            const int lowerion, const int lowerlevel, const int upperion, int upperlevel_in,
                            std::vector<float> &tmpallphixs, size_t *mem_usage_phixs, const int phixs_file_version) {
   std::string phixsline;
-  auto *lowerion_levels = get_ion_levels(element, lowerion);
   const auto phixstargetstart = static_cast<int>(globals::allphixstargets.size());
   const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
   assert_always(globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
@@ -94,8 +93,9 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   if (upperlevel_in >= 0) {  // file gives photoionisation to a single target state only
     int upperlevel = upperlevel_in - groundstate_index_in;
     assert_always(upperlevel >= 0);
-    assert_always(lowerion_levels[lowerlevel].nphixstargets == 0 || lowerion_levels[lowerlevel].nphixstargets == 1);
-    lowerion_levels[lowerlevel].nphixstargets = 1;
+    assert_always(globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
+                  globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] == 1);
+    globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] = 1;
     *mem_usage_phixs += sizeof(PhotoionTarget);
 
     if (single_level_top_ion && (upperion == get_nions(element) - 1)) {
@@ -112,7 +112,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     // read in a table of target states and probabilities and store them
     if (!single_level_top_ion || upperion < get_nions(element) - 1)  // in case the top ion has nlevelsmax = 1
     {
-      lowerion_levels[lowerlevel].nphixstargets = in_nphixstargets;
+      globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
       *mem_usage_phixs += in_nphixstargets * sizeof(PhotoionTarget);
 
       double probability_sum = 0.;
@@ -132,7 +132,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
                  get_atomicnumber(element), get_ionstage(element, lowerion), probability_sum);
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
-      lowerion_levels[lowerlevel].nphixstargets = 1;
+      globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] = 1;
       *mem_usage_phixs += sizeof(PhotoionTarget);
 
       for (int i = 0; i < in_nphixstargets; i++) {
@@ -354,7 +354,6 @@ void read_ion_levels(std::fstream &adata, const int element, const int ion, cons
           .epsilon = currentlevelenergy,
           .ndowntrans = 0,
           .nuptrans = 0,
-          .nphixstargets = 0,
           .stat_weight = statweight,
       });
 
@@ -1174,10 +1173,12 @@ void read_atomicdata_files() {
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_phixsstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels_nphixstargets = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_phixstargetstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_cont_index = MPI_shared_malloc_span<int>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     std::ranges::fill(globals::alllevels_phixsstart, -1);
+    std::ranges::fill(globals::alllevels_nphixstargets, 0);
     std::ranges::fill(globals::alllevels_phixstargetstart, -1);
     std::ranges::fill(globals::alllevels_cont_index, -1);
     std::ranges::fill(globals::alllevels_closestgroundlevelcont, -1);
@@ -1186,7 +1187,6 @@ void read_atomicdata_files() {
           .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
           .ndowntrans = temp_alllevels[i].ndowntrans,
           .nuptrans = temp_alllevels[i].nuptrans,
-          .nphixstargets = temp_alllevels[i].nphixstargets,
       };
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;

--- a/input.cc
+++ b/input.cc
@@ -89,10 +89,11 @@ constexpr std::array<std::string_view, 24> inputlinecomments = {
     "23: kpktdiffusion_timescale n_kpktdiffusion_timesteps: kpkts diffuse x of a time step's length for the first y "
     "time steps"};
 
-void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_inputtable, const int element,
-                           const int lowerion, const int lowerlevel, const int upperion, int upperlevel_in,
-                           std::vector<float> &tmpallphixs, std::vector<PhotoionTarget> &tmpallphixstargets,
-                           size_t *mem_usage_phixs, const int phixs_file_version) {
+void read_phixs_data_table(
+    std::fstream &phixsfile, const int nphixspoints_inputtable, const int element, const int lowerion,
+    const int lowerlevel, const int upperion, int upperlevel_in, std::vector<float> &tmpallphixs,
+    std::vector<PhotoionTarget> &tmpallphixstargets,  // cppcheck-suppress constParameterReference
+    size_t *mem_usage_phixs, const int phixs_file_version) {
   std::string phixsline;
   const auto phixstargetstart = static_cast<int>(tmpallphixstargets.size());
   const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
@@ -137,8 +138,9 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
         probability_sum += phixstargetprobability;
       }
       if (fabs(probability_sum - 1.0) > 0.01) {
-        printout("WARNING: photoionisation table for Z=%d ionstage %d has probabilities that sum to %g",
+        printout("ERROR: photoionisation table for Z=%d ionstage %d has probabilities that sum to %g",
                  get_atomicnumber(element), get_ionstage(element, lowerion), probability_sum);
+        assert_always(false);
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
       globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;

--- a/input.cc
+++ b/input.cc
@@ -87,15 +87,15 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   std::string phixsline;
   const auto phixstargetstart = static_cast<int>(globals::allphixstargets.size());
   const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
-  assert_always(globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
-                globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
-  globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] = phixstargetstart;
+  assert_always(globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
+                globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
+  globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] = phixstargetstart;
   if (upperlevel_in >= 0) {  // file gives photoionisation to a single target state only
     int upperlevel = upperlevel_in - groundstate_index_in;
     assert_always(upperlevel >= 0);
-    assert_always(globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
-                  globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] == 1);
-    globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] = 1;
+    assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
+                  globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 1);
+    globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
     *mem_usage_phixs += sizeof(PhotoionTarget);
 
     if (single_level_top_ion && (upperion == get_nions(element) - 1)) {
@@ -112,7 +112,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     // read in a table of target states and probabilities and store them
     if (!single_level_top_ion || upperion < get_nions(element) - 1)  // in case the top ion has nlevelsmax = 1
     {
-      globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
+      globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
       *mem_usage_phixs += in_nphixstargets * sizeof(PhotoionTarget);
 
       double probability_sum = 0.;
@@ -132,7 +132,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
                  get_atomicnumber(element), get_ionstage(element, lowerion), probability_sum);
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
-      globals::alllevels_nphixstargets[lowerionlower_uniquelevelindex] = 1;
+      globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
       *mem_usage_phixs += sizeof(PhotoionTarget);
 
       for (int i = 0; i < in_nphixstargets; i++) {
@@ -153,7 +153,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
          phixstargetindex++) {
       const int upperlevel =
-          globals::allphixstargets[globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] +
+          globals::allphixstargets[globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] +
                                    phixstargetindex]
               .levelindex;
       if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
@@ -165,7 +165,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
   assert_always(tmpallphixs.size() % globals::NPHIXSPOINTS == 0);
   const auto tmpphixsstart = tmpallphixs.size();
-  globals::alllevels_phixsstart[lowerionlower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
+  globals::alllevels.phixsstart[lowerionlower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
   tmpallphixs.resize(tmpallphixs.size() + globals::NPHIXSPOINTS);
 
   auto *levelphixstable = &tmpallphixs[tmpphixsstart];
@@ -761,7 +761,7 @@ void setup_phixs_list() {
             const auto groundcontindex = search_groundphixslist(nu_edge_target0, element, ion, level);
             nonconstallcont[allcontindex].index_in_groundphixslist = groundcontindex;
 
-            globals::alllevels_closestgroundlevelcont[uniquelevelindex] = groundcontindex;
+            globals::alllevels.closestgroundlevelcont[uniquelevelindex] = groundcontindex;
           }
           allcontindex++;
         }
@@ -851,7 +851,7 @@ void read_phixs_data() {
       for (int level = 0; level < nlevels; level++) {
         const int nphixstargets = get_nphixstargets(element, ion, level);
         const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-        globals::alllevels_cont_index[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
+        globals::alllevels.cont_index[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
         cont_index += nphixstargets;
         if (nphixstargets > 0) {
           nbftables++;
@@ -1170,28 +1170,28 @@ void read_atomicdata_files() {
   }
 
   // create a shared level list and copy data across, freeing the local copy
-  globals::alllevels_alltrans_startdown = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_ndowntrans = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_nuptrans = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
-  globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
-  globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_phixsstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_nphixstargets = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_phixstargetstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
-  globals::alllevels_cont_index = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.alltrans_startdown = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.ndowntrans = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.nuptrans = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
+  globals::alllevels.statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
+  globals::alllevels.closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.phixsstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.nphixstargets = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.phixstargetstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels.cont_index = MPI_shared_malloc_span<int>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
-    std::ranges::fill(globals::alllevels_phixsstart, -1);
-    std::ranges::fill(globals::alllevels_nphixstargets, 0);
-    std::ranges::fill(globals::alllevels_phixstargetstart, -1);
-    std::ranges::fill(globals::alllevels_cont_index, -1);
-    std::ranges::fill(globals::alllevels_closestgroundlevelcont, -1);
+    std::ranges::fill(globals::alllevels.phixsstart, -1);
+    std::ranges::fill(globals::alllevels.nphixstargets, 0);
+    std::ranges::fill(globals::alllevels.phixstargetstart, -1);
+    std::ranges::fill(globals::alllevels.cont_index, -1);
+    std::ranges::fill(globals::alllevels.closestgroundlevelcont, -1);
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
-      globals::alllevels_alltrans_startdown[i] = temp_alllevels[i].alltrans_startdown;
-      globals::alllevels_ndowntrans[i] = temp_alllevels[i].ndowntrans;
-      globals::alllevels_nuptrans[i] = temp_alllevels[i].nuptrans;
-      globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
-      globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
+      globals::alllevels.alltrans_startdown[i] = temp_alllevels[i].alltrans_startdown;
+      globals::alllevels.ndowntrans[i] = temp_alllevels[i].ndowntrans;
+      globals::alllevels.nuptrans[i] = temp_alllevels[i].nuptrans;
+      globals::alllevels.epsilon[i] = temp_alllevels[i].epsilon;
+      globals::alllevels.statweight[i] = temp_alllevels[i].stat_weight;
     }
   }
   MPI_Barrier(globals::mpi_comm_node);

--- a/input.cc
+++ b/input.cc
@@ -332,7 +332,7 @@ constexpr auto downtranslevelstart(const int level) {
 
 void read_ion_levels(std::fstream &adata, const int element, const int ion, const int nions, const int nlevels,
                      int nlevelsmax, const double energyoffset, const double ionpot,
-                     std::vector<EnergyLevel> &temp_alllevels) {  // cppcheck-suppress constParameterReference
+                     std::vector<EnergyLevelInput> &temp_alllevels) {  // cppcheck-suppress constParameterReference
   for (int level = 0; level < nlevels; level++) {
     int levelindex_in = 0;
     double levelenergy{NAN};
@@ -459,7 +459,7 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion, cons
                                           std::vector<int> &iondowntranstmplineindicies, int &lineindex,
                                           std::vector<TransitionLine> &temp_linelist,
                                           std::vector<LevelTransition> &temp_alltranslist,
-                                          size_t &temp_alltranslist_size, EnergyLevel *ion_levels) {
+                                          size_t &temp_alltranslist_size, EnergyLevelInput *ion_levels) {
   const int lineindex_initial = lineindex;
   ptrdiff_t totupdowntrans = 0;
   // pass 0 to get transition counts of each level
@@ -922,7 +922,7 @@ void read_atomicdata_files() {
   std::vector<LevelTransition> temp_alltranslist;
   size_t temp_alltranslist_size = 0;  // keep size separate because the vector is only resized on rank_in_node == 0
 
-  std::vector<EnergyLevel> temp_alllevels;
+  std::vector<EnergyLevelInput> temp_alllevels;
 
   std::vector<Transition> iontransitiontable;
   std::vector<int> iondowntranstmplineindicies;
@@ -1170,8 +1170,17 @@ void read_atomicdata_files() {
   globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
-    std::ranges::copy(temp_alllevels, globals::alllevels.begin());
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
+      globals::alllevels[i] = {
+          .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
+          .ndowntrans = temp_alllevels[i].ndowntrans,
+          .nuptrans = temp_alllevels[i].nuptrans,
+          .phixsstart = temp_alllevels[i].phixsstart,
+          .nphixstargets = temp_alllevels[i].nphixstargets,
+          .phixstargetstart = temp_alllevels[i].phixstargetstart,
+          .cont_index = temp_alllevels[i].cont_index,
+          .closestgroundlevelcont = temp_alllevels[i].closestgroundlevelcont,
+      };
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
     }

--- a/input.cc
+++ b/input.cc
@@ -87,9 +87,10 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   std::string phixsline;
   auto *lowerion_levels = get_ion_levels(element, lowerion);
   const auto phixstargetstart = static_cast<int>(globals::allphixstargets.size());
-  assert_always(lowerion_levels[lowerlevel].phixstargetstart == -1 ||
-                lowerion_levels[lowerlevel].phixstargetstart == phixstargetstart);
-  lowerion_levels[lowerlevel].phixstargetstart = phixstargetstart;
+  const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
+  assert_always(globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
+                globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
+  globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] = phixstargetstart;
   if (upperlevel_in >= 0) {  // file gives photoionisation to a single target state only
     int upperlevel = upperlevel_in - groundstate_index_in;
     assert_always(upperlevel >= 0);
@@ -152,7 +153,9 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
          phixstargetindex++) {
       const int upperlevel =
-          globals::allphixstargets[lowerion_levels[lowerlevel].phixstargetstart + phixstargetindex].levelindex;
+          globals::allphixstargets[globals::alllevels_phixstargetstart[lowerionlower_uniquelevelindex] +
+                                   phixstargetindex]
+              .levelindex;
       if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
         globals::elements[element].ions[lowerion + 1].maxrecombininglevel = upperlevel;
       }
@@ -162,8 +165,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
   assert_always(tmpallphixs.size() % globals::NPHIXSPOINTS == 0);
   const auto tmpphixsstart = tmpallphixs.size();
-  const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
-  globals::alllevels_phixsstart[lower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
+  globals::alllevels_phixsstart[lowerionlower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
   tmpallphixs.resize(tmpallphixs.size() + globals::NPHIXSPOINTS);
 
   auto *levelphixstable = &tmpallphixs[tmpphixsstart];
@@ -355,7 +357,6 @@ void read_ion_levels(std::fstream &adata, const int element, const int ion, cons
           .phixsstart = -1,
           .nphixstargets = 0,
           .stat_weight = statweight,
-          .phixstargetstart = -1,
       });
 
       // The level contributes to the ionisinglevels if its energy
@@ -1174,17 +1175,18 @@ void read_atomicdata_files() {
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_phixsstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels_phixstargetstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_cont_index = MPI_shared_malloc_span<int>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
-    std::ranges::fill(globals::alllevels_cont_index, -1);
     std::ranges::fill(globals::alllevels_phixsstart, -1);
+    std::ranges::fill(globals::alllevels_phixstargetstart, -1);
+    std::ranges::fill(globals::alllevels_cont_index, -1);
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
       globals::alllevels[i] = {
           .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
           .ndowntrans = temp_alllevels[i].ndowntrans,
           .nuptrans = temp_alllevels[i].nuptrans,
           .nphixstargets = temp_alllevels[i].nphixstargets,
-          .phixstargetstart = temp_alllevels[i].phixstargetstart,
       };
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;

--- a/input.cc
+++ b/input.cc
@@ -1361,14 +1361,11 @@ void setup_cellcache() {
 
     if (allphixstargetcount > 0) {
       resize_exactly(globals::cellcache[cellcachenum].allphixstargets_corrphotoioncoeff, allphixstargetcount);
-      resize_exactly(globals::cellcache[cellcachenum].alpha_sp_E_integrals,
-                     allphixstargetcount * globals::NPHIXSPOINTS);
       if constexpr (SEPARATE_STIMRECOMB) {
         resize_exactly(globals::cellcache[cellcachenum].allphixstargets_stimrecombcoeff, allphixstargetcount);
       }
     }
-    mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + allphixstargetcount * sizeof(double) * 2 +
-                           allphixstargetcount * globals::NPHIXSPOINTS * sizeof(double);
+    mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + allphixstargetcount * sizeof(double) * 2;
 
     mem_usage_cellcache += chtransblocksize * sizeof(double);
     if (chtransblocksize > 0) {

--- a/input.cc
+++ b/input.cc
@@ -1136,7 +1136,7 @@ void read_atomicdata_files() {
   printout("total downtrans %d\n", totaldowntrans);
 
   printout("[info] mem_usage: transition lists occupy %.3f MB (shared on node)\n",
-           (totaluptrans + totaldowntrans) * sizeof(LevelTransition) / 1024. / 1024.);
+           (totaluptrans + totaldowntrans) * (2 * sizeof(int) + 3 * sizeof(float) + sizeof(bool)) / 1024. / 1024.);
 
   if (globals::rank_in_node == 0) {
     // sort the lineline in descending frequency
@@ -1246,24 +1246,25 @@ void read_atomicdata_files() {
     const int upperlevel = line.upperlevelindex;
 
     // there is never more than one transition per pair of levels,
-    // so find the first matching the upper and lower transition
+    // so find the first up and the first down transition that match: element, ion, lowerlevel, upperlevel
 
-    const int nupperdowntrans = get_ndowntrans(element, ion, upperlevel);
-    auto *downtranslist = get_downtranslist(element, ion, upperlevel);
-    auto *downtransition = std::find_if(downtranslist, downtranslist + nupperdowntrans, [=](const auto &downtrans) {
-      return downtrans.targetlevelindex == lowerlevel;
-    });
-    assert_always(downtransition != (downtranslist + nupperdowntrans));
-    // assert_always(downtrans->targetlevelindex == lowerlevel);
-    downtransition->lineindex = lineindex;
+    const auto upper_uniquelevelindex = get_uniquelevelindex(element, ion, upperlevel);
+    const auto downtransspan = std::span{globals::alltrans}.subspan(get_alltrans_startdown(upper_uniquelevelindex),
+                                                                    get_ndowntrans(upper_uniquelevelindex));
+    const auto downtrans = std::find_if(downtransspan.begin(), downtransspan.end(),
+                                        [=](const auto &trans) { return trans.targetlevelindex == lowerlevel; });
+    assert_always(downtrans != downtransspan.end());
+    const auto downtransid = static_cast<int>(std::distance(downtransspan.begin(), downtrans));
+    downtransspan[downtransid].lineindex = lineindex;
 
-    const int nloweruptrans = get_nuptrans(element, ion, lowerlevel);
-    auto *uptranslist = get_uptranslist(element, ion, lowerlevel);
-    auto *uptransition = std::find_if(uptranslist, uptranslist + nloweruptrans,
-                                      [=](const auto &uptr) { return uptr.targetlevelindex == upperlevel; });
-    assert_always(uptransition != (uptranslist + nloweruptrans));
-    // assert_always(uptrans->targetlevelindex == upperlevel);
-    uptransition->lineindex = lineindex;
+    const auto lower_uniquelevelindex = get_uniquelevelindex(element, ion, lowerlevel);
+    const auto uptransspan = std::span{globals::alltrans}.subspan(get_alltrans_startup(lower_uniquelevelindex),
+                                                                  get_nuptrans(lower_uniquelevelindex));
+    const auto &uptrans = std::find_if(uptransspan.begin(), uptransspan.end(),
+                                       [=](const auto &trans) { return trans.targetlevelindex == upperlevel; });
+    assert_always(uptrans != uptransspan.end());
+    const auto uptransid = static_cast<int>(std::distance(uptransspan.begin(), uptrans));
+    uptransspan[uptransid].lineindex = lineindex;
   }
 
   printout("  took %lds\n", std::time(nullptr) - time_start_establish_linelist_connections);

--- a/input.cc
+++ b/input.cc
@@ -85,7 +85,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
                            const int lowerion, const int lowerlevel, const int upperion, int upperlevel_in,
                            std::vector<float> &tmpallphixs, size_t *mem_usage_phixs, const int phixs_file_version) {
   std::string phixsline;
-  const auto phixstargetstart = static_cast<int>(globals::allphixstargets.size());
+  const auto phixstargetstart = static_cast<int>(globals::allphixstargets_probability.size());
   const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
   assert_always(globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
                 globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
@@ -96,14 +96,15 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
                   globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 1);
     globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
-    *mem_usage_phixs += sizeof(PhotoionTarget);
+    *mem_usage_phixs += sizeof(double) + sizeof(int);
 
     if (single_level_top_ion && (upperion == get_nions(element) - 1)) {
       // top ion has only one level, so send it to that level
       upperlevel = 0;
     }
 
-    globals::allphixstargets.push_back({.probability = 1., .levelindex = upperlevel});
+    globals::allphixstargets_probability.push_back(1.);
+    globals::allphixstargets_levelindex.push_back(upperlevel);
   } else {  // upperlevel < 0, indicating that a table of upper levels and their probabilities will follow
     int in_nphixstargets = 0;
     assert_always(get_noncommentline(phixsfile, phixsline));
@@ -113,7 +114,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     if (!single_level_top_ion || upperion < get_nions(element) - 1)  // in case the top ion has nlevelsmax = 1
     {
       globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
-      *mem_usage_phixs += in_nphixstargets * sizeof(PhotoionTarget);
+      *mem_usage_phixs += in_nphixstargets * sizeof(double) + sizeof(int);
 
       double probability_sum = 0.;
       for (int i = 0; i < in_nphixstargets; i++) {
@@ -123,7 +124,8 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
         const int upperlevel = upperlevel_in - groundstate_index_in;
         assert_always(upperlevel >= 0);
         assert_always(phixstargetprobability > 0);
-        globals::allphixstargets.push_back({.probability = phixstargetprobability, .levelindex = upperlevel});
+        globals::allphixstargets_probability.push_back(phixstargetprobability);
+        globals::allphixstargets_levelindex.push_back(upperlevel);
 
         probability_sum += phixstargetprobability;
       }
@@ -133,14 +135,15 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
       globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
-      *mem_usage_phixs += sizeof(PhotoionTarget);
+      *mem_usage_phixs += sizeof(double) + sizeof(int);
 
       for (int i = 0; i < in_nphixstargets; i++) {
         assert_always(get_noncommentline(phixsfile, phixsline));
       }
 
       // send it to the ground state of the top ion
-      globals::allphixstargets.push_back({.probability = 1., .levelindex = 0});
+      globals::allphixstargets_probability.push_back(1.);
+      globals::allphixstargets_levelindex.push_back(0);
     }
   }
 
@@ -153,9 +156,8 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
          phixstargetindex++) {
       const int upperlevel =
-          globals::allphixstargets[globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] +
-                                   phixstargetindex]
-              .levelindex;
+          globals::allphixstargets_levelindex[globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] +
+                                              phixstargetindex];
       if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
         globals::elements[element].ions[lowerion + 1].maxrecombininglevel = upperlevel;
       }
@@ -820,7 +822,8 @@ void read_phixs_data() {
   globals::nbfcontinua_ground = 0;
   globals::nbfcontinua = 0;
   std::vector<float> tmpallphixs;
-  globals::allphixstargets.clear();
+  globals::allphixstargets_probability.clear();
+  globals::allphixstargets_levelindex.clear();
 
   // read in photoionisation cross sections
   phixs_file_version_exists[0] = false;
@@ -899,8 +902,9 @@ void read_phixs_data() {
     tmpallphixs.shrink_to_fit();
   }
 
-  globals::allphixstargets.shrink_to_fit();
-  assert_always(cont_index == std::ssize(globals::allphixstargets));
+  globals::allphixstargets_probability.shrink_to_fit();
+  globals::allphixstargets_levelindex.shrink_to_fit();
+  assert_always(cont_index == std::ssize(globals::allphixstargets_probability));
 
   setup_phixs_list();
 }

--- a/input.cc
+++ b/input.cc
@@ -1348,7 +1348,7 @@ void setup_cellcache() {
 
         for (int level = 0; level < nlevels; level++) {
           const int nphixstargets = get_nphixstargets(element, ion, level);
-          chphixsblocksize += nphixstargets * sizeof(CellCachePhixsTargets);
+          chphixsblocksize += nphixstargets * sizeof(double) * 2;
 
           const int ndowntrans = get_ndowntrans(element, ion, level);
           const int nuptrans = get_nuptrans(element, ion, level);
@@ -1360,7 +1360,10 @@ void setup_cellcache() {
     resize_exactly(globals::cellcache[cellcachenum].ch_all_levels, chlevelcount);
 
     if (chphixsblocksize > 0) {
-      resize_exactly(globals::cellcache[cellcachenum].challphixstargets, chphixsblocksize);
+      resize_exactly(globals::cellcache[cellcachenum].allphixstargets_corrphotoioncoeff, chphixsblocksize);
+      if constexpr (SEPARATE_STIMRECOMB) {
+        resize_exactly(globals::cellcache[cellcachenum].allphixstargets_stimrecombcoeff, chphixsblocksize);
+      }
     }
     mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + chphixsblocksize;
 

--- a/input.cc
+++ b/input.cc
@@ -882,16 +882,16 @@ void read_phixs_data() {
     globals::allphixstargets_levelindex = MPI_shared_malloc_span<int>(tmpallphixstargets.size());
     globals::allphixstargets_probability = MPI_shared_malloc_span<double>(tmpallphixstargets.size());
 
-    MPI_Barrier(globals::mpi_comm_node);
+    if (globals::rank_in_node == 0) {
+      std::copy_n(tmpallphixs.cbegin(), tmpallphixs.size(), globals::allphixs.data());
 
-    std::copy_n(tmpallphixs.cbegin(), tmpallphixs.size(), globals::allphixs.data());
-
-    for (int i = 0; i < std::ssize(tmpallphixstargets); i++) {
-      globals::allphixstargets_levelindex[i] = tmpallphixstargets[i].levelindex;
-      globals::allphixstargets_probability[i] = tmpallphixstargets[i].probability;
+      for (int i = 0; i < std::ssize(tmpallphixstargets); i++) {
+        globals::allphixstargets_levelindex[i] = tmpallphixstargets[i].levelindex;
+        globals::allphixstargets_probability[i] = tmpallphixstargets[i].probability;
+      }
     }
 
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(globals::mpi_comm_node);
 
     tmpallphixs.clear();
     tmpallphixs.shrink_to_fit();

--- a/input.cc
+++ b/input.cc
@@ -760,7 +760,7 @@ void setup_phixs_list() {
             const auto groundcontindex = search_groundphixslist(nu_edge_target0, element, ion, level);
             nonconstallcont[allcontindex].index_in_groundphixslist = groundcontindex;
 
-            get_ion_levels(element, ion)[level].closestgroundlevelcont = groundcontindex;
+            globals::alllevels_closestgroundlevelcont[get_uniquelevelindex(element, ion, level)] = groundcontindex;
           }
           allcontindex++;
         }
@@ -1169,6 +1169,7 @@ void read_atomicdata_files() {
   globals::alllevels = MPI_shared_malloc_span<EnergyLevel>(temp_alllevels.size());
   globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
+  globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
       globals::alllevels[i] = {
@@ -1179,10 +1180,10 @@ void read_atomicdata_files() {
           .nphixstargets = temp_alllevels[i].nphixstargets,
           .phixstargetstart = temp_alllevels[i].phixstargetstart,
           .cont_index = temp_alllevels[i].cont_index,
-          .closestgroundlevelcont = temp_alllevels[i].closestgroundlevelcont,
       };
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
+      globals::alllevels_closestgroundlevelcont[i] = temp_alllevels[i].closestgroundlevelcont;
     }
   }
   MPI_Barrier(globals::mpi_comm_node);

--- a/input.cc
+++ b/input.cc
@@ -1249,22 +1249,30 @@ void read_atomicdata_files() {
     // so find the first up and the first down transition that match: element, ion, lowerlevel, upperlevel
 
     const auto upper_uniquelevelindex = get_uniquelevelindex(element, ion, upperlevel);
-    const auto downtransspan = std::span{globals::alltrans}.subspan(get_alltrans_startdown(upper_uniquelevelindex),
-                                                                    get_ndowntrans(upper_uniquelevelindex));
-    const auto downtrans = std::find_if(downtransspan.begin(), downtransspan.end(),
-                                        [=](const auto &trans) { return trans.targetlevelindex == lowerlevel; });
-    assert_always(downtrans != downtransspan.end());
-    const auto downtransid = static_cast<int>(std::distance(downtransspan.begin(), downtrans));
-    downtransspan[downtransid].lineindex = lineindex;
+    const auto alltrans_startdown = get_alltrans_startdown(upper_uniquelevelindex);
+    const auto ndowntrans = get_ndowntrans(upper_uniquelevelindex);
+    int downtransid = -1;
+    for (int i = alltrans_startdown; i < alltrans_startdown + ndowntrans; i++) {
+      if (globals::alltrans[i].targetlevelindex == lowerlevel) {
+        downtransid = i;
+        break;
+      }
+    }
+    assert_always(downtransid != -1);
+    globals::alltrans[downtransid].lineindex = lineindex;
 
     const auto lower_uniquelevelindex = get_uniquelevelindex(element, ion, lowerlevel);
-    const auto uptransspan = std::span{globals::alltrans}.subspan(get_alltrans_startup(lower_uniquelevelindex),
-                                                                  get_nuptrans(lower_uniquelevelindex));
-    const auto &uptrans = std::find_if(uptransspan.begin(), uptransspan.end(),
-                                       [=](const auto &trans) { return trans.targetlevelindex == upperlevel; });
-    assert_always(uptrans != uptransspan.end());
-    const auto uptransid = static_cast<int>(std::distance(uptransspan.begin(), uptrans));
-    uptransspan[uptransid].lineindex = lineindex;
+    const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
+    const auto nuptrans = get_nuptrans(lower_uniquelevelindex);
+    int uptransid = -1;
+    for (int i = alltrans_startup; i < alltrans_startup + nuptrans; i++) {
+      if (globals::alltrans[i].targetlevelindex == upperlevel) {
+        uptransid = i;
+        break;
+      }
+    }
+    assert_always(uptransid != -1);
+    globals::alltrans[uptransid].lineindex = lineindex;
   }
 
   printout("  took %lds\n", std::time(nullptr) - time_start_establish_linelist_connections);

--- a/input.cc
+++ b/input.cc
@@ -1167,8 +1167,14 @@ void read_atomicdata_files() {
 
   // create a shared level list and copy data across, freeing the local copy
   globals::alllevels = MPI_shared_malloc_span<EnergyLevel>(temp_alllevels.size());
+  globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
+  globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     std::ranges::copy(temp_alllevels, globals::alllevels.begin());
+    for (size_t i = 0; i < temp_alllevels.size(); i++) {
+      globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
+      globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
+    }
   }
   MPI_Barrier(globals::mpi_comm_node);
   temp_alllevels.clear();

--- a/input.cc
+++ b/input.cc
@@ -162,7 +162,8 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
   assert_always(tmpallphixs.size() % globals::NPHIXSPOINTS == 0);
   const auto tmpphixsstart = tmpallphixs.size();
-  lowerion_levels[lowerlevel].phixsstart = tmpphixsstart / globals::NPHIXSPOINTS;
+  const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
+  globals::alllevels_phixsstart[lower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
   tmpallphixs.resize(tmpallphixs.size() + globals::NPHIXSPOINTS);
 
   auto *levelphixstable = &tmpallphixs[tmpphixsstart];
@@ -1170,13 +1171,13 @@ void read_atomicdata_files() {
   globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels_phixsstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
       globals::alllevels[i] = {
           .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
           .ndowntrans = temp_alllevels[i].ndowntrans,
           .nuptrans = temp_alllevels[i].nuptrans,
-          .phixsstart = temp_alllevels[i].phixsstart,
           .nphixstargets = temp_alllevels[i].nphixstargets,
           .phixstargetstart = temp_alllevels[i].phixstargetstart,
           .cont_index = temp_alllevels[i].cont_index,
@@ -1184,6 +1185,7 @@ void read_atomicdata_files() {
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
       globals::alllevels_closestgroundlevelcont[i] = temp_alllevels[i].closestgroundlevelcont;
+      globals::alllevels_phixsstart[i] = temp_alllevels[i].phixsstart;
     }
   }
   MPI_Barrier(globals::mpi_comm_node);

--- a/input.cc
+++ b/input.cc
@@ -1168,7 +1168,7 @@ void read_atomicdata_files() {
   // create a shared level list and copy data across, freeing the local copy
   globals::alllevels = MPI_shared_malloc_span<EnergyLevel>(temp_alllevels.size());
   globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
-  globals::alllevels_statweight = MPI_shared_malloc_span<double>(temp_alllevels.size());
+  globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     std::ranges::copy(temp_alllevels, globals::alllevels.begin());
     for (size_t i = 0; i < temp_alllevels.size(); i++) {

--- a/input.cc
+++ b/input.cc
@@ -1555,7 +1555,7 @@ void input(int rank) {
 
   // Read in parameters from vpkt.txt
   if (VPKT_ON) {
-    read_parameterfile_vpkt();
+    vpkt::read_vpktparameterfile();
   }
 
   read_atomicdata();
@@ -1851,7 +1851,7 @@ void update_parameterfile(const int nts) {
 }
 
 // initialise the time steps
-void time_init() {
+void setup_timesteps() {
   // t=globals::tmin is the start of the calculation. t=globals::tmax is the end of the calculation.
   // globals::ntimesteps is the number of time steps
 

--- a/input.cc
+++ b/input.cc
@@ -147,23 +147,6 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     }
   }
 
-  // The level contributes to the ionisinglevels if its energy
-  // is below the ionisation potential and the level doesn't
-  // belong to the topmost ion included.
-  // Rate coefficients are only available for ionising levels.
-  //  also need (levelenergy < ionpot && ...)?
-  if (lowerion < get_nions(element) - 1) {
-    for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
-         phixstargetindex++) {
-      const int upperlevel =
-          globals::allphixstargets_levelindex[globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] +
-                                              phixstargetindex];
-      if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
-        globals::elements[element].ions[lowerion + 1].maxrecombininglevel = upperlevel;
-      }
-    }
-  }
-
   *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
   assert_always(tmpallphixs.size() % globals::NPHIXSPOINTS == 0);
   const auto tmpphixsstart = tmpallphixs.size();
@@ -219,6 +202,23 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
       // the photoionisation cross-sections in the database are given in Mbarn = 1e6 * 1e-28m^2
       // to convert to cgs units multiply by 1e-18
       levelphixstable[i] = phixs * 1e-18;
+    }
+  }
+
+  // The level contributes to the ionisinglevels if its energy
+  // is below the ionisation potential and the level doesn't
+  // belong to the topmost ion included.
+  // Rate coefficients are only available for ionising levels.
+  //  also need (levelenergy < ionpot && ...)?
+  if (lowerion < get_nions(element) - 1) {
+    for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
+         phixstargetindex++) {
+      const int upperlevel =
+          globals::allphixstargets_levelindex[globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] +
+                                              phixstargetindex];
+      if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
+        globals::elements[element].ions[lowerion + 1].maxrecombininglevel = upperlevel;
+      }
     }
   }
 

--- a/input.cc
+++ b/input.cc
@@ -1361,11 +1361,14 @@ void setup_cellcache() {
 
     if (allphixstargetcount > 0) {
       resize_exactly(globals::cellcache[cellcachenum].allphixstargets_corrphotoioncoeff, allphixstargetcount);
+      resize_exactly(globals::cellcache[cellcachenum].alpha_sp_E_integrals,
+                     allphixstargetcount * globals::NPHIXSPOINTS);
       if constexpr (SEPARATE_STIMRECOMB) {
         resize_exactly(globals::cellcache[cellcachenum].allphixstargets_stimrecombcoeff, allphixstargetcount);
       }
     }
-    mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + allphixstargetcount * sizeof(double) * 2;
+    mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + allphixstargetcount * sizeof(double) * 2 +
+                           allphixstargetcount * globals::NPHIXSPOINTS * sizeof(double);
 
     mem_usage_cellcache += chtransblocksize * sizeof(double);
     if (chtransblocksize > 0) {

--- a/input.cc
+++ b/input.cc
@@ -354,7 +354,6 @@ void read_ion_levels(std::fstream &adata, const int element, const int ion, cons
           .epsilon = currentlevelenergy,
           .ndowntrans = 0,
           .nuptrans = 0,
-          .phixsstart = -1,
           .nphixstargets = 0,
           .stat_weight = statweight,
       });

--- a/input.cc
+++ b/input.cc
@@ -1205,10 +1205,23 @@ void read_atomicdata_files() {
   // create a shared all transitions list and then copy data across, freeing the local copy
   MPI_Barrier(globals::mpi_comm_node);
 
-  globals::alltrans = MPI_shared_malloc_span<LevelTransition>(totupdowntrans);
+  globals::alltrans.lineindex = MPI_shared_malloc_span<int>(totupdowntrans);
+  globals::alltrans.targetlevelindex = MPI_shared_malloc_span<int>(totupdowntrans);
+  globals::alltrans.einstein_A = MPI_shared_malloc_span<float>(totupdowntrans);
+  globals::alltrans.coll_str = MPI_shared_malloc_span<float>(totupdowntrans);
+  globals::alltrans.osc_strength = MPI_shared_malloc_span<float>(totupdowntrans);
+  globals::alltrans.forbidden = MPI_shared_malloc_span<bool>(totupdowntrans);
+
   if (globals::rank_in_node == 0) {
     assert_always(std::ssize(temp_alltranslist) == totupdowntrans);
-    std::ranges::copy(temp_alltranslist, globals::alltrans.data());
+    for (int t = 0; t < totupdowntrans; t++) {
+      globals::alltrans.lineindex[t] = temp_alltranslist[t].lineindex;
+      globals::alltrans.targetlevelindex[t] = temp_alltranslist[t].targetlevelindex;
+      globals::alltrans.einstein_A[t] = temp_alltranslist[t].einstein_A;
+      globals::alltrans.coll_str[t] = temp_alltranslist[t].coll_str;
+      globals::alltrans.osc_strength[t] = temp_alltranslist[t].osc_strength;
+      globals::alltrans.forbidden[t] = temp_alltranslist[t].forbidden;
+    }
   }
   temp_alltranslist.clear();
   temp_alltranslist.shrink_to_fit();
@@ -1253,26 +1266,26 @@ void read_atomicdata_files() {
     const auto ndowntrans = get_ndowntrans(upper_uniquelevelindex);
     int downtransid = -1;
     for (int i = alltrans_startdown; i < alltrans_startdown + ndowntrans; i++) {
-      if (globals::alltrans[i].targetlevelindex == lowerlevel) {
+      if (globals::alltrans.targetlevelindex[i] == lowerlevel) {
         downtransid = i;
         break;
       }
     }
     assert_always(downtransid != -1);
-    globals::alltrans[downtransid].lineindex = lineindex;
+    globals::alltrans.lineindex[downtransid] = lineindex;
 
     const auto lower_uniquelevelindex = get_uniquelevelindex(element, ion, lowerlevel);
     const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
     const auto nuptrans = get_nuptrans(lower_uniquelevelindex);
     int uptransid = -1;
     for (int i = alltrans_startup; i < alltrans_startup + nuptrans; i++) {
-      if (globals::alltrans[i].targetlevelindex == upperlevel) {
+      if (globals::alltrans.targetlevelindex[i] == upperlevel) {
         uptransid = i;
         break;
       }
     }
     assert_always(uptransid != -1);
-    globals::alltrans[uptransid].lineindex = lineindex;
+    globals::alltrans.lineindex[uptransid] = lineindex;
   }
 
   printout("  took %lds\n", std::time(nullptr) - time_start_establish_linelist_connections);

--- a/input.cc
+++ b/input.cc
@@ -850,7 +850,8 @@ void read_phixs_data() {
       const int nlevels = get_nlevels(element, ion);
       for (int level = 0; level < nlevels; level++) {
         const int nphixstargets = get_nphixstargets(element, ion, level);
-        get_ion_levels(element, ion)[level].cont_index = (nphixstargets > 0) ? cont_index : -1;
+        const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+        globals::alllevels_cont_index[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
         cont_index += nphixstargets;
         if (nphixstargets > 0) {
           nbftables++;
@@ -1172,7 +1173,10 @@ void read_atomicdata_files() {
   globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   globals::alllevels_closestgroundlevelcont = MPI_shared_malloc_span<int>(temp_alllevels.size());
   globals::alllevels_phixsstart = MPI_shared_malloc_span<int>(temp_alllevels.size());
+  globals::alllevels_cont_index = MPI_shared_malloc_span<int>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
+    std::ranges::fill(globals::alllevels_cont_index, -1);
+    std::ranges::fill(globals::alllevels_phixsstart, -1);
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
       globals::alllevels[i] = {
           .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
@@ -1180,12 +1184,10 @@ void read_atomicdata_files() {
           .nuptrans = temp_alllevels[i].nuptrans,
           .nphixstargets = temp_alllevels[i].nphixstargets,
           .phixstargetstart = temp_alllevels[i].phixstargetstart,
-          .cont_index = temp_alllevels[i].cont_index,
       };
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
       globals::alllevels_closestgroundlevelcont[i] = temp_alllevels[i].closestgroundlevelcont;
-      globals::alllevels_phixsstart[i] = temp_alllevels[i].phixsstart;
     }
   }
   MPI_Barrier(globals::mpi_comm_node);

--- a/input.cc
+++ b/input.cc
@@ -1335,7 +1335,7 @@ void setup_cellcache() {
     resize_exactly(globals::cellcache[cellcachenum].ch_all_levels, chlevelcount);
 
     if (chphixsblocksize > 0) {
-      resize_exactly(globals::cellcache[cellcachenum].chphixstargetsblock, chphixsblocksize);
+      resize_exactly(globals::cellcache[cellcachenum].challphixstargets, chphixsblocksize);
     }
     mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + chphixsblocksize;
 
@@ -1364,8 +1364,7 @@ void setup_cellcache() {
           const int allphixstargetindex =
               globals::alllevels.phixstargetstart[get_uniquelevelindex(element, ion, level)];
           chion.chlevels[level].chphixstargets =
-              chphixsblocksize > 0 ? &globals::cellcache[cellcachenum].chphixstargetsblock[allphixstargetindex]
-                                   : nullptr;
+              chphixsblocksize > 0 ? &globals::cellcache[cellcachenum].challphixstargets[allphixstargetindex] : nullptr;
         }
 
         for (int level = 0; level < nlevels; level++) {

--- a/input.cc
+++ b/input.cc
@@ -1168,7 +1168,7 @@ void read_atomicdata_files() {
   // create a shared level list and copy data across, freeing the local copy
   globals::alllevels = MPI_shared_malloc_span<EnergyLevel>(temp_alllevels.size());
   globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
-  globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
+  globals::alllevels_statweight = MPI_shared_malloc_span<double>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     std::ranges::copy(temp_alllevels, globals::alllevels.begin());
     for (size_t i = 0; i < temp_alllevels.size(); i++) {

--- a/input.cc
+++ b/input.cc
@@ -1338,7 +1338,7 @@ void setup_cellcache() {
     assert_always(globals::cellcache[cellcachenum].chelements != nullptr);
 
     ptrdiff_t chlevelcount = 0;
-    size_t chphixsblocksize = 0;
+    size_t allphixstargetcount = 0;
     int chtransblocksize = 0;
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);
@@ -1348,7 +1348,7 @@ void setup_cellcache() {
 
         for (int level = 0; level < nlevels; level++) {
           const int nphixstargets = get_nphixstargets(element, ion, level);
-          chphixsblocksize += nphixstargets * sizeof(double) * 2;
+          allphixstargetcount += nphixstargets * sizeof(double);
 
           const int ndowntrans = get_ndowntrans(element, ion, level);
           const int nuptrans = get_nuptrans(element, ion, level);
@@ -1359,13 +1359,13 @@ void setup_cellcache() {
     assert_always(chlevelcount > 0);
     resize_exactly(globals::cellcache[cellcachenum].ch_all_levels, chlevelcount);
 
-    if (chphixsblocksize > 0) {
-      resize_exactly(globals::cellcache[cellcachenum].allphixstargets_corrphotoioncoeff, chphixsblocksize);
+    if (allphixstargetcount > 0) {
+      resize_exactly(globals::cellcache[cellcachenum].allphixstargets_corrphotoioncoeff, allphixstargetcount);
       if constexpr (SEPARATE_STIMRECOMB) {
-        resize_exactly(globals::cellcache[cellcachenum].allphixstargets_stimrecombcoeff, chphixsblocksize);
+        resize_exactly(globals::cellcache[cellcachenum].allphixstargets_stimrecombcoeff, allphixstargetcount);
       }
     }
-    mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + chphixsblocksize;
+    mem_usage_cellcache += chlevelcount * sizeof(CellCacheLevels) + allphixstargetcount * sizeof(double) * 2;
 
     mem_usage_cellcache += chtransblocksize * sizeof(double);
     if (chtransblocksize > 0) {

--- a/input.cc
+++ b/input.cc
@@ -44,13 +44,21 @@ namespace {
 
 const int groundstate_index_in = 1;  // starting level index in the input files
 
+// only used temporarily during input
 struct Transition {
   int lower;
   int upper;
   float A;
   float coll_str;
   bool forbidden;
-};  // only used temporarily during input
+};
+
+// only used temporarily during input before copy to node-shared globals::allphixstargets_levelindex and
+// allphixstargets_probability
+struct PhotoionTarget {
+  double probability;  // fraction of phixs cross section leading to this final level
+  int levelindex;  // index of upper ion level after photoionisation
+};
 
 constexpr std::array<std::string_view, 24> inputlinecomments = {
     " 0: pre_zseed: specific random number seed if > 0 or random if negative",
@@ -83,9 +91,10 @@ constexpr std::array<std::string_view, 24> inputlinecomments = {
 
 void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_inputtable, const int element,
                            const int lowerion, const int lowerlevel, const int upperion, int upperlevel_in,
-                           std::vector<float> &tmpallphixs, size_t *mem_usage_phixs, const int phixs_file_version) {
+                           std::vector<float> &tmpallphixs, std::vector<PhotoionTarget> &tmpallphixstargets,
+                           size_t *mem_usage_phixs, const int phixs_file_version) {
   std::string phixsline;
-  const auto phixstargetstart = static_cast<int>(globals::allphixstargets_probability.size());
+  const auto phixstargetstart = static_cast<int>(tmpallphixstargets.size());
   const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
   assert_always(globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
                 globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
@@ -102,8 +111,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
       upperlevel = 0;
     }
 
-    globals::allphixstargets_probability.push_back(1.);
-    globals::allphixstargets_levelindex.push_back(upperlevel);
+    tmpallphixstargets.push_back({.probability = 1., .levelindex = upperlevel});
   } else {  // upperlevel < 0, indicating that a table of upper levels and their probabilities will follow
     int in_nphixstargets = 0;
     assert_always(get_noncommentline(phixsfile, phixsline));
@@ -124,8 +132,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
         const int upperlevel = upperlevel_in - groundstate_index_in;
         assert_always(upperlevel >= 0);
         assert_always(phixstargetprobability > 0);
-        globals::allphixstargets_probability.push_back(phixstargetprobability);
-        globals::allphixstargets_levelindex.push_back(upperlevel);
+        tmpallphixstargets.push_back({.probability = phixstargetprobability, .levelindex = upperlevel});
 
         probability_sum += phixstargetprobability;
       }
@@ -141,8 +148,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
       }
 
       // send it to the ground state of the top ion
-      globals::allphixstargets_probability.push_back(1.);
-      globals::allphixstargets_levelindex.push_back(0);
+      tmpallphixstargets.push_back({.probability = 1., .levelindex = 0});
     }
   }
 
@@ -154,7 +160,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   const auto levelphixstable = std::span{tmpallphixs}.subspan(tmpphixsstart, globals::NPHIXSPOINTS);
   if (phixs_file_version == 1) {
     assert_always(get_nphixstargets(element, lowerion, lowerlevel) == 1);
-    assert_always(get_phixsupperlevel(element, lowerion, lowerlevel, 0) == 0);
+    assert_always(tmpallphixstargets[get_allphixstargetindex(lowerionlower_uniquelevelindex, 0)].levelindex == 0);
 
     const double nu_edge = (epsilon(element, upperion, 0) - epsilon(element, lowerion, lowerlevel)) / H;
 
@@ -212,8 +218,7 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
          phixstargetindex++) {
       const int upperlevel =
-          globals::allphixstargets_levelindex[globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] +
-                                              phixstargetindex];
+          tmpallphixstargets[get_allphixstargetindex(lowerionlower_uniquelevelindex, phixstargetindex)].levelindex;
       if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
         globals::elements[element].ions[lowerion + 1].maxrecombininglevel = upperlevel;
       }
@@ -228,7 +233,8 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
   }
 }
 
-void read_phixs_file(const int phixs_file_version, std::vector<float> &tmpallphixs) {
+void read_phixs_file(const int phixs_file_version, std::vector<float> &tmpallphixs,
+                     std::vector<PhotoionTarget> &tmpallphixstargets) {
   size_t mem_usage_phixs = 0;
 
   printout("readin phixs data from %s\n", phixsdata_filenames[phixs_file_version]);
@@ -296,7 +302,7 @@ void read_phixs_file(const int phixs_file_version, std::vector<float> &tmpallphi
       // store only photoionization crosssections for ions that are part of the current model atom
       if (lowerion >= 0 && upperion < get_nions(element) && lowerlevel < get_nlevels_ionising(element, lowerion)) {
         read_phixs_data_table(phixsfile, nphixspoints_inputtable, element, lowerion, lowerlevel, upperion,
-                              upperlevel_in, tmpallphixs, &mem_usage_phixs, phixs_file_version);
+                              upperlevel_in, tmpallphixs, tmpallphixstargets, &mem_usage_phixs, phixs_file_version);
 
         skip_this_phixs_table = false;
       }
@@ -822,8 +828,7 @@ void read_phixs_data() {
   globals::nbfcontinua_ground = 0;
   globals::nbfcontinua = 0;
   std::vector<float> tmpallphixs;
-  globals::allphixstargets_probability.clear();
-  globals::allphixstargets_levelindex.clear();
+  std::vector<PhotoionTarget> tmpallphixstargets;
 
   // read in photoionisation cross sections
   phixs_file_version_exists[0] = false;
@@ -838,11 +843,15 @@ void read_phixs_data() {
         "Reading two phixs files: Reading phixsdata_v2.txt first so we use NPHIXSPOINTS and NPHIXSNUINCREMENT "
         "from phixsdata_v2.txt to interpolate the phixsdata.txt data\n");
   }
+
   if (phixs_file_version_exists[2]) {
-    read_phixs_file(2, tmpallphixs);
+    read_phixs_file(2, tmpallphixs, tmpallphixstargets);
+    MPI_Barrier(globals::mpi_comm_node);
   }
+
   if (phixs_file_version_exists[1]) {
-    read_phixs_file(1, tmpallphixs);
+    read_phixs_file(1, tmpallphixs, tmpallphixstargets);
+    MPI_Barrier(globals::mpi_comm_node);
   }
 
   int cont_index = 0;
@@ -860,7 +869,40 @@ void read_phixs_data() {
           nbftables++;
         }
       }
+    }
+  }
+  printout("cont_index %d\n", cont_index);
+  assert_always(cont_index == std::ssize(tmpallphixstargets));
 
+  if (!tmpallphixs.empty()) {
+    assert_always((nbftables * globals::NPHIXSPOINTS) == std::ssize(tmpallphixs));
+
+    // copy the photoionisation tables into one contiguous block of memory
+    globals::allphixs = MPI_shared_malloc_span<float>(tmpallphixs.size());
+    globals::allphixstargets_levelindex = MPI_shared_malloc_span<int>(tmpallphixstargets.size());
+    globals::allphixstargets_probability = MPI_shared_malloc_span<double>(tmpallphixstargets.size());
+
+    MPI_Barrier(globals::mpi_comm_node);
+
+    std::copy_n(tmpallphixs.cbegin(), tmpallphixs.size(), globals::allphixs.data());
+
+    for (int i = 0; i < std::ssize(tmpallphixstargets); i++) {
+      globals::allphixstargets_levelindex[i] = tmpallphixstargets[i].levelindex;
+      globals::allphixstargets_probability[i] = tmpallphixstargets[i].probability;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    tmpallphixs.clear();
+    tmpallphixs.shrink_to_fit();
+
+    tmpallphixstargets.clear();
+    tmpallphixstargets.shrink_to_fit();
+  }
+
+  for (int element = 0; element < get_nelements(); element++) {
+    const int nions = get_nions(element);
+    for (int ion = 0; ion < nions; ion++) {
       // below is just an extra warning consistency check
       const int nlevels_groundterm = globals::elements[element].ions[ion].nlevels_groundterm;
 
@@ -883,28 +925,6 @@ void read_phixs_data() {
       }
     }
   }
-
-  printout("cont_index %d\n", cont_index);
-
-  if (!tmpallphixs.empty()) {
-    assert_always((nbftables * globals::NPHIXSPOINTS) == std::ssize(tmpallphixs));
-
-    // copy the photoionisation tables into one contiguous block of memory
-    globals::allphixs = MPI_shared_malloc_span<float>(tmpallphixs.size());
-
-    assert_always(globals::allphixs.data() != nullptr);
-
-    std::copy_n(tmpallphixs.cbegin(), tmpallphixs.size(), globals::allphixs.data());
-
-    MPI_Barrier(MPI_COMM_WORLD);
-
-    tmpallphixs.clear();
-    tmpallphixs.shrink_to_fit();
-  }
-
-  globals::allphixstargets_probability.shrink_to_fit();
-  globals::allphixstargets_levelindex.shrink_to_fit();
-  assert_always(cont_index == std::ssize(globals::allphixstargets_probability));
 
   setup_phixs_list();
 }

--- a/input.cc
+++ b/input.cc
@@ -1361,13 +1361,6 @@ void setup_cellcache() {
         alllevelindex += nlevels;
 
         for (int level = 0; level < nlevels; level++) {
-          const int allphixstargetindex =
-              globals::alllevels.phixstargetstart[get_uniquelevelindex(element, ion, level)];
-          chion.chlevels[level].chphixstargets =
-              chphixsblocksize > 0 ? &globals::cellcache[cellcachenum].challphixstargets[allphixstargetindex] : nullptr;
-        }
-
-        for (int level = 0; level < nlevels; level++) {
           const int ndowntrans = get_ndowntrans(element, ion, level);
           chion.chlevels[level].sum_epstrans_rad_deexc =
               globals::cellcache[cellcachenum].chtransblock.data() + chtransindex;

--- a/input.cc
+++ b/input.cc
@@ -113,6 +113,8 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     // read in a table of target states and probabilities and store them
     if (!single_level_top_ion || upperion < get_nions(element) - 1)  // in case the top ion has nlevelsmax = 1
     {
+      assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
+                    globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == in_nphixstargets);
       globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
       *mem_usage_phixs += in_nphixstargets * sizeof(double) + sizeof(int);
 

--- a/input.cc
+++ b/input.cc
@@ -96,7 +96,6 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
                   globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 1);
     globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
-    *mem_usage_phixs += sizeof(double) + sizeof(int);
 
     if (single_level_top_ion && (upperion == get_nions(element) - 1)) {
       // top ion has only one level, so send it to that level
@@ -116,7 +115,6 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
       assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
                     globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == in_nphixstargets);
       globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
-      *mem_usage_phixs += in_nphixstargets * sizeof(double) + sizeof(int);
 
       double probability_sum = 0.;
       for (int i = 0; i < in_nphixstargets; i++) {
@@ -137,7 +135,6 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
       globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
-      *mem_usage_phixs += sizeof(double) + sizeof(int);
 
       for (int i = 0; i < in_nphixstargets; i++) {
         assert_always(get_noncommentline(phixsfile, phixsline));
@@ -149,7 +146,6 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     }
   }
 
-  *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
   assert_always(tmpallphixs.size() % globals::NPHIXSPOINTS == 0);
   const auto tmpphixsstart = tmpallphixs.size();
   globals::alllevels.phixsstart[lowerionlower_uniquelevelindex] = tmpphixsstart / globals::NPHIXSPOINTS;
@@ -224,8 +220,10 @@ void read_phixs_data_table(std::fstream &phixsfile, const int nphixspoints_input
     }
   }
 
-  globals::nbfcontinua += get_nphixstargets(element, lowerion, lowerlevel);
-  if (lowerlevel == 0 && get_nphixstargets(element, lowerion, lowerlevel) > 0) {
+  *mem_usage_phixs += get_nphixstargets(lowerionlower_uniquelevelindex) * sizeof(double) + sizeof(int);
+  *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
+  globals::nbfcontinua += get_nphixstargets(lowerionlower_uniquelevelindex);
+  if (lowerlevel == 0 && get_nphixstargets(lowerionlower_uniquelevelindex) > 0) {
     globals::nbfcontinua_ground++;
   }
 }

--- a/input.cc
+++ b/input.cc
@@ -1180,6 +1180,7 @@ void read_atomicdata_files() {
     std::ranges::fill(globals::alllevels_phixsstart, -1);
     std::ranges::fill(globals::alllevels_phixstargetstart, -1);
     std::ranges::fill(globals::alllevels_cont_index, -1);
+    std::ranges::fill(globals::alllevels_closestgroundlevelcont, -1);
     for (size_t i = 0; i < temp_alllevels.size(); i++) {
       globals::alllevels[i] = {
           .alltrans_startdown = temp_alllevels[i].alltrans_startdown,
@@ -1189,7 +1190,6 @@ void read_atomicdata_files() {
       };
       globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
       globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
-      globals::alllevels_closestgroundlevelcont[i] = temp_alllevels[i].closestgroundlevelcont;
     }
   }
   MPI_Barrier(globals::mpi_comm_node);

--- a/input.cc
+++ b/input.cc
@@ -459,7 +459,7 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion, cons
                                           std::vector<int> &iondowntranstmplineindicies, int &lineindex,
                                           std::vector<TransitionLine> &temp_linelist,
                                           std::vector<LevelTransition> &temp_alltranslist,
-                                          size_t &temp_alltranslist_size, EnergyLevelInput *ion_levels) {
+                                          size_t &temp_alltranslist_size, std::span<EnergyLevelInput> ion_levels) {
   const int lineindex_initial = lineindex;
   ptrdiff_t totupdowntrans = 0;
   // pass 0 to get transition counts of each level
@@ -1071,7 +1071,6 @@ void read_atomicdata_files() {
       assert_always(std::ssize(temp_alllevels) == uniquelevelindex);
 
       read_ion_levels(adata, element, ion, nions, nlevels, nlevelsmax, energyoffset, ionpot, temp_alllevels);
-      auto *ion_levels = temp_alllevels.data() + globals::elements[element].ions[ion].uniquelevelindexstart;
 
       int tottransitions = tottransitions_in_file;
 
@@ -1098,14 +1097,16 @@ void read_atomicdata_files() {
       // last level index is (nlevelsmax - 1), so this is the correct size
       iondowntranstmplineindicies.resize(downtranslevelstart(nlevelsmax));
 
+      auto ion_levels =
+          std::span{temp_alllevels}.subspan(globals::elements[element].ions[ion].uniquelevelindexstart, nlevelsmax);
       add_transitions_to_unsorted_linelist(element, ion, nlevelsmax, iontransitiontable, iondowntranstmplineindicies,
                                            lineindex, temp_linelist, temp_alltranslist, temp_alltranslist_size,
                                            ion_levels);
 
-      for (int level = 0; level < nlevelsmax; level++) {
+      for (const auto &level : ion_levels) {
         uniquelevelindex++;
-        totaldowntrans += ion_levels[level].ndowntrans;
-        totaluptrans += ion_levels[level].nuptrans;
+        totaldowntrans += level.ndowntrans;
+        totaluptrans += level.nuptrans;
       }
 
       if (ion < nions - 1) {

--- a/input.cc
+++ b/input.cc
@@ -852,19 +852,12 @@ void read_phixs_data() {
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels = get_nlevels(element, ion);
       for (int level = 0; level < nlevels; level++) {
+        const int nphixstargets = get_nphixstargets(element, ion, level);
         const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-        const int nphixstargets = get_nphixstargets(uniquelevelindex);
+        globals::alllevels.cont_index[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
+        cont_index += nphixstargets;
         if (nphixstargets > 0) {
           nbftables++;
-        }
-        globals::alllevels.cont_index[uniquelevelindex] = (get_nphixstargets(uniquelevelindex) > 0) ? cont_index : -1;
-        cont_index += nphixstargets;
-
-        const auto phixstable = std::span{tmpallphixs}.subspan(
-            globals::alllevels.phixsstart[uniquelevelindex] * globals::NPHIXSPOINTS, globals::NPHIXSPOINTS);
-        if (!std::ranges::any_of(phixstable, [](const auto &x) { return x > 0.; })) {
-          globals::alllevels.nphixstargets[uniquelevelindex] = 0;
-          printout("All-zero cross section for element %d ion %d level %d\n", element, ion, level);
         }
       }
 

--- a/input.cc
+++ b/input.cc
@@ -1167,14 +1167,8 @@ void read_atomicdata_files() {
 
   // create a shared level list and copy data across, freeing the local copy
   globals::alllevels = MPI_shared_malloc_span<EnergyLevel>(temp_alllevels.size());
-  globals::alllevels_epsilon = MPI_shared_malloc_span<double>(temp_alllevels.size());
-  globals::alllevels_statweight = MPI_shared_malloc_span<float>(temp_alllevels.size());
   if (globals::rank_in_node == 0) {
     std::ranges::copy(temp_alllevels, globals::alllevels.begin());
-    for (size_t i = 0; i < temp_alllevels.size(); i++) {
-      globals::alllevels_epsilon[i] = temp_alllevels[i].epsilon;
-      globals::alllevels_statweight[i] = temp_alllevels[i].stat_weight;
-    }
   }
   MPI_Barrier(globals::mpi_comm_node);
   temp_alllevels.clear();

--- a/input.cc
+++ b/input.cc
@@ -852,12 +852,19 @@ void read_phixs_data() {
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels = get_nlevels(element, ion);
       for (int level = 0; level < nlevels; level++) {
-        const int nphixstargets = get_nphixstargets(element, ion, level);
         const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-        globals::alllevels.cont_index[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
-        cont_index += nphixstargets;
+        const int nphixstargets = get_nphixstargets(uniquelevelindex);
         if (nphixstargets > 0) {
           nbftables++;
+        }
+        globals::alllevels.cont_index[uniquelevelindex] = (get_nphixstargets(uniquelevelindex) > 0) ? cont_index : -1;
+        cont_index += nphixstargets;
+
+        const auto phixstable = std::span{tmpallphixs}.subspan(
+            globals::alllevels.phixsstart[uniquelevelindex] * globals::NPHIXSPOINTS, globals::NPHIXSPOINTS);
+        if (!std::ranges::any_of(phixstable, [](const auto &x) { return x > 0.; })) {
+          globals::alllevels.nphixstargets[uniquelevelindex] = 0;
+          printout("All-zero cross section for element %d ion %d level %d\n", element, ion, level);
         }
       }
 

--- a/input.cc
+++ b/input.cc
@@ -741,6 +741,7 @@ void setup_phixs_list() {
       }
       const int nlevels = get_nlevels_ionising(element, ion);
       for (int level = 0; level < nlevels; level++) {
+        const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
         const int nphixstargets = get_nphixstargets(element, ion, level);
 
         for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
@@ -761,7 +762,7 @@ void setup_phixs_list() {
             const auto groundcontindex = search_groundphixslist(nu_edge_target0, element, ion, level);
             nonconstallcont[allcontindex].index_in_groundphixslist = groundcontindex;
 
-            globals::alllevels_closestgroundlevelcont[get_uniquelevelindex(element, ion, level)] = groundcontindex;
+            globals::alllevels_closestgroundlevelcont[uniquelevelindex] = groundcontindex;
           }
           allcontindex++;
         }

--- a/input.h
+++ b/input.h
@@ -8,7 +8,7 @@
 void input(int rank);
 void read_parameterfile(int rank);
 void update_parameterfile(int nts);
-void time_init();
+void setup_timesteps();
 void write_timestep_file();
 auto get_noncommentline(std::fstream &input, std::string &line) -> bool;
 

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -343,9 +343,10 @@ void setup_coolinglist() {
       if (ion < (nions - 1))  // check whether further ionisation stage available
       {
         for (int level = 0; level < nionisinglevels; level++) {
-          const int nphixstargets = get_nphixstargets(element, ion, level);
+          const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+          const int nphixstargets = get_nphixstargets(uniquelevelindex);
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-            const int upper = get_phixsupperlevel(element, ion, level, phixstargetindex);
+            const int upper = get_phixsupperlevel(uniquelevelindex, phixstargetindex);
             coolinglist[i].type = CoolingType::COLLION;
             coolinglist[i].level = level;
             coolinglist[i].upperlevel = upper;
@@ -356,9 +357,10 @@ void setup_coolinglist() {
         // fb creation of r-pkt
         // free bound rates are calculated from the lower ion, but associated to the higher ion
         for (int level = 0; level < nionisinglevels; level++) {
-          const int nphixstargets = get_nphixstargets(element, ion, level);
+          const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+          const int nphixstargets = get_nphixstargets(uniquelevelindex);
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-            const int upper = get_phixsupperlevel(element, ion, level, phixstargetindex);
+            const int upper = get_phixsupperlevel(uniquelevelindex, phixstargetindex);
             coolinglist[i].type = CoolingType::FREEBOUND;
             coolinglist[i].level = level;
             coolinglist[i].upperlevel = upper;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -94,8 +94,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
     const int nuptrans = get_nuptrans(uniquelevelindex);
     for (int alltransindex = alltrans_startup; alltransindex < (alltrans_startup + nuptrans); alltransindex++) {
-      const auto &uptrans = globals::alltrans[alltransindex];
-      const int upper = uptrans.targetlevelindex;
+      const int upper = globals::alltrans.targetlevelindex[alltransindex];
       const double epsilon_trans = epsilon(ionuniquelevelindexstart + upper) - epsilon_current;
       const auto upper_statweight = stat_weight(ionuniquelevelindexstart + upper);
       const double C = nnlevel *
@@ -602,7 +601,7 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
     const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
     const int nuptrans = get_nuptrans(uniquelevelindex);
     for (int alltransindex = alltrans_startup; alltransindex < (alltrans_startup + nuptrans); alltransindex++) {
-      const int tmpupper = globals::alltrans[alltransindex].targetlevelindex;
+      const int tmpupper = globals::alltrans.targetlevelindex[alltransindex];
       // printout("    excitation to level %d possible\n",upper);
       const auto upperuniquelevelindex = ionuniquelevelindexstart + tmpupper;
       const double epsilon_trans = epsilon(upperuniquelevelindex) - epsilon_current;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -592,9 +592,8 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
     const double statweight = stat_weight(element, ion, level);
     int upper = -1;
     // excitation to same ionization stage
-    const int nuptrans = get_nuptrans(element, ion, level);
-    const auto *const uptranslist = get_uptranslist(element, ion, level);
-    for (int ii = 0; ii < nuptrans; ii++) {
+    const auto uptranslist = get_uptransspan(element, ion, level);
+    for (int ii = 0; ii < std::ssize(uptranslist); ii++) {
       const int tmpupper = uptranslist[ii].targetlevelindex;
       // printout("    excitation to level %d possible\n",upper);
       const double epsilon_trans = epsilon(element, ion, tmpupper) - epsilon_current;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <numeric>
 #include <ranges>
 #include <vector>
 
@@ -279,11 +280,10 @@ void calculate_cooling_rates(const int nonemptymgi, HeatingCoolingRates *heating
 
   // this loop is made separate for future parallelisation of upper loop.
   // the ion contributions must be added in this exact order
-  double C_total = 0.;
-  for (int allionindex = 0; allionindex < get_includedions(); allionindex++) {
-    C_total +=
-        grid::ion_cooling_contribs_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + allionindex];
-  }
+  const auto cellioncontribs = grid::ion_cooling_contribs_allcells.subspan(
+      (static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()), get_includedions());
+  const double C_total = std::accumulate(cellioncontribs.begin(), cellioncontribs.end(), 0.0);
+
   grid::modelgrid[nonemptymgi].totalcooling = C_total;
 
   // only used in the T_e solver and write_to_estimators file

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -91,13 +91,15 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     const double epsilon_current = epsilon(uniquelevelindex);
     const double statweight = stat_weight(uniquelevelindex);
 
-    const auto uptranslist = get_uptransspan(element, ion, level);
-    for (const auto &transition : uptranslist) {
-      const int upper = transition.targetlevelindex;
+    const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
+    const int nuptrans = get_nuptrans(uniquelevelindex);
+    for (int alltransindex = alltrans_startup; alltransindex < (alltrans_startup + nuptrans); alltransindex++) {
+      const auto &uptrans = globals::alltrans[alltransindex];
+      const int upper = uptrans.targetlevelindex;
       const double epsilon_trans = epsilon(ionuniquelevelindexstart + upper) - epsilon_current;
       const auto upper_statweight = stat_weight(ionuniquelevelindexstart + upper);
       const double C = nnlevel *
-                       col_excitation_ratecoeff(T_e, nne, upper_statweight, transition, epsilon_trans, statweight) *
+                       col_excitation_ratecoeff(T_e, nne, upper_statweight, uptrans, epsilon_trans, statweight) *
                        epsilon_trans;
       C_ion += C;
       if constexpr (!update_cooling_contrib_list) {
@@ -105,7 +107,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
       }
     }
     if constexpr (update_cooling_contrib_list) {
-      if (!uptranslist.empty()) {
+      if (nuptrans > 0) {
         globals::cellcache[cellcacheslotid].cooling_contrib[i] = C_ion;
 
         assert_testmodeonly(coolinglist[i].type == CoolingType::COLLEXC);

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -80,18 +80,20 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     }
   }
 
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   // excitation to same ionization stage
   const int nlevels = get_nlevels(element, ion);
   for (int level = 0; level < nlevels; level++) {
     // printout("[debug] do_kpkt: element %d, ion %d, level %d\n", element, ion, level);
     const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-    const double epsilon_current = epsilon(element, ion, level);
-    const double statweight = stat_weight(element, ion, level);
+
+    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+    const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
 
     const auto uptranslist = get_uptransspan(element, ion, level);
     for (const auto &transition : uptranslist) {
       const int upper = transition.targetlevelindex;
-      const double epsilon_trans = epsilon(element, ion, upper) - epsilon_current;
+      const double epsilon_trans = globals::alllevels_epsilon[ionuniquelevelindexstart + upper] - epsilon_current;
       const double C = nnlevel *
                        col_excitation_ratecoeff(T_e, nne, element, ion, transition, epsilon_trans, statweight) *
                        epsilon_trans;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -85,10 +85,11 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
   const int nlevels = get_nlevels(element, ion);
   for (int level = 0; level < nlevels; level++) {
     // printout("[debug] do_kpkt: element %d, ion %d, level %d\n", element, ion, level);
-    const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
+    const auto uniquelevelindex = ionuniquelevelindexstart + level;
+    const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
 
-    const double epsilon_current = epsilon(ionuniquelevelindexstart + level);
-    const double statweight = stat_weight(ionuniquelevelindexstart + level);
+    const double epsilon_current = epsilon(uniquelevelindex);
+    const double statweight = stat_weight(uniquelevelindex);
 
     const auto uptranslist = get_uptransspan(element, ion, level);
     for (const auto &transition : uptranslist) {
@@ -118,11 +119,12 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
 
     // ionization to higher ionization stage
     for (int level = 0; level < nionisinglevels; level++) {
-      const double epsilon_current = epsilon(element, ion, level);
-      const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-      const int nphixstargets = get_nphixstargets(element, ion, level);
+      const auto uniquelevelindex = ionuniquelevelindexstart + level;
+      const double epsilon_current = epsilon(uniquelevelindex);
+      const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+      const int nphixstargets = get_nphixstargets(uniquelevelindex);
       for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-        const int upper = get_phixsupperlevel(element, ion, level, phixstargetindex);
+        const int upper = get_phixsupperlevel(uniquelevelindex, phixstargetindex);
         const double epsilon_upper = epsilon(element, ion + 1, upper);
         const double epsilon_trans = epsilon_upper - epsilon_current;
         const double C = nnlevel *

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -87,13 +87,13 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     // printout("[debug] do_kpkt: element %d, ion %d, level %d\n", element, ion, level);
     const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
-    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+    const double epsilon_current = epsilon(ionuniquelevelindexstart + level);
     const double statweight = stat_weight(ionuniquelevelindexstart + level);
 
     const auto uptranslist = get_uptransspan(element, ion, level);
     for (const auto &transition : uptranslist) {
       const int upper = transition.targetlevelindex;
-      const double epsilon_trans = globals::alllevels_epsilon[ionuniquelevelindexstart + upper] - epsilon_current;
+      const double epsilon_trans = epsilon(ionuniquelevelindexstart + upper) - epsilon_current;
       const double C = nnlevel *
                        col_excitation_ratecoeff(T_e, nne, element, ion, transition, epsilon_trans, statweight) *
                        epsilon_trans;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -530,7 +530,7 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
     pkt.em_time = pkt.prop_time;
     pkt.nscatterings = 0;
     if constexpr (VPKT_ON) {
-      vpkt_call_estimators(pkt, TYPE_KPKT);
+      vpkt::call_estimators(pkt, TYPE_KPKT);
     }
 
   } else if (rndcoolingtype == CoolingType::FREEBOUND) {
@@ -570,7 +570,7 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
     pkt.nscatterings = 0;
 
     if constexpr (VPKT_ON) {
-      vpkt_call_estimators(pkt, TYPE_KPKT);
+      vpkt::call_estimators(pkt, TYPE_KPKT);
     }
   } else if (rndcoolingtype == CoolingType::COLLEXC) {
     // the k-packet activates a macro-atom due to collisional excitation

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -99,7 +99,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
       const double epsilon_trans = epsilon(ionuniquelevelindexstart + upper) - epsilon_current;
       const auto upper_statweight = stat_weight(ionuniquelevelindexstart + upper);
       const double C = nnlevel *
-                       col_excitation_ratecoeff(T_e, nne, upper_statweight, uptrans, epsilon_trans, statweight) *
+                       col_excitation_ratecoeff(T_e, nne, upper_statweight, alltransindex, epsilon_trans, statweight) *
                        epsilon_trans;
       C_ion += C;
       if constexpr (!update_cooling_contrib_list) {
@@ -599,16 +599,17 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
     const double statweight = stat_weight(uniquelevelindex);
     int upper = -1;
     // excitation to same ionization stage
-    const auto uptranslist = get_uptransspan(element, ion, level);
-    for (int ii = 0; ii < std::ssize(uptranslist); ii++) {
-      const int tmpupper = uptranslist[ii].targetlevelindex;
+    const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
+    const int nuptrans = get_nuptrans(uniquelevelindex);
+    for (int alltransindex = alltrans_startup; alltransindex < (alltrans_startup + nuptrans); alltransindex++) {
+      const int tmpupper = globals::alltrans[alltransindex].targetlevelindex;
       // printout("    excitation to level %d possible\n",upper);
       const auto upperuniquelevelindex = ionuniquelevelindexstart + tmpupper;
       const double epsilon_trans = epsilon(upperuniquelevelindex) - epsilon_current;
       const auto upper_statweight = stat_weight(upperuniquelevelindex);
-      const double C =
-          nnlevel * col_excitation_ratecoeff(T_e, nne, upper_statweight, uptranslist[ii], epsilon_trans, statweight) *
-          epsilon_trans;
+      const double C = nnlevel *
+                       col_excitation_ratecoeff(T_e, nne, upper_statweight, alltransindex, epsilon_trans, statweight) *
+                       epsilon_trans;
       contrib += C;
       if (contrib > rndcool_ion_process) {
         upper = tmpupper;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -80,20 +80,18 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     }
   }
 
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   // excitation to same ionization stage
   const int nlevels = get_nlevels(element, ion);
   for (int level = 0; level < nlevels; level++) {
     // printout("[debug] do_kpkt: element %d, ion %d, level %d\n", element, ion, level);
     const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-
-    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
-    const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
+    const double epsilon_current = epsilon(element, ion, level);
+    const double statweight = stat_weight(element, ion, level);
 
     const auto uptranslist = get_uptransspan(element, ion, level);
     for (const auto &transition : uptranslist) {
       const int upper = transition.targetlevelindex;
-      const double epsilon_trans = globals::alllevels_epsilon[ionuniquelevelindexstart + upper] - epsilon_current;
+      const double epsilon_trans = epsilon(element, ion, upper) - epsilon_current;
       const double C = nnlevel *
                        col_excitation_ratecoeff(T_e, nne, element, ion, transition, epsilon_trans, statweight) *
                        epsilon_trans;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -88,7 +88,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
     const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
-    const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
+    const double statweight = stat_weight(ionuniquelevelindexstart + level);
 
     const auto uptranslist = get_uptransspan(element, ion, level);
     for (const auto &transition : uptranslist) {

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -95,8 +95,9 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     for (const auto &transition : uptranslist) {
       const int upper = transition.targetlevelindex;
       const double epsilon_trans = epsilon(ionuniquelevelindexstart + upper) - epsilon_current;
+      const auto upper_statweight = stat_weight(ionuniquelevelindexstart + upper);
       const double C = nnlevel *
-                       col_excitation_ratecoeff(T_e, nne, element, ion, transition, epsilon_trans, statweight) *
+                       col_excitation_ratecoeff(T_e, nne, upper_statweight, transition, epsilon_trans, statweight) *
                        epsilon_trans;
       C_ion += C;
       if constexpr (!update_cooling_contrib_list) {
@@ -589,19 +590,23 @@ __host__ __device__ void do_kpkt(Packet &pkt, const double t2, const int nts) {
 
     double contrib = contrib_low;
     const int level = coolinglist[i].level;
-    const double epsilon_current = epsilon(element, ion, level);
-    const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-    const double statweight = stat_weight(element, ion, level);
+    const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+    const auto uniquelevelindex = ionuniquelevelindexstart + level;
+    const double epsilon_current = epsilon(uniquelevelindex);
+    const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+    const double statweight = stat_weight(uniquelevelindex);
     int upper = -1;
     // excitation to same ionization stage
     const auto uptranslist = get_uptransspan(element, ion, level);
     for (int ii = 0; ii < std::ssize(uptranslist); ii++) {
       const int tmpupper = uptranslist[ii].targetlevelindex;
       // printout("    excitation to level %d possible\n",upper);
-      const double epsilon_trans = epsilon(element, ion, tmpupper) - epsilon_current;
-      const double C = nnlevel *
-                       col_excitation_ratecoeff(T_e, nne, element, ion, uptranslist[ii], epsilon_trans, statweight) *
-                       epsilon_trans;
+      const auto upperuniquelevelindex = ionuniquelevelindexstart + tmpupper;
+      const double epsilon_trans = epsilon(upperuniquelevelindex) - epsilon_current;
+      const auto upper_statweight = stat_weight(upperuniquelevelindex);
+      const double C =
+          nnlevel * col_excitation_ratecoeff(T_e, nne, upper_statweight, uptranslist[ii], epsilon_trans, statweight) *
+          epsilon_trans;
       contrib += C;
       if (contrib > rndcool_ion_process) {
         upper = tmpupper;

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -501,9 +501,25 @@ auto calculate_levelpop(const int nonemptymgi, const int element, const int ion,
   return nn;
 }
 
+[[nodiscard]] __host__ __device__ auto get_levelpop(const int nonemptymgi, const int uniquelevelindex) -> double {
+  double nn = 0.;
+  if (use_cellcache) {
+    assert_testmodeonly(globals::cellcache[cellcacheslotid].nonemptymgi == nonemptymgi);
+    nn = globals::cellcache[cellcacheslotid].ch_all_levels[uniquelevelindex].population;
+  } else {
+    const auto [element, ion, level] = get_levelfromuniquelevelindex(uniquelevelindex);
+    nn = calculate_levelpop(nonemptymgi, element, ion, level);
+  }
+
+  assert_testmodeonly(nn >= 0.);
+  assert_testmodeonly(std::isfinite(nn));
+
+  return nn;
+}
+
 // Calculate the population of a level from either LTE or NLTE information
-__host__ __device__ auto get_levelpop(const int nonemptymgi, const int element, const int ion, const int level)
-    -> double {
+[[nodiscard]] __host__ __device__ auto get_levelpop(const int nonemptymgi, const int element, const int ion,
+                                                    const int level) -> double {
   double nn = 0.;
   if (use_cellcache) {
     assert_testmodeonly(globals::cellcache[cellcacheslotid].nonemptymgi == nonemptymgi);

--- a/ltepop.h
+++ b/ltepop.h
@@ -9,6 +9,7 @@
 
 [[nodiscard]] auto calculate_levelpop_boltzmann(int nonemptymgi, int element, int ion, int level) -> double;
 
+[[nodiscard]] auto get_levelpop(int nonemptymgi, int uniquelevelindex) -> double;
 [[nodiscard]] auto get_levelpop(int nonemptymgi, int element, int ion, int level) -> double;
 [[nodiscard]] auto calculate_sahafact(int element, int ion, int level, int upperionlevel, double T, double E_threshold)
     -> double;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -53,16 +53,17 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   double sum_internal_down_same = 0.;
   double sum_raddeexc = 0.;
   double sum_coldeexc = 0.;
-  const auto downtranslist = get_downtransspan(uniquelevelindex);
+  const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
+  const auto ndowntrans = get_ndowntrans(uniquelevelindex);
   auto *const arr_sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
-  for (int i = 0; i < std::ssize(downtranslist); i++) {
-    const auto &downtrans = downtranslist[i];
+  for (int i = 0; i < ndowntrans; i++) {
+    const auto &downtrans = globals::alltrans[alltrans_startdown + i];
     const int lower = downtrans.targetlevelindex;
     const auto A_ul = downtrans.einstein_A;
-    const double epsilon_target = epsilon(ionuniquelevelindexstart + lower);
-    const double epsilon_trans = epsilon_current - epsilon_target;
     const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
+    const double epsilon_target = epsilon(lower_uniquelevelindex);
+    const double epsilon_trans = epsilon_current - epsilon_target;
     const auto lower_statweight = stat_weight(lower_uniquelevelindex);
 
     const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -40,10 +40,12 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // printout("Calculating transition rates for element %d ion %d level %d\n", element, ion, level);
   auto processrates = std::array<double, MA_ACTION_COUNT>{};
 
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+
   const auto T_e = grid::get_Te(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
-  const double epsilon_current = epsilon(element, ion, level);
-  const double statweight = stat_weight(element, ion, level);
+  const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+  const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
   const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
   // Downward transitions within the current ionisation stage:

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -103,6 +103,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
   assert_always(std::isfinite(processrates[MA_ACTION_INTERNALUPSAME]));
 
+  const auto lowerionuniquelevelindexstart = globals::elements[element].ions[ion - 1].uniquelevelindexstart;
   // Downward transitions to lower ionisation stages:
   // radiative/collisional recombination and internal downward jumps
   // checks only if there is a lower ion, doesn't make sure that Z(ion)=Z(ion-1)+1
@@ -112,7 +113,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   if (ion > 0 && level <= get_maxrecombininglevel(element, ion)) {
     const int nlevels = get_nlevels_ionising(element, ion - 1);
     for (int lower = 0; lower < nlevels; lower++) {
-      const double epsilon_target = epsilon(element, ion - 1, lower);
+      const double epsilon_target = globals::alllevels_epsilon[lowerionuniquelevelindexstart + lower];
       const double epsilon_trans = epsilon_current - epsilon_target;
 
       const double R = rad_recombination_ratecoeff(T_e, nne, element, ion, level, lower, nonemptymgi);

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -40,12 +40,13 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // printout("Calculating transition rates for element %d ion %d level %d\n", element, ion, level);
   auto processrates = std::array<double, MA_ACTION_COUNT>{};
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const auto uniquelevelindex = ionuniquelevelindexstart + level;
 
   const auto T_e = grid::get_Te(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
-  const double epsilon_current = epsilon(ionuniquelevelindexstart + level);
-  const double statweight = stat_weight(ionuniquelevelindexstart + level);
-  const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
+  const double epsilon_current = epsilon(uniquelevelindex);
+  const double statweight = stat_weight(uniquelevelindex);
+  const auto nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
 
   // Downward transitions within the current ionisation stage:
   // radiative/collisional deexcitation and internal downward jumps

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -99,7 +99,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
                                               epsilon_trans, nnlevel, statweight, uptrans.lineindex, t_mid);
     const double C =
         col_excitation_ratecoeff(T_e, nne, upper_statweight, alltrans_startup + ii, epsilon_trans, statweight);
-    const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, ii, uptrans.lineindex);
+    const double NT =
+        nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, uptrans.targetlevelindex, uptrans.lineindex);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
     chlevel.sum_internal_up_same[ii] = sum_internal_up_same;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -946,7 +946,9 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
     // forbidden transitions: magnetic dipole, electric quadropole...
     // Axelrod's approximation (thesis 1980)
     const int upper = uptrans.targetlevelindex;
-    const double upperstatweight = stat_weight(element, ion, upper);
+    const double upperstatweight =
+        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + upper];
+
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -87,10 +87,11 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto uptranslist = get_uptransspan(uniquelevelindex);
   for (int i = 0; i < std::ssize(uptranslist); i++) {
     const auto &uptrans = uptranslist[i];
-    const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
+    const auto upper_uniquelevelindex = ionuniquelevelindexstart + uptrans.targetlevelindex;
+    const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_current;
 
-    const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, uptrans, epsilon_trans, nnlevel, statweight,
-                                              uptrans.lineindex, t_mid);
+    const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, uptrans, epsilon_trans, nnlevel,
+                                              statweight, uptrans.lineindex, t_mid);
     const double C = col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, statweight);
     const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, uptrans.lineindex);
 
@@ -686,18 +687,15 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
 // radiative excitation rate: paperII 3.5.2
 // multiply by lower level population to get a rate per second
 
-auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const int ion, const LevelTransition &uptrans,
+auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevelindex, const LevelTransition &uptrans,
                               const double epsilon_trans, const double nnlevel_lower, const double statweight_lower,
                               const int lineindex, const double t_current) -> double {
-  const int upper = uptrans.targetlevelindex;
-
-  const double n_u = get_levelpop(nonemptymgi, element, ion, upper);
+  const double n_u = get_levelpop(nonemptymgi, upper_uniquelevelindex);
   const auto &n_l = nnlevel_lower;
   const double nu_trans = epsilon_trans / H;
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double B_lu = stat_weight(ionuniquelevelindexstart + upper) / statweight_lower * B_ul;
+  const double B_lu = stat_weight(upper_uniquelevelindex) / statweight_lower * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -738,7 +738,7 @@ auto rad_recombination_ratecoeff(const float T_e, const float nne, const int ele
   const int nphixstargets = get_nphixstargets(lowerionlower_uniquelevelindex);
   for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
     if (get_phixsupperlevel(lowerionlower_uniquelevelindex, phixstargetindex) == upperionlevel) {
-      R = nne * get_spontrecombcoeff(element, lowerion, lowerionlevel, phixstargetindex, T_e);
+      R = nne * get_spontrecombcoeff(lowerionlower_uniquelevelindex, phixstargetindex, T_e);
 
       if constexpr (SEPARATE_STIMRECOMB) {
         R += nne * get_stimrecombcoeff(element, lowerion, lowerionlevel, phixstargetindex, nonemptymgi);

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -40,10 +40,12 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // printout("Calculating transition rates for element %d ion %d level %d\n", element, ion, level);
   auto processrates = std::array<double, MA_ACTION_COUNT>{};
 
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+
   const auto T_e = grid::get_Te(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
-  const double epsilon_current = epsilon(element, ion, level);
-  const double statweight = stat_weight(element, ion, level);
+  const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+  const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
   const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
   // Downward transitions within the current ionisation stage:
@@ -59,7 +61,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto &downtrans = leveldowntranslist[i];
     const int lower = downtrans.targetlevelindex;
     const auto A_ul = downtrans.einstein_A;
-    const double epsilon_target = epsilon(element, ion, lower);
+    const double epsilon_target = globals::alllevels_epsilon[ionuniquelevelindexstart + lower];
     const double epsilon_trans = epsilon_current - epsilon_target;
 
     const double R =
@@ -86,7 +88,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto *const uptranslist = get_uptranslist(element, ion, level);
   for (int i = 0; i < nuptrans; i++) {
     const auto &uptrans = uptranslist[i];
-    const double epsilon_trans = epsilon(element, ion, uptrans.targetlevelindex) - epsilon_current;
+    const double epsilon_trans =
+        globals::alllevels_epsilon[ionuniquelevelindexstart + uptrans.targetlevelindex] - epsilon_current;
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
                                               uptrans.lineindex, t_mid);
@@ -100,6 +103,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
   assert_always(std::isfinite(processrates[MA_ACTION_INTERNALUPSAME]));
 
+  const auto lowerionuniquelevelindexstart = globals::elements[element].ions[ion - 1].uniquelevelindexstart;
   // Downward transitions to lower ionisation stages:
   // radiative/collisional recombination and internal downward jumps
   // checks only if there is a lower ion, doesn't make sure that Z(ion)=Z(ion-1)+1
@@ -109,7 +113,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   if (ion > 0 && level <= get_maxrecombininglevel(element, ion)) {
     const int nlevels = get_nlevels_ionising(element, ion - 1);
     for (int lower = 0; lower < nlevels; lower++) {
-      const double epsilon_target = epsilon(element, ion - 1, lower);
+      const double epsilon_target = globals::alllevels_epsilon[lowerionuniquelevelindexstart + lower];
       const double epsilon_trans = epsilon_current - epsilon_target;
 
       const double R = rad_recombination_ratecoeff(T_e, nne, element, ion, level, lower, nonemptymgi);
@@ -197,7 +201,9 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
     atomicadd(globals::ecounter[downtrans.lineindex], 1);
   }
 
-  const double epsilon_trans = epsilon_current - epsilon(element, ion, downtrans.targetlevelindex);
+  const double epsilon_trans =
+      epsilon_current - globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart +
+                                                   downtrans.targetlevelindex];
 
   const double oldnucmf = pkt.nu_cmf;
   pkt.nu_cmf = epsilon_trans / H;
@@ -350,8 +356,9 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
     assert_testmodeonly(ion >= 0);
     assert_testmodeonly(ion < get_nions(element));
+    const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
 
-    const double epsilon_current = epsilon(element, ion, level);
+    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
     const int nuptrans = get_nuptrans(element, ion, level);
 
     auto &chlevel = globals::cellcache[cellcacheslotid].chelements[element].chions[ion].chlevels[level];
@@ -661,7 +668,9 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
+    const double B_lu = upperstatweight /
+                        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + lower] *
+                        B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -702,7 +711,9 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const in
   const double nu_trans = epsilon_trans / H;
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
+                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -854,8 +865,9 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans, const int element,
                                 const int ion, const int upper, const LevelTransition &downtransition) -> double {
   const int lower = downtransition.targetlevelindex;
-  const double upperstatweight = stat_weight(element, ion, upper);
-  const double lowerstatweight = stat_weight(element, ion, lower);
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double upperstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + upper];
+  const double lowerstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + lower];
   const double coll_str_thisline = downtransition.coll_str;
   if (coll_str_thisline < 0) {
     const bool forbidden = downtransition.forbidden;
@@ -937,7 +949,9 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
     // forbidden transitions: magnetic dipole, electric quadropole...
     // Axelrod's approximation (thesis 1980)
     const int upper = uptrans.targetlevelindex;
-    const double upperstatweight = stat_weight(element, ion, upper);
+    const double upperstatweight =
+        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + upper];
+
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -39,7 +39,6 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
                                          const double t_mid, CellCacheLevels &chlevel) {
   // printout("Calculating transition rates for element %d ion %d level %d\n", element, ion, level);
   auto processrates = std::array<double, MA_ACTION_COUNT>{};
-
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
 
   const auto T_e = grid::get_Te(nonemptymgi);
@@ -62,9 +61,10 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto A_ul = downtrans.einstein_A;
     const double epsilon_target = epsilon(ionuniquelevelindexstart + lower);
     const double epsilon_trans = epsilon_current - epsilon_target;
+    const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
 
-    const double R =
-        rad_deexcitation_ratecoeff(nonemptymgi, element, ion, lower, epsilon_trans, A_ul, statweight, nnlevel, t_mid);
+    const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
+                                                nnlevel, t_mid);
     const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtrans);
 
     sum_raddeexc += R * epsilon_trans;
@@ -652,11 +652,11 @@ void macroatom_close_file() {
 // radiative deexcitation rate: paperII 3.5.2
 // multiply by upper level population to get a rate per second
 
-auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const int ion, const int lower,
-                                const double epsilon_trans, const float A_ul, const double upperstatweight,
-                                const double nnlevelupper, const double t_current) -> double {
+auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelevelindex, const double epsilon_trans,
+                                const float A_ul, const double upperstatweight, const double nnlevelupper,
+                                const double t_current) -> double {
   const auto &n_u = nnlevelupper;
-  const double n_l = get_levelpop(nonemptymgi, element, ion, lower);
+  const double n_l = get_levelpop(nonemptymgi, lower_uniquelevelindex);
 
   double R = 0.;
 
@@ -665,7 +665,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
+    const double B_lu = upperstatweight / stat_weight(lower_uniquelevelindex) * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -83,9 +83,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // Calculate sum for upward internal transitions
   // transitions within the current ionisation stage
   double sum_internal_up_same = 0.;
-  const int nuptrans = get_nuptrans(ionuniquelevelindexstart + level);
-  const auto *const uptranslist = get_uptranslist(ionuniquelevelindexstart + level);
-  for (int i = 0; i < nuptrans; i++) {
+  const auto uptranslist = get_uptransspan(ionuniquelevelindexstart + level);
+  for (int i = 0; i < std::ssize(uptranslist); i++) {
     const auto &uptrans = uptranslist[i];
     const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -668,7 +668,9 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
+    const double B_lu = upperstatweight /
+                        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + lower] *
+                        B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -40,12 +40,10 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // printout("Calculating transition rates for element %d ion %d level %d\n", element, ion, level);
   auto processrates = std::array<double, MA_ACTION_COUNT>{};
 
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-
   const auto T_e = grid::get_Te(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
-  const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
-  const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
+  const double epsilon_current = epsilon(element, ion, level);
+  const double statweight = stat_weight(element, ion, level);
   const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
   // Downward transitions within the current ionisation stage:
@@ -61,7 +59,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto &downtrans = leveldowntranslist[i];
     const int lower = downtrans.targetlevelindex;
     const auto A_ul = downtrans.einstein_A;
-    const double epsilon_target = globals::alllevels_epsilon[ionuniquelevelindexstart + lower];
+    const double epsilon_target = epsilon(element, ion, lower);
     const double epsilon_trans = epsilon_current - epsilon_target;
 
     const double R =
@@ -88,8 +86,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto *const uptranslist = get_uptranslist(element, ion, level);
   for (int i = 0; i < nuptrans; i++) {
     const auto &uptrans = uptranslist[i];
-    const double epsilon_trans =
-        globals::alllevels_epsilon[ionuniquelevelindexstart + uptrans.targetlevelindex] - epsilon_current;
+    const double epsilon_trans = epsilon(element, ion, uptrans.targetlevelindex) - epsilon_current;
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
                                               uptrans.lineindex, t_mid);
@@ -103,7 +100,6 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
   assert_always(std::isfinite(processrates[MA_ACTION_INTERNALUPSAME]));
 
-  const auto lowerionuniquelevelindexstart = globals::elements[element].ions[ion - 1].uniquelevelindexstart;
   // Downward transitions to lower ionisation stages:
   // radiative/collisional recombination and internal downward jumps
   // checks only if there is a lower ion, doesn't make sure that Z(ion)=Z(ion-1)+1
@@ -113,7 +109,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   if (ion > 0 && level <= get_maxrecombininglevel(element, ion)) {
     const int nlevels = get_nlevels_ionising(element, ion - 1);
     for (int lower = 0; lower < nlevels; lower++) {
-      const double epsilon_target = globals::alllevels_epsilon[lowerionuniquelevelindexstart + lower];
+      const double epsilon_target = epsilon(element, ion - 1, lower);
       const double epsilon_trans = epsilon_current - epsilon_target;
 
       const double R = rad_recombination_ratecoeff(T_e, nne, element, ion, level, lower, nonemptymgi);
@@ -201,9 +197,7 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
     atomicadd(globals::ecounter[downtrans.lineindex], 1);
   }
 
-  const double epsilon_trans =
-      epsilon_current - globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart +
-                                                   downtrans.targetlevelindex];
+  const double epsilon_trans = epsilon_current - epsilon(element, ion, downtrans.targetlevelindex);
 
   const double oldnucmf = pkt.nu_cmf;
   pkt.nu_cmf = epsilon_trans / H;
@@ -356,9 +350,8 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
     assert_testmodeonly(ion >= 0);
     assert_testmodeonly(ion < get_nions(element));
-    const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
 
-    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+    const double epsilon_current = epsilon(element, ion, level);
     const int nuptrans = get_nuptrans(element, ion, level);
 
     auto &chlevel = globals::cellcache[cellcacheslotid].chelements[element].chions[ion].chlevels[level];
@@ -668,9 +661,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight /
-                        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + lower] *
-                        B_ul;
+    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -711,9 +702,7 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const in
   const double nu_trans = epsilon_trans / H;
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
-                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
+  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -865,9 +854,8 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans, const int element,
                                 const int ion, const int upper, const LevelTransition &downtransition) -> double {
   const int lower = downtransition.targetlevelindex;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double upperstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + upper];
-  const double lowerstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + lower];
+  const double upperstatweight = stat_weight(element, ion, upper);
+  const double lowerstatweight = stat_weight(element, ion, lower);
   const double coll_str_thisline = downtransition.coll_str;
   if (coll_str_thisline < 0) {
     const bool forbidden = downtransition.forbidden;
@@ -949,9 +937,7 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
     // forbidden transitions: magnetic dipole, electric quadropole...
     // Axelrod's approximation (thesis 1980)
     const int upper = uptrans.targetlevelindex;
-    const double upperstatweight =
-        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + upper];
-
+    const double upperstatweight = stat_weight(element, ion, upper);
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -89,10 +89,11 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto &uptrans = uptranslist[i];
     const auto upper_uniquelevelindex = ionuniquelevelindexstart + uptrans.targetlevelindex;
     const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_current;
+    const auto upper_statweight = stat_weight(upper_uniquelevelindex);
 
-    const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, uptrans, epsilon_trans, nnlevel,
-                                              statweight, uptrans.lineindex, t_mid);
-    const double C = col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, statweight);
+    const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight, uptrans,
+                                              epsilon_trans, nnlevel, statweight, uptrans.lineindex, t_mid);
+    const double C = col_excitation_ratecoeff(T_e, nne, upper_statweight, uptrans, epsilon_trans, statweight);
     const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, uptrans.lineindex);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
@@ -687,15 +688,15 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
 // radiative excitation rate: paperII 3.5.2
 // multiply by lower level population to get a rate per second
 
-auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevelindex, const LevelTransition &uptrans,
-                              const double epsilon_trans, const double nnlevel_lower, const double statweight_lower,
-                              const int lineindex, const double t_current) -> double {
+auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevelindex, const double upper_statweight,
+                              const LevelTransition &uptrans, const double epsilon_trans, const double nnlevel_lower,
+                              const double statweight_lower, const int lineindex, const double t_current) -> double {
   const double n_u = get_levelpop(nonemptymgi, upper_uniquelevelindex);
   const auto &n_l = nnlevel_lower;
   const double nu_trans = epsilon_trans / H;
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-  const double B_lu = stat_weight(upper_uniquelevelindex) / statweight_lower * B_ul;
+  const double B_lu = upper_statweight / statweight_lower * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -897,7 +898,7 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
 
 // multiply by lower level population to get a rate per second
 
-auto col_excitation_ratecoeff(const float T_e, const float nne, const int element, const int ion,
+auto col_excitation_ratecoeff(const float T_e, const float nne, const double upperstatweight,
                               const LevelTransition &uptrans, const double epsilon_trans, const double lowerstatweight)
     -> double {
   const double coll_strength = uptrans.coll_str;
@@ -931,8 +932,6 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
 
     // forbidden transitions: magnetic dipole, electric quadropole...
     // Axelrod's approximation (thesis 1980)
-    const int upper = uptrans.targetlevelindex;
-    const double upperstatweight = stat_weight(element, ion, upper);
 
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -61,7 +61,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto &downtrans = leveldowntranslist[i];
     const int lower = downtrans.targetlevelindex;
     const auto A_ul = downtrans.einstein_A;
-    const double epsilon_target = epsilon(element, ion, lower);
+    const double epsilon_target = globals::alllevels_epsilon[ionuniquelevelindexstart + lower];
     const double epsilon_trans = epsilon_current - epsilon_target;
 
     const double R =

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -53,7 +53,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   double sum_internal_down_same = 0.;
   double sum_raddeexc = 0.;
   double sum_coldeexc = 0.;
-  const auto downtranslist = get_downtransspan(ionuniquelevelindexstart + level);
+  const auto downtranslist = get_downtransspan(uniquelevelindex);
   auto *const arr_sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
   for (int i = 0; i < std::ssize(downtranslist); i++) {
@@ -84,7 +84,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // Calculate sum for upward internal transitions
   // transitions within the current ionisation stage
   double sum_internal_up_same = 0.;
-  const auto uptranslist = get_uptransspan(ionuniquelevelindexstart + level);
+  const auto uptranslist = get_uptransspan(uniquelevelindex);
   for (int i = 0; i < std::ssize(uptranslist); i++) {
     const auto &uptrans = uptranslist[i];
     const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
@@ -363,8 +363,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
     {
 #if (defined(STDPAR_ON) || defined(_OPENMP_ON)) && !defined(GPU_ON)
-      const auto lock =
-          std::lock_guard<std::mutex>(globals::mutex_cellcachemacroatom[get_uniquelevelindex(element, ion, level)]);
+      const auto lock = std::lock_guard<std::mutex>(globals::mutex_cellcachemacroatom[uniquelevelindex]);
 #endif
 
       assert_testmodeonly(globals::cellcache[cellcacheslotid].nonemptymgi == nonemptymgi);
@@ -447,7 +446,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
       case MA_ACTION_INTERNALDOWNSAME: {
         stats::increment(stats::COUNTER_INTERACTIONS);
-        level = do_macroatom_internal_down_same(ionuniquelevelindexstart + level, chlevel);
+        level = do_macroatom_internal_down_same(uniquelevelindex, chlevel);
 
         break;
       }
@@ -556,7 +555,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
             std::upper_bound(sum_internal_up_same, sum_internal_up_same + nuptrans - 1, targetval) -
             sum_internal_up_same;
 
-        const int upper = get_uptranslist(ionuniquelevelindexstart + level)[uptransindex].targetlevelindex;
+        const int upper = get_uptranslist(uniquelevelindex)[uptransindex].targetlevelindex;
 
         level = upper;
         break;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -356,8 +356,9 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
     assert_testmodeonly(ion >= 0);
     assert_testmodeonly(ion < get_nions(element));
+    const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
 
-    const double epsilon_current = epsilon(element, ion, level);
+    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
     const int nuptrans = get_nuptrans(element, ion, level);
 
     auto &chlevel = globals::cellcache[cellcacheslotid].chelements[element].chions[ion].chlevels[level];

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -45,7 +45,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto T_e = grid::get_Te(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
   const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
-  const double statweight = globals::alllevels_statweight[ionuniquelevelindexstart + level];
+  const double statweight = stat_weight(ionuniquelevelindexstart + level);
   const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
   // Downward transitions within the current ionisation stage:
@@ -669,8 +669,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
     const double B_lu =
-        upperstatweight /
-        globals::alllevels_statweight[globals::elements[element].ions[ion].uniquelevelindexstart + lower] * B_ul;
+        upperstatweight / stat_weight(globals::elements[element].ions[ion].uniquelevelindexstart + lower) * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -712,8 +711,8 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const in
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
-                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
+  const double B_lu =
+      stat_weight(ionuniquelevelindexstart + upper) / stat_weight(ionuniquelevelindexstart + lower) * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -866,8 +865,8 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
                                 const int ion, const int upper, const LevelTransition &downtransition) -> double {
   const int lower = downtransition.targetlevelindex;
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double upperstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + upper];
-  const double lowerstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + lower];
+  const double upperstatweight = stat_weight(ionuniquelevelindexstart + upper);
+  const double lowerstatweight = stat_weight(ionuniquelevelindexstart + lower);
   const double coll_str_thisline = downtransition.coll_str;
   if (coll_str_thisline < 0) {
     const bool forbidden = downtransition.forbidden;
@@ -949,8 +948,7 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
     // forbidden transitions: magnetic dipole, electric quadropole...
     // Axelrod's approximation (thesis 1980)
     const int upper = uptrans.targetlevelindex;
-    const double upperstatweight =
-        globals::alllevels_statweight[globals::elements[element].ions[ion].uniquelevelindexstart + upper];
+    const double upperstatweight = stat_weight(globals::elements[element].ions[ion].uniquelevelindexstart + upper);
 
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -139,9 +139,9 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
       sum_up_highernt = nonthermal::nt_ionization_ratecoeff(nonemptymgi, element, ion) * epsilon_current;
     }
 
-    const auto nphixstargets = get_nphixstargets(element, ion, level);
+    const auto nphixstargets = get_nphixstargets(uniquelevelindex);
     for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-      const double epsilon_trans = get_phixs_threshold(element, ion, level, phixstargetindex);
+      const double epsilon_trans = get_phixs_threshold(uniquelevelindex, phixstargetindex);
 
       const double R = get_corrphotoioncoeff(element, ion, level, phixstargetindex, nonemptymgi);
       const double C = col_ionization_ratecoeff(T_e, nne, element, ion, level, phixstargetindex, epsilon_trans);

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -865,8 +865,9 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans, const int element,
                                 const int ion, const int upper, const LevelTransition &downtransition) -> double {
   const int lower = downtransition.targetlevelindex;
-  const double upperstatweight = stat_weight(element, ion, upper);
-  const double lowerstatweight = stat_weight(element, ion, lower);
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double upperstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + upper];
+  const double lowerstatweight = globals::alllevels_statweight[ionuniquelevelindexstart + lower];
   const double coll_str_thisline = downtransition.coll_str;
   if (coll_str_thisline < 0) {
     const bool forbidden = downtransition.forbidden;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -88,7 +88,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto *const uptranslist = get_uptranslist(element, ion, level);
   for (int i = 0; i < nuptrans; i++) {
     const auto &uptrans = uptranslist[i];
-    const double epsilon_trans = epsilon(element, ion, uptrans.targetlevelindex) - epsilon_current;
+    const double epsilon_trans =
+        globals::alllevels_epsilon[ionuniquelevelindexstart + uptrans.targetlevelindex] - epsilon_current;
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
                                               uptrans.lineindex, t_mid);

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -621,7 +621,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
   if (pkt.type == TYPE_RPKT) {
     if constexpr (VPKT_ON) {
-      vpkt_call_estimators(pkt, TYPE_MA);
+      vpkt::call_estimators(pkt, TYPE_MA);
     }
   }
 }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -160,23 +160,6 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   return processrates;
 }
 
-auto do_macroatom_internal_down_same(const int uniquelevelindex, const double *sum_internal_down_same) -> int {
-  const int ndowntrans = get_ndowntrans(uniquelevelindex);
-
-  // Randomly select the occurring transition
-  const double targetval = rng_uniform() * sum_internal_down_same[ndowntrans - 1];
-
-  // first sum_internal_down_same[i] such that sum_internal_down_same[i] > targetval
-  const auto downtransindex =
-      std::upper_bound(sum_internal_down_same, sum_internal_down_same + ndowntrans - 1, targetval) -
-      sum_internal_down_same;
-  const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
-
-  const int lower = globals::alltrans.targetlevelindex[alltrans_startdown + downtransindex];
-
-  return lower;
-}
-
 // radiative deexcitation
 void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion, const int uniquelevelindex,
                                   const double epsilon_current, const int activatingline,
@@ -453,7 +436,19 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
       case MA_ACTION_INTERNALDOWNSAME: {
         stats::increment(stats::COUNTER_INTERACTIONS);
-        level = do_macroatom_internal_down_same(uniquelevelindex, chlevel.sum_internal_down_same);
+        const double *sum_internal_down_same = chlevel.sum_internal_down_same;
+        const int ndowntrans = get_ndowntrans(uniquelevelindex);
+
+        // Randomly select the occurring transition
+        const double targetval = rng_uniform() * sum_internal_down_same[ndowntrans - 1];
+
+        // first sum_internal_down_same[i] such that sum_internal_down_same[i] > targetval
+        const auto downtransindex =
+            std::upper_bound(sum_internal_down_same, sum_internal_down_same + ndowntrans - 1, targetval) -
+            sum_internal_down_same;
+        const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
+
+        level = globals::alltrans.targetlevelindex[alltrans_startdown + downtransindex];
 
         break;
       }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -63,10 +63,11 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const double epsilon_target = epsilon(ionuniquelevelindexstart + lower);
     const double epsilon_trans = epsilon_current - epsilon_target;
     const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
+    const auto lower_statweight = stat_weight(lower_uniquelevelindex);
 
     const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
-                                                nnlevel, t_mid);
-    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtrans);
+                                                lower_statweight, nnlevel, t_mid);
+    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, downtrans);
 
     sum_raddeexc += R * epsilon_trans;
     sum_coldeexc += C * epsilon_trans;
@@ -655,8 +656,8 @@ void macroatom_close_file() {
 // multiply by upper level population to get a rate per second
 
 auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelevelindex, const double epsilon_trans,
-                                const float A_ul, const double upperstatweight, const double nnlevelupper,
-                                const double t_current) -> double {
+                                const float A_ul, const double upperstatweight, const double lowerstatweight,
+                                const double nnlevelupper, const double t_current) -> double {
   const auto &n_u = nnlevelupper;
   const double n_l = get_levelpop(nonemptymgi, lower_uniquelevelindex);
 
@@ -667,7 +668,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight / stat_weight(lower_uniquelevelindex) * B_ul;
+    const double B_lu = upperstatweight / lowerstatweight * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -846,12 +847,9 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 
 // multiply by upper level population to get a rate per second
 
-auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans, const int element,
-                                const int ion, const double upperstatweight, const LevelTransition &downtransition)
-    -> double {
-  const int lower = downtransition.targetlevelindex;
-  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double lowerstatweight = stat_weight(ionuniquelevelindexstart + lower);
+auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans,
+                                const double upperstatweight, const double lowerstatweight,
+                                const LevelTransition &downtransition) -> double {
   const double coll_str_thisline = downtransition.coll_str;
   if (coll_str_thisline < 0) {
     const bool forbidden = downtransition.forbidden;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -950,7 +950,7 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
     // Axelrod's approximation (thesis 1980)
     const int upper = uptrans.targetlevelindex;
     const double upperstatweight =
-        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + upper];
+        globals::alllevels_statweight[globals::elements[element].ions[ion].uniquelevelindexstart + upper];
 
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -668,7 +668,9 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
+    const double B_lu =
+        upperstatweight /
+        globals::alllevels_statweight[globals::elements[element].ions[ion].uniquelevelindexstart + lower] * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -668,9 +668,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight /
-                        globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart + lower] *
-                        B_ul;
+    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -674,19 +674,9 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
       // const double beta = 1.;
       R = A_ul * beta;
     } else {
-      // printout("[warning] rad_deexcitation: tau_sobolev %g <= 0, set beta=1\n",tau_sobolev);
-      // printout("[warning] rad_deexcitation: element %d, ion %d, upper %d, lower %d\n",element,ion,upper,lower);
-      // printout("[warning] rad_deexcitation: n_l %g, n_u %g, B_lu %g, B_ul %g\n",n_l,n_u,B_lu,B_ul);
-      // printout("[warning] rad_deexcitation: T_e %g, T_R %g, W %g in model cell
-      // %d\n",grid::get_Te(nonemptymgi),get_TR(nonemptymgi),get_W(nonemptymgi),modelgridindex);
       R = 0.;
-      // printout("[fatal] rad_excitation: tau_sobolev <= 0 ... %g abort",tau_sobolev);
-      // abort();
     }
 
-    // printout("[debug] rad_rates_down: Z=%d, ionstage %d, upper %d, lower %d\n", get_atomicnumber(element),
-    // get_ionstage(element, ion), upper, lower); printout("[debug] rad_deexc: A_ul %g, tau_sobolev %g, n_u %g\n",
-    // A_ul, tau_sobolev, n_u);
     assert_testmodeonly(std::isfinite(R));
   }
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -530,7 +530,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
           printout("internal downward transition to ground level occurred ... abort\n");
           printout("element %d, ion %d, level %d, lower %d\n", element, ion, level, lower);
           printout("Z %d, ionstage %d, energy %g\n", get_atomicnumber(element), get_ionstage(element, ion - 1),
-                   get_ion_levels(element, ion - 1)[lower].epsilon);
+                   epsilon(element, ion - 1, lower));
           printout("[debug] do_ma:   internal downward jump to lower ionstage\n");
           std::abort();
         }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -59,8 +59,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
   for (int i = 0; i < ndowntrans; i++) {
     const auto alltransindex = alltrans_startdown + i;
-    const int lower = globals::alltrans[alltransindex].targetlevelindex;
-    const auto A_ul = globals::alltrans[alltransindex].einstein_A;
+    const int lower = globals::alltrans.targetlevelindex[alltransindex];
+    const auto A_ul = globals::alltrans.einstein_A[alltransindex];
     const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
     const double epsilon_target = epsilon(lower_uniquelevelindex);
     const double epsilon_trans = epsilon_current - epsilon_target;
@@ -89,17 +89,19 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
   const int nuptrans = get_nuptrans(uniquelevelindex);
   for (int ii = 0; ii < nuptrans; ii++) {
-    const auto &uptrans = globals::alltrans[alltrans_startup + ii];
-    const auto upper_uniquelevelindex = ionuniquelevelindexstart + uptrans.targetlevelindex;
+    const auto alltransindex = alltrans_startup + ii;
+    const auto upper_uniquelevelindex = ionuniquelevelindexstart + globals::alltrans.targetlevelindex[alltransindex];
     const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_current;
     const auto upper_statweight = stat_weight(upper_uniquelevelindex);
 
-    const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight, uptrans,
-                                              epsilon_trans, nnlevel, statweight, uptrans.lineindex, t_mid);
+    const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight,
+                                              globals::alltrans.lineindex[alltransindex], epsilon_trans, nnlevel,
+                                              statweight, globals::alltrans.lineindex[alltransindex], t_mid);
     const double C =
         col_excitation_ratecoeff(T_e, nne, upper_statweight, alltrans_startup + ii, epsilon_trans, statweight);
     const double NT =
-        nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, uptrans.targetlevelindex, uptrans.lineindex);
+        nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, globals::alltrans.targetlevelindex[alltransindex],
+                                            globals::alltrans.lineindex[alltransindex]);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
     chlevel.sum_internal_up_same[ii] = sum_internal_up_same;
@@ -173,18 +175,19 @@ auto do_macroatom_internal_down_same(const int uniquelevelindex, const CellCache
   const auto downtransindex =
       std::upper_bound(sum_internal_down_same, sum_internal_down_same + ndowntrans - 1, targetval) -
       sum_internal_down_same;
+  const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
 
-  const int lower = get_downtranslist(uniquelevelindex)[downtransindex].targetlevelindex;
+  const int lower = globals::alltrans.targetlevelindex[alltrans_startdown + downtransindex];
 
   return lower;
 }
 
 // radiative deexcitation
-void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion, const int level,
+void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion, const int uniquelevelindex,
                                   const double epsilon_current, const int activatingline,
                                   const CellCacheLevels &chlevel) {
   // randomly select which line transitions occurs
-  const int ndowntrans = get_ndowntrans(element, ion, level);
+  const int ndowntrans = get_ndowntrans(uniquelevelindex);
 
   const auto *sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
 
@@ -194,19 +197,21 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
   const auto downtransindex =
       std::upper_bound(sum_epstrans_rad_deexc, sum_epstrans_rad_deexc + ndowntrans - 1, targetval) -
       sum_epstrans_rad_deexc;
+  const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
 
-  const auto &downtrans = get_downtranslist(element, ion, level)[downtransindex];
+  const auto lineindex = globals::alltrans.lineindex[alltrans_startdown + downtransindex];
 
-  if (downtrans.lineindex == activatingline) {
+  if (lineindex == activatingline) {
     stats::increment(stats::COUNTER_RESONANCESCATTERINGS);
   }
 
   if constexpr (RECORD_LINESTAT) {
-    atomicadd(globals::ecounter[downtrans.lineindex], 1);
+    atomicadd(globals::ecounter[lineindex], 1);
   }
 
-  const double epsilon_trans = epsilon_current - epsilon(globals::elements[element].ions[ion].uniquelevelindexstart +
-                                                         downtrans.targetlevelindex);
+  const double epsilon_trans =
+      epsilon_current - epsilon(globals::elements[element].ions[ion].uniquelevelindexstart +
+                                globals::alltrans.targetlevelindex[alltrans_startdown + downtransindex]);
 
   const double oldnucmf = pkt.nu_cmf;
   pkt.nu_cmf = epsilon_trans / H;
@@ -222,8 +227,8 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
   emit_rpkt(pkt);
 
   // the r-pkt can only interact with lines redder than the current one
-  pkt.next_trans = downtrans.lineindex + 1;
-  pkt.emissiontype = downtrans.lineindex;
+  pkt.next_trans = lineindex + 1;
+  pkt.emissiontype = lineindex;
   pkt.em_pos = pkt.pos;
   pkt.em_time = pkt.prop_time;
   pkt.nscatterings = 0;
@@ -409,7 +414,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
     switch (selected_action) {
       case MA_ACTION_RADDEEXC: {
         // printout("[debug] do_ma:   radiative deexcitation\n");
-        do_macroatom_raddeexcitation(pkt, element, ion, level, epsilon_current, activatingline, chlevel);
+        do_macroatom_raddeexcitation(pkt, element, ion, uniquelevelindex, epsilon_current, activatingline, chlevel);
 
         if constexpr (TRACK_ION_STATS) {
           stats::increment_ion_stats(nonemptymgi, element, ion, stats::ION_MACROATOM_ENERGYOUT_RADDEEXC, pkt.e_cmf);
@@ -561,8 +566,9 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
         const auto uptransindex =
             std::upper_bound(sum_internal_up_same, sum_internal_up_same + nuptrans - 1, targetval) -
             sum_internal_up_same;
+        const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
 
-        const int upper = get_uptranslist(uniquelevelindex)[uptransindex].targetlevelindex;
+        const int upper = globals::alltrans.targetlevelindex[alltrans_startup + uptransindex];
 
         level = upper;
         break;
@@ -692,12 +698,12 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
 // radiative excitation rate: paperII 3.5.2
 // multiply by lower level population to get a rate per second
 auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevelindex, const double upper_statweight,
-                              const LevelTransition &uptrans, const double epsilon_trans, const double nnlevel_lower,
+                              const double einstein_A, const double epsilon_trans, const double nnlevel_lower,
                               const double statweight_lower, const int lineindex, const double t_current) -> double {
   const double n_u = get_levelpop(nonemptymgi, upper_uniquelevelindex);
   const auto &n_l = nnlevel_lower;
   const double nu_trans = epsilon_trans / H;
-  const double A_ul = uptrans.einstein_A;
+  const double A_ul = einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
   const double B_lu = upper_statweight / statweight_lower * B_ul;
 
@@ -849,9 +855,9 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans,
                                 const double upperstatweight, const double lowerstatweight, const int alltransindex)
     -> double {
-  const double coll_strength = globals::alltrans[alltransindex].coll_str;
+  const double coll_strength = globals::alltrans.coll_str[alltransindex];
   if (coll_strength < 0) {
-    if (!globals::alltrans[alltransindex].forbidden)  // alternative: (coll_strength > -1.5) i.e. to catch -1
+    if (!globals::alltrans.forbidden[alltransindex])  // alternative: (coll_strength > -1.5) i.e. to catch -1
     {
       // permitted E1 electric dipole transitions
       // collisional deexcitation: formula valid only for atoms!!!!!!!!!!!
@@ -859,7 +865,7 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
       // f = osc_strength(element,ion,upper,lower);
       // C = n_u * 2.16 * pow(fac1,-1.68) * pow(T_e,-1.5) *
       // stat_weight(element,ion,lower)/stat_weight(element,ion,upper)  * nne * f;
-      const double trans_osc_strength = globals::alltrans[alltransindex].osc_strength;
+      const double trans_osc_strength = globals::alltrans.osc_strength[alltransindex];
 
       const double eoverkt = epsilon_trans / (KB * T_e);
       // Van-Regemorter formula, Mihalas (1978), eq.5-75, p.133
@@ -895,14 +901,14 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
 // multiply by lower level population to get a rate per second
 auto col_excitation_ratecoeff(const float T_e, const float nne, const double upperstatweight, const int alltransindex,
                               const double epsilon_trans, const double lowerstatweight) -> double {
-  const double coll_strength = globals::alltrans[alltransindex].coll_str;
+  const double coll_strength = globals::alltrans.coll_str[alltransindex];
   const double eoverkt = epsilon_trans / (KB * T_e);
 
   if (coll_strength < 0) {
-    const bool forbidden = globals::alltrans[alltransindex].forbidden;
+    const bool forbidden = globals::alltrans.forbidden[alltransindex];
     if (!forbidden) {
       // alternative condition: (coll_strength > -1.5) i.e. to catch -1
-      const double trans_osc_strength = globals::alltrans[alltransindex].osc_strength;
+      const double trans_osc_strength = globals::alltrans.osc_strength[alltransindex];
       // permitted E1 electric dipole transitions
       // collisional excitation: formula valid only for atoms!!!!!!!!!!!
       // Rutten script eq. 3.32. p.50

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -160,12 +160,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   return processrates;
 }
 
-auto do_macroatom_internal_down_same(const int uniquelevelindex, const CellCacheLevels &chlevel) -> int {
+auto do_macroatom_internal_down_same(const int uniquelevelindex, const double *sum_internal_down_same) -> int {
   const int ndowntrans = get_ndowntrans(uniquelevelindex);
-
-  // printout("[debug] do_ma:   internal downward jump within current ionstage\n");
-
-  const double *sum_internal_down_same = chlevel.sum_internal_down_same;
 
   // Randomly select the occurring transition
   const double targetval = rng_uniform() * sum_internal_down_same[ndowntrans - 1];
@@ -457,7 +453,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
       case MA_ACTION_INTERNALDOWNSAME: {
         stats::increment(stats::COUNTER_INTERACTIONS);
-        level = do_macroatom_internal_down_same(uniquelevelindex, chlevel);
+        level = do_macroatom_internal_down_same(uniquelevelindex, chlevel.sum_internal_down_same);
 
         break;
       }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -201,7 +201,9 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
     atomicadd(globals::ecounter[downtrans.lineindex], 1);
   }
 
-  const double epsilon_trans = epsilon_current - epsilon(element, ion, downtrans.targetlevelindex);
+  const double epsilon_trans =
+      epsilon_current - globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart +
+                                                   downtrans.targetlevelindex];
 
   const double oldnucmf = pkt.nu_cmf;
   pkt.nu_cmf = epsilon_trans / H;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -53,8 +53,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   double sum_internal_down_same = 0.;
   double sum_raddeexc = 0.;
   double sum_coldeexc = 0.;
-  const int ndowntrans = get_ndowntrans(element, ion, level);
-  const auto *const leveldowntranslist = get_downtranslist(element, ion, level);
+  const int ndowntrans = get_ndowntrans(ionuniquelevelindexstart + level);
+  const auto *const leveldowntranslist = get_downtranslist(ionuniquelevelindexstart + level);
   auto *const arr_sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
   for (int i = 0; i < ndowntrans; i++) {
@@ -84,8 +84,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // Calculate sum for upward internal transitions
   // transitions within the current ionisation stage
   double sum_internal_up_same = 0.;
-  const int nuptrans = get_nuptrans(element, ion, level);
-  const auto *const uptranslist = get_uptranslist(element, ion, level);
+  const int nuptrans = get_nuptrans(ionuniquelevelindexstart + level);
+  const auto *const uptranslist = get_uptranslist(ionuniquelevelindexstart + level);
   for (int i = 0; i < nuptrans; i++) {
     const auto &uptrans = uptranslist[i];
     const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
@@ -153,9 +153,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   return processrates;
 }
 
-auto do_macroatom_internal_down_same(const int element, const int ion, const int level, const CellCacheLevels &chlevel)
-    -> int {
-  const int ndowntrans = get_ndowntrans(element, ion, level);
+auto do_macroatom_internal_down_same(const int uniquelevelindex, const CellCacheLevels &chlevel) -> int {
+  const int ndowntrans = get_ndowntrans(uniquelevelindex);
 
   // printout("[debug] do_ma:   internal downward jump within current ionstage\n");
 
@@ -169,7 +168,7 @@ auto do_macroatom_internal_down_same(const int element, const int ion, const int
       std::upper_bound(sum_internal_down_same, sum_internal_down_same + ndowntrans - 1, targetval) -
       sum_internal_down_same;
 
-  const int lower = get_downtranslist(element, ion, level)[downtransindex].targetlevelindex;
+  const int lower = get_downtranslist(uniquelevelindex)[downtransindex].targetlevelindex;
 
   return lower;
 }
@@ -448,7 +447,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
       case MA_ACTION_INTERNALDOWNSAME: {
         stats::increment(stats::COUNTER_INTERACTIONS);
-        level = do_macroatom_internal_down_same(element, ion, level, chlevel);
+        level = do_macroatom_internal_down_same(ionuniquelevelindexstart + level, chlevel);
 
         break;
       }
@@ -557,7 +556,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
             std::upper_bound(sum_internal_up_same, sum_internal_up_same + nuptrans - 1, targetval) -
             sum_internal_up_same;
 
-        const int upper = get_uptranslist(element, ion, level)[uptransindex].targetlevelindex;
+        const int upper = get_uptranslist(ionuniquelevelindexstart + level)[uptransindex].targetlevelindex;
 
         level = upper;
         break;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -842,7 +842,6 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 }
 
 // multiply by upper level population to get a rate per second
-
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans,
                                 const double upperstatweight, const double lowerstatweight,
                                 const LevelTransition &downtransition) -> double {
@@ -891,7 +890,6 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
 }
 
 // multiply by lower level population to get a rate per second
-
 auto col_excitation_ratecoeff(const float T_e, const float nne, const double upperstatweight,
                               const LevelTransition &uptrans, const double epsilon_trans, const double lowerstatweight)
     -> double {

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -666,8 +666,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu =
-        upperstatweight / stat_weight(globals::elements[element].ions[ion].uniquelevelindexstart + lower) * B_ul;
+    const double B_lu = upperstatweight / stat_weight(get_uniquelevelindex(element, ion, lower)) * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -291,7 +291,8 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
   // Randomly select the occurring transition
   const double targetrate = rng_uniform() * internal_up_higher;
   double rate = 0.;
-  const int nphixstargets = get_nphixstargets(element, ion, level);
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  const int nphixstargets = get_nphixstargets(uniquelevelindex);
   for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
     const double epsilon_trans = get_phixs_threshold(element, ion, level, phixstargetindex);
     const double R = get_corrphotoioncoeff(element, ion, level, phixstargetindex, nonemptymgi);
@@ -299,7 +300,7 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
     rate += (R + C) * epsilon_current;
     if (rate > targetrate) {
       // set the macroatom's new state
-      return get_phixsupperlevel(element, ion, level, phixstargetindex);
+      return get_phixsupperlevel(uniquelevelindex, phixstargetindex);
     }
   }
 
@@ -748,9 +749,10 @@ auto rad_recombination_ratecoeff(const float T_e, const float nne, const int ele
 
   double R = 0.;
   const int lowerion = upperion - 1;
-  const int nphixstargets = get_nphixstargets(element, lowerion, lowerionlevel);
+  const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerionlevel);
+  const int nphixstargets = get_nphixstargets(lowerionlower_uniquelevelindex);
   for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-    if (get_phixsupperlevel(element, lowerion, lowerionlevel, phixstargetindex) == upperionlevel) {
+    if (get_phixsupperlevel(lowerionlower_uniquelevelindex, phixstargetindex) == upperionlevel) {
       R = nne * get_spontrecombcoeff(element, lowerion, lowerionlevel, phixstargetindex, T_e);
 
       if constexpr (SEPARATE_STIMRECOMB) {
@@ -790,10 +792,10 @@ auto col_recombination_ratecoeff(const float T_e, const float nne, const int ele
   // in a case where this wasn't checked, the function will return zero anyway
   // if (upper > get_maxrecombininglevel(element, upperion))
   //   return 0.;
-
-  const int nphixstargets = get_nphixstargets(element, upperion - 1, lower);
+  const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, upperion - 1, lower);
+  const int nphixstargets = get_nphixstargets(lowerionlower_uniquelevelindex);
   for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-    if (get_phixsupperlevel(element, upperion - 1, lower, phixstargetindex) == upper) {
+    if (get_phixsupperlevel(lowerionlower_uniquelevelindex, phixstargetindex) == upper) {
       const double fac1 = epsilon_trans / KB / T_e;
       const int ionstage = get_ionstage(element, upperion);
 
@@ -808,8 +810,8 @@ auto col_recombination_ratecoeff(const float T_e, const float nne, const int ele
         g = 0.3;
       }
 
-      const double sigma_bf = (get_phixs_table(element, upperion - 1, lower)[0] *
-                               get_phixsprobability(element, upperion - 1, lower, phixstargetindex));
+      const double sigma_bf = (get_phixs_table(lowerionlower_uniquelevelindex)[0] *
+                               get_phixsprobability(lowerionlower_uniquelevelindex, phixstargetindex));
 
       const double sf = calculate_sahafact(element, upperion - 1, lower, upper, T_e, epsilon_trans);
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -90,7 +90,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto &uptrans = uptranslist[i];
     const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
 
-    const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
+    const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, uptrans, epsilon_trans, nnlevel, statweight,
                                               uptrans.lineindex, t_mid);
     const double C = col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, statweight);
     const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, uptrans.lineindex);
@@ -697,8 +697,8 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
 // radiative excitation rate: paperII 3.5.2
 // multiply by lower level population to get a rate per second
 
-auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const int ion, const int lower,
-                              const LevelTransition &uptrans, const double epsilon_trans, const double nnlevel_lower,
+auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const int ion, const LevelTransition &uptrans,
+                              const double epsilon_trans, const double nnlevel_lower, const double statweight_lower,
                               const int lineindex, const double t_current) -> double {
   const int upper = uptrans.targetlevelindex;
 
@@ -708,8 +708,7 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const in
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double B_lu =
-      stat_weight(ionuniquelevelindexstart + upper) / stat_weight(ionuniquelevelindexstart + lower) * B_ul;
+  const double B_lu = stat_weight(ionuniquelevelindexstart + upper) / statweight_lower * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -711,7 +711,9 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int element, const in
   const double nu_trans = epsilon_trans / H;
   const double A_ul = uptrans.einstein_A;
   const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-  const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+  const double B_lu = globals::alllevels_statweight[ionuniquelevelindexstart + upper] /
+                      globals::alllevels_statweight[ionuniquelevelindexstart + lower] * B_ul;
 
   const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -44,7 +44,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
   const auto T_e = grid::get_Te(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
-  const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+  const double epsilon_current = epsilon(ionuniquelevelindexstart + level);
   const double statweight = stat_weight(ionuniquelevelindexstart + level);
   const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
 
@@ -61,7 +61,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
     const auto &downtrans = leveldowntranslist[i];
     const int lower = downtrans.targetlevelindex;
     const auto A_ul = downtrans.einstein_A;
-    const double epsilon_target = globals::alllevels_epsilon[ionuniquelevelindexstart + lower];
+    const double epsilon_target = epsilon(ionuniquelevelindexstart + lower);
     const double epsilon_trans = epsilon_current - epsilon_target;
 
     const double R =
@@ -88,8 +88,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const auto *const uptranslist = get_uptranslist(element, ion, level);
   for (int i = 0; i < nuptrans; i++) {
     const auto &uptrans = uptranslist[i];
-    const double epsilon_trans =
-        globals::alllevels_epsilon[ionuniquelevelindexstart + uptrans.targetlevelindex] - epsilon_current;
+    const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
                                               uptrans.lineindex, t_mid);
@@ -113,7 +112,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   if (ion > 0 && level <= get_maxrecombininglevel(element, ion)) {
     const int nlevels = get_nlevels_ionising(element, ion - 1);
     for (int lower = 0; lower < nlevels; lower++) {
-      const double epsilon_target = globals::alllevels_epsilon[lowerionuniquelevelindexstart + lower];
+      const double epsilon_target = epsilon(lowerionuniquelevelindexstart + lower);
       const double epsilon_trans = epsilon_current - epsilon_target;
 
       const double R = rad_recombination_ratecoeff(T_e, nne, element, ion, level, lower, nonemptymgi);
@@ -201,9 +200,8 @@ void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion,
     atomicadd(globals::ecounter[downtrans.lineindex], 1);
   }
 
-  const double epsilon_trans =
-      epsilon_current - globals::alllevels_epsilon[globals::elements[element].ions[ion].uniquelevelindexstart +
-                                                   downtrans.targetlevelindex];
+  const double epsilon_trans = epsilon_current - epsilon(globals::elements[element].ions[ion].uniquelevelindexstart +
+                                                         downtrans.targetlevelindex);
 
   const double oldnucmf = pkt.nu_cmf;
   pkt.nu_cmf = epsilon_trans / H;
@@ -358,7 +356,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
     assert_testmodeonly(ion < get_nions(element));
     const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
 
-    const double epsilon_current = globals::alllevels_epsilon[ionuniquelevelindexstart + level];
+    const double epsilon_current = epsilon(ionuniquelevelindexstart + level);
     const int nuptrans = get_nuptrans(element, ion, level);
 
     auto &chlevel = globals::cellcache[cellcacheslotid].chelements[element].chions[ion].chlevels[level];

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -666,7 +666,7 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int element, const 
     const double nu_trans = epsilon_trans / H;
 
     const double B_ul = CLIGHTSQUAREDOVERTWOH / std::pow(nu_trans, 3) * A_ul;
-    const double B_lu = upperstatweight / stat_weight(get_uniquelevelindex(element, ion, lower)) * B_ul;
+    const double B_lu = upperstatweight / stat_weight(element, ion, lower) * B_ul;
 
     const double tau_sobolev = (B_lu * n_l - B_ul * n_u) * HCLIGHTOVERFOURPI * t_current;
 
@@ -945,7 +945,7 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const int elemen
     // forbidden transitions: magnetic dipole, electric quadropole...
     // Axelrod's approximation (thesis 1980)
     const int upper = uptrans.targetlevelindex;
-    const double upperstatweight = stat_weight(globals::elements[element].ions[ion].uniquelevelindexstart + upper);
+    const double upperstatweight = stat_weight(element, ion, upper);
 
     return nne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -87,20 +87,22 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // Calculate sum for upward internal transitions
   // transitions within the current ionisation stage
   double sum_internal_up_same = 0.;
-  const auto uptranslist = get_uptransspan(uniquelevelindex);
-  for (int i = 0; i < std::ssize(uptranslist); i++) {
-    const auto &uptrans = uptranslist[i];
+  const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
+  const int nuptrans = get_nuptrans(uniquelevelindex);
+  for (int ii = 0; ii < nuptrans; ii++) {
+    const auto &uptrans = globals::alltrans[alltrans_startup + ii];
     const auto upper_uniquelevelindex = ionuniquelevelindexstart + uptrans.targetlevelindex;
     const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_current;
     const auto upper_statweight = stat_weight(upper_uniquelevelindex);
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight, uptrans,
                                               epsilon_trans, nnlevel, statweight, uptrans.lineindex, t_mid);
-    const double C = col_excitation_ratecoeff(T_e, nne, upper_statweight, uptrans, epsilon_trans, statweight);
-    const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, uptrans.lineindex);
+    const double C =
+        col_excitation_ratecoeff(T_e, nne, upper_statweight, alltrans_startup + ii, epsilon_trans, statweight);
+    const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, ii, uptrans.lineindex);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
-    chlevel.sum_internal_up_same[i] = sum_internal_up_same;
+    chlevel.sum_internal_up_same[ii] = sum_internal_up_same;
   }
   processrates[MA_ACTION_INTERNALUPSAME] = sum_internal_up_same;
 
@@ -890,17 +892,16 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
 }
 
 // multiply by lower level population to get a rate per second
-auto col_excitation_ratecoeff(const float T_e, const float nne, const double upperstatweight,
-                              const LevelTransition &uptrans, const double epsilon_trans, const double lowerstatweight)
-    -> double {
-  const double coll_strength = uptrans.coll_str;
+auto col_excitation_ratecoeff(const float T_e, const float nne, const double upperstatweight, const int alltransindex,
+                              const double epsilon_trans, const double lowerstatweight) -> double {
+  const double coll_strength = globals::alltrans[alltransindex].coll_str;
   const double eoverkt = epsilon_trans / (KB * T_e);
 
   if (coll_strength < 0) {
-    const bool forbidden = uptrans.forbidden;
+    const bool forbidden = globals::alltrans[alltransindex].forbidden;
     if (!forbidden) {
       // alternative condition: (coll_strength > -1.5) i.e. to catch -1
-      const double trans_osc_strength = uptrans.osc_strength;
+      const double trans_osc_strength = globals::alltrans[alltransindex].osc_strength;
       // permitted E1 electric dipole transitions
       // collisional excitation: formula valid only for atoms!!!!!!!!!!!
       // Rutten script eq. 3.32. p.50

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -53,8 +53,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   double sum_internal_down_same = 0.;
   double sum_raddeexc = 0.;
   double sum_coldeexc = 0.;
-  const int ndowntrans = get_ndowntrans(ionuniquelevelindexstart + level);
-  const auto *const leveldowntranslist = get_downtranslist(ionuniquelevelindexstart + level);
+  const int ndowntrans = get_ndowntrans(element, ion, level);
+  const auto *const leveldowntranslist = get_downtranslist(element, ion, level);
   auto *const arr_sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
   for (int i = 0; i < ndowntrans; i++) {
@@ -84,8 +84,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   // Calculate sum for upward internal transitions
   // transitions within the current ionisation stage
   double sum_internal_up_same = 0.;
-  const int nuptrans = get_nuptrans(ionuniquelevelindexstart + level);
-  const auto *const uptranslist = get_uptranslist(ionuniquelevelindexstart + level);
+  const int nuptrans = get_nuptrans(element, ion, level);
+  const auto *const uptranslist = get_uptranslist(element, ion, level);
   for (int i = 0; i < nuptrans; i++) {
     const auto &uptrans = uptranslist[i];
     const double epsilon_trans = epsilon(ionuniquelevelindexstart + uptrans.targetlevelindex) - epsilon_current;
@@ -153,8 +153,9 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   return processrates;
 }
 
-auto do_macroatom_internal_down_same(const int uniquelevelindex, const CellCacheLevels &chlevel) -> int {
-  const int ndowntrans = get_ndowntrans(uniquelevelindex);
+auto do_macroatom_internal_down_same(const int element, const int ion, const int level, const CellCacheLevels &chlevel)
+    -> int {
+  const int ndowntrans = get_ndowntrans(element, ion, level);
 
   // printout("[debug] do_ma:   internal downward jump within current ionstage\n");
 
@@ -168,7 +169,7 @@ auto do_macroatom_internal_down_same(const int uniquelevelindex, const CellCache
       std::upper_bound(sum_internal_down_same, sum_internal_down_same + ndowntrans - 1, targetval) -
       sum_internal_down_same;
 
-  const int lower = get_downtranslist(uniquelevelindex)[downtransindex].targetlevelindex;
+  const int lower = get_downtranslist(element, ion, level)[downtransindex].targetlevelindex;
 
   return lower;
 }
@@ -447,7 +448,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
       case MA_ACTION_INTERNALDOWNSAME: {
         stats::increment(stats::COUNTER_INTERACTIONS);
-        level = do_macroatom_internal_down_same(ionuniquelevelindexstart + level, chlevel);
+        level = do_macroatom_internal_down_same(element, ion, level, chlevel);
 
         break;
       }
@@ -556,7 +557,7 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
             std::upper_bound(sum_internal_up_same, sum_internal_up_same + nuptrans - 1, targetval) -
             sum_internal_up_same;
 
-        const int upper = get_uptranslist(ionuniquelevelindexstart + level)[uptransindex].targetlevelindex;
+        const int upper = get_uptranslist(element, ion, level)[uptransindex].targetlevelindex;
 
         level = upper;
         break;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -58,9 +58,9 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   auto *const arr_sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
   for (int i = 0; i < ndowntrans; i++) {
-    const auto &downtrans = globals::alltrans[alltrans_startdown + i];
-    const int lower = downtrans.targetlevelindex;
-    const auto A_ul = downtrans.einstein_A;
+    const auto alltransindex = alltrans_startdown + i;
+    const int lower = globals::alltrans[alltransindex].targetlevelindex;
+    const auto A_ul = globals::alltrans[alltransindex].einstein_A;
     const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
     const double epsilon_target = epsilon(lower_uniquelevelindex);
     const double epsilon_trans = epsilon_current - epsilon_target;
@@ -68,8 +68,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
     const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
                                                 lower_statweight, nnlevel, t_mid);
-    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight,
-                                                downtrans.coll_str, downtrans.osc_strength, downtrans.forbidden);
+    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, alltransindex);
 
     sum_raddeexc += R * epsilon_trans;
     sum_coldeexc += C * epsilon_trans;
@@ -848,10 +847,11 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 
 // multiply by upper level population to get a rate per second
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans,
-                                const double upperstatweight, const double lowerstatweight, const float coll_str,
-                                const float osc_strength, const bool forbidden) -> double {
-  if (coll_str < 0) {
-    if (!forbidden)  // alternative: (coll_strength > -1.5) i.e. to catch -1
+                                const double upperstatweight, const double lowerstatweight, const int alltransindex)
+    -> double {
+  const double coll_strength = globals::alltrans[alltransindex].coll_str;
+  if (coll_strength < 0) {
+    if (!globals::alltrans[alltransindex].forbidden)  // alternative: (coll_strength > -1.5) i.e. to catch -1
     {
       // permitted E1 electric dipole transitions
       // collisional deexcitation: formula valid only for atoms!!!!!!!!!!!
@@ -859,7 +859,7 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
       // f = osc_strength(element,ion,upper,lower);
       // C = n_u * 2.16 * pow(fac1,-1.68) * pow(T_e,-1.5) *
       // stat_weight(element,ion,lower)/stat_weight(element,ion,upper)  * nne * f;
-      const double trans_osc_strength = osc_strength;
+      const double trans_osc_strength = globals::alltrans[alltransindex].osc_strength;
 
       const double eoverkt = epsilon_trans / (KB * T_e);
       // Van-Regemorter formula, Mihalas (1978), eq.5-75, p.133
@@ -889,7 +889,7 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
   // positive coll_str is treated as effective collision strength
 
   // from Osterbrock and Ferland, p51
-  return nne * 8.629e-6 * coll_str / upperstatweight / std::sqrt(T_e);
+  return nne * 8.629e-6 * coll_strength / upperstatweight / std::sqrt(T_e);
 }
 
 // multiply by lower level population to get a rate per second

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -36,7 +36,8 @@ constexpr bool LOG_MACROATOM = false;
 FILE *macroatom_file{};
 
 auto calculate_macroatom_transitionrates(const int nonemptymgi, const int element, const int ion, const int level,
-                                         const double t_mid, CellCacheLevels &chlevel) {
+                                         const double t_mid, CellCacheLevels &chlevel,
+                                         const globals::AllTransitions &alltrans) {
   // printout("Calculating transition rates for element %d ion %d level %d\n", element, ion, level);
   auto processrates = std::array<double, MA_ACTION_COUNT>{};
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
@@ -59,8 +60,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
   for (int i = 0; i < ndowntrans; i++) {
     const auto alltransindex = alltrans_startdown + i;
-    const int lower = globals::alltrans.targetlevelindex[alltransindex];
-    const auto A_ul = globals::alltrans.einstein_A[alltransindex];
+    const int lower = alltrans.targetlevelindex[alltransindex];
+    const auto A_ul = alltrans.einstein_A[alltransindex];
     const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
     const double epsilon_target = epsilon(lower_uniquelevelindex);
     const double epsilon_trans = epsilon_current - epsilon_target;
@@ -90,18 +91,16 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   const int nuptrans = get_nuptrans(uniquelevelindex);
   for (int ii = 0; ii < nuptrans; ii++) {
     const auto alltransindex = alltrans_startup + ii;
-    const auto upper_uniquelevelindex = ionuniquelevelindexstart + globals::alltrans.targetlevelindex[alltransindex];
+    const auto upper = alltrans.targetlevelindex[alltransindex];
+    const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
     const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_current;
     const auto upper_statweight = stat_weight(upper_uniquelevelindex);
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight,
-                                              globals::alltrans.lineindex[alltransindex], epsilon_trans, nnlevel,
-                                              statweight, globals::alltrans.lineindex[alltransindex], t_mid);
-    const double C =
-        col_excitation_ratecoeff(T_e, nne, upper_statweight, alltrans_startup + ii, epsilon_trans, statweight);
-    const double NT =
-        nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, globals::alltrans.targetlevelindex[alltransindex],
-                                            globals::alltrans.lineindex[alltransindex]);
+                                              alltrans.einstein_A[alltransindex], epsilon_trans, nnlevel, statweight,
+                                              alltrans.lineindex[alltransindex], t_mid);
+    const double C = col_excitation_ratecoeff(T_e, nne, upper_statweight, alltransindex, epsilon_trans, statweight);
+    const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, alltrans.lineindex[alltransindex]);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
     chlevel.sum_internal_up_same[ii] = sum_internal_up_same;
@@ -382,7 +381,8 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
 
       // If there are no precalculated rates available then calculate them
       if (chlevel.processrates[MA_ACTION_INTERNALUPHIGHER] < 0) {
-        chlevel.processrates = calculate_macroatom_transitionrates(nonemptymgi, element, ion, level, t_mid, chlevel);
+        chlevel.processrates =
+            calculate_macroatom_transitionrates(nonemptymgi, element, ion, level, t_mid, chlevel, globals::alltrans);
       }
     }
 
@@ -855,7 +855,7 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans,
                                 const double upperstatweight, const double lowerstatweight, const int alltransindex)
     -> double {
-  const double coll_strength = globals::alltrans.coll_str[alltransindex];
+  const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   if (coll_strength < 0) {
     if (!globals::alltrans.forbidden[alltransindex])  // alternative: (coll_strength > -1.5) i.e. to catch -1
     {
@@ -895,13 +895,13 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
   // positive coll_str is treated as effective collision strength
 
   // from Osterbrock and Ferland, p51
-  return nne * 8.629e-6 * coll_strength / upperstatweight / std::sqrt(T_e);
+  return nne * 8.629e-6 * static_cast<double>(coll_strength) / upperstatweight / std::sqrt(T_e);
 }
 
 // multiply by lower level population to get a rate per second
 auto col_excitation_ratecoeff(const float T_e, const float nne, const double upperstatweight, const int alltransindex,
                               const double epsilon_trans, const double lowerstatweight) -> double {
-  const double coll_strength = globals::alltrans.coll_str[alltransindex];
+  const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   const double eoverkt = epsilon_trans / (KB * T_e);
 
   if (coll_strength < 0) {
@@ -937,5 +937,5 @@ auto col_excitation_ratecoeff(const float T_e, const float nne, const double upp
   }
 
   // from Osterbrock and Ferland, p51
-  return nne * 8.629e-6 * coll_strength * std::exp(-eoverkt) / lowerstatweight / std::sqrt(T_e);
+  return nne * 8.629e-6 * static_cast<double>(coll_strength) * std::exp(-eoverkt) / lowerstatweight / std::sqrt(T_e);
 }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -654,7 +654,6 @@ void macroatom_close_file() {
 
 // radiative deexcitation rate: paperII 3.5.2
 // multiply by upper level population to get a rate per second
-
 auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelevelindex, const double epsilon_trans,
                                 const float A_ul, const double upperstatweight, const double lowerstatweight,
                                 const double nnlevelupper, const double t_current) -> double {
@@ -688,7 +687,6 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
 
 // radiative excitation rate: paperII 3.5.2
 // multiply by lower level population to get a rate per second
-
 auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevelindex, const double upper_statweight,
                               const LevelTransition &uptrans, const double epsilon_trans, const double nnlevel_lower,
                               const double statweight_lower, const int lineindex, const double t_current) -> double {
@@ -727,7 +725,6 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevel
 
 // radiative recombination rate: paperII 3.5.2
 // multiply by upper level population to get a rate per second
-
 auto rad_recombination_ratecoeff(const float T_e, const float nne, const int element, const int upperion,
                                  const int upperionlevel, const int lowerionlevel, const int nonemptymgi) -> double {
   // it's probably faster to only check this condition outside this function
@@ -773,7 +770,6 @@ auto stim_recombination_ratecoeff(const float nne, const int element, const int 
 }
 
 // multiply by upper level population to get a rate per second
-
 auto col_recombination_ratecoeff(const float T_e, const float nne, const int element, const int upperion,
                                  const int upper, const int lower, const double epsilon_trans) -> double {
   // it's probably faster to only check this condition outside this function

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -53,12 +53,11 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   double sum_internal_down_same = 0.;
   double sum_raddeexc = 0.;
   double sum_coldeexc = 0.;
-  const int ndowntrans = get_ndowntrans(ionuniquelevelindexstart + level);
-  const auto *const leveldowntranslist = get_downtranslist(ionuniquelevelindexstart + level);
+  const auto downtranslist = get_downtransspan(ionuniquelevelindexstart + level);
   auto *const arr_sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
   auto *const arr_sum_internal_down_same = chlevel.sum_internal_down_same;
-  for (int i = 0; i < ndowntrans; i++) {
-    const auto &downtrans = leveldowntranslist[i];
+  for (int i = 0; i < std::ssize(downtranslist); i++) {
+    const auto &downtrans = downtranslist[i];
     const int lower = downtrans.targetlevelindex;
     const auto A_ul = downtrans.einstein_A;
     const double epsilon_target = epsilon(ionuniquelevelindexstart + lower);

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -66,7 +66,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
     const double R =
         rad_deexcitation_ratecoeff(nonemptymgi, element, ion, lower, epsilon_trans, A_ul, statweight, nnlevel, t_mid);
-    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, level, downtrans);
+    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtrans);
 
     sum_raddeexc += R * epsilon_trans;
     sum_coldeexc += C * epsilon_trans;
@@ -859,10 +859,10 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 // multiply by upper level population to get a rate per second
 
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans, const int element,
-                                const int ion, const int upper, const LevelTransition &downtransition) -> double {
+                                const int ion, const double upperstatweight, const LevelTransition &downtransition)
+    -> double {
   const int lower = downtransition.targetlevelindex;
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
-  const double upperstatweight = stat_weight(ionuniquelevelindexstart + upper);
   const double lowerstatweight = stat_weight(ionuniquelevelindexstart + lower);
   const double coll_str_thisline = downtransition.coll_str;
   if (coll_str_thisline < 0) {

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -98,9 +98,9 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
     const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight,
                                               alltrans.einstein_A[alltransindex], epsilon_trans, nnlevel, statweight,
-                                              alltrans.lineindex[alltransindex], t_mid);
+                                              alltransindex, t_mid);
     const double C = col_excitation_ratecoeff(T_e, nne, upper_statweight, alltransindex, epsilon_trans, statweight);
-    const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, alltrans.lineindex[alltransindex]);
+    const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, alltransindex);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
     chlevel.sum_internal_up_same[ii] = sum_internal_up_same;
@@ -689,7 +689,8 @@ auto rad_deexcitation_ratecoeff(const int nonemptymgi, const int lower_uniquelev
 // multiply by lower level population to get a rate per second
 auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevelindex, const double upper_statweight,
                               const double einstein_A, const double epsilon_trans, const double nnlevel_lower,
-                              const double statweight_lower, const int lineindex, const double t_current) -> double {
+                              const double statweight_lower, const int alltransindex, const double t_current)
+    -> double {
   const double n_u = get_levelpop(nonemptymgi, upper_uniquelevelindex);
   const auto &n_l = nnlevel_lower;
   const double nu_trans = epsilon_trans / H;
@@ -707,7 +708,8 @@ auto rad_excitation_ratecoeff(const int nonemptymgi, const int upper_uniquelevel
     if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
       if (!globals::lte_iteration) {
         // check for a detailed line flux estimator to replace the binned/blackbody radiation field estimate
-        if (const int jblueindex = radfield::get_Jblueindex(lineindex); jblueindex >= 0) {
+        if (const int jblueindex = radfield::get_Jblueindex(globals::alltrans.lineindex[alltransindex]);
+            jblueindex >= 0) {
           return R_over_J_nu * radfield::get_Jb_lu(nonemptymgi, jblueindex);
         }
       }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -68,7 +68,8 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
     const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
                                                 lower_statweight, nnlevel, t_mid);
-    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, downtrans);
+    const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight,
+                                                downtrans.coll_str, downtrans.osc_strength, downtrans.forbidden);
 
     sum_raddeexc += R * epsilon_trans;
     sum_coldeexc += C * epsilon_trans;
@@ -844,11 +845,9 @@ auto col_ionization_ratecoeff(const float T_e, const float nne, const int elemen
 
 // multiply by upper level population to get a rate per second
 auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double epsilon_trans,
-                                const double upperstatweight, const double lowerstatweight,
-                                const LevelTransition &downtransition) -> double {
-  const double coll_str_thisline = downtransition.coll_str;
-  if (coll_str_thisline < 0) {
-    const bool forbidden = downtransition.forbidden;
+                                const double upperstatweight, const double lowerstatweight, const float coll_str,
+                                const float osc_strength, const bool forbidden) -> double {
+  if (coll_str < 0) {
     if (!forbidden)  // alternative: (coll_strength > -1.5) i.e. to catch -1
     {
       // permitted E1 electric dipole transitions
@@ -857,7 +856,7 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
       // f = osc_strength(element,ion,upper,lower);
       // C = n_u * 2.16 * pow(fac1,-1.68) * pow(T_e,-1.5) *
       // stat_weight(element,ion,lower)/stat_weight(element,ion,upper)  * nne * f;
-      const double trans_osc_strength = downtransition.osc_strength;
+      const double trans_osc_strength = osc_strength;
 
       const double eoverkt = epsilon_trans / (KB * T_e);
       // Van-Regemorter formula, Mihalas (1978), eq.5-75, p.133
@@ -884,10 +883,10 @@ auto col_deexcitation_ratecoeff(const float T_e, const float nne, const double e
     return nne * 8.629e-6 * 0.01 * lowerstatweight / std::sqrt(T_e);
   }
 
-  // positive coll_str_thisline is treated as effective collision strength
+  // positive coll_str is treated as effective collision strength
 
   // from Osterbrock and Ferland, p51
-  return nne * 8.629e-6 * coll_str_thisline / upperstatweight / std::sqrt(T_e);
+  return nne * 8.629e-6 * coll_str / upperstatweight / std::sqrt(T_e);
 }
 
 // multiply by lower level population to get a rate per second

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -102,7 +102,6 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
 
   assert_always(std::isfinite(processrates[MA_ACTION_INTERNALUPSAME]));
 
-  const auto lowerionuniquelevelindexstart = globals::elements[element].ions[ion - 1].uniquelevelindexstart;
   // Downward transitions to lower ionisation stages:
   // radiative/collisional recombination and internal downward jumps
   // checks only if there is a lower ion, doesn't make sure that Z(ion)=Z(ion-1)+1
@@ -111,6 +110,7 @@ auto calculate_macroatom_transitionrates(const int nonemptymgi, const int elemen
   double sum_colrecomb = 0.;
   if (ion > 0 && level <= get_maxrecombininglevel(element, ion)) {
     const int nlevels = get_nlevels_ionising(element, ion - 1);
+    const auto lowerionuniquelevelindexstart = globals::elements[element].ions[ion - 1].uniquelevelindexstart;
     for (int lower = 0; lower < nlevels; lower++) {
       const double epsilon_target = epsilon(lowerionuniquelevelindexstart + lower);
       const double epsilon_trans = epsilon_current - epsilon_target;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -184,11 +184,9 @@ auto do_macroatom_internal_down_same(const int uniquelevelindex, const CellCache
 // radiative deexcitation
 void do_macroatom_raddeexcitation(Packet &pkt, const int element, const int ion, const int uniquelevelindex,
                                   const double epsilon_current, const int activatingline,
-                                  const CellCacheLevels &chlevel) {
+                                  const auto *sum_epstrans_rad_deexc) {
   // randomly select which line transitions occurs
   const int ndowntrans = get_ndowntrans(uniquelevelindex);
-
-  const auto *sum_epstrans_rad_deexc = chlevel.sum_epstrans_rad_deexc;
 
   const double targetval = rng_uniform() * sum_epstrans_rad_deexc[ndowntrans - 1];
 
@@ -414,7 +412,8 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
     switch (selected_action) {
       case MA_ACTION_RADDEEXC: {
         // printout("[debug] do_ma:   radiative deexcitation\n");
-        do_macroatom_raddeexcitation(pkt, element, ion, uniquelevelindex, epsilon_current, activatingline, chlevel);
+        do_macroatom_raddeexcitation(pkt, element, ion, uniquelevelindex, epsilon_current, activatingline,
+                                     chlevel.sum_epstrans_rad_deexc);
 
         if constexpr (TRACK_ION_STATS) {
           stats::increment_ion_stats(nonemptymgi, element, ion, stats::ION_MACROATOM_ENERGYOUT_RADDEEXC, pkt.e_cmf);

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -353,11 +353,12 @@ __host__ __device__ void do_macroatom(Packet &pkt, const MacroAtomState &pktmast
     assert_testmodeonly(ion >= 0);
     assert_testmodeonly(ion < get_nions(element));
     const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
+    const int uniquelevelindex = ionuniquelevelindexstart + level;
 
-    const double epsilon_current = epsilon(ionuniquelevelindexstart + level);
-    const int nuptrans = get_nuptrans(element, ion, level);
+    const double epsilon_current = epsilon(uniquelevelindex);
+    const int nuptrans = get_nuptrans(uniquelevelindex);
 
-    auto &chlevel = globals::cellcache[cellcacheslotid].chelements[element].chions[ion].chlevels[level];
+    auto &chlevel = globals::cellcache[cellcacheslotid].ch_all_levels[uniquelevelindex];
 
     {
 #if (defined(STDPAR_ON) || defined(_OPENMP_ON)) && !defined(GPU_ON)

--- a/macroatom.h
+++ b/macroatom.h
@@ -30,7 +30,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                             double epsilon_trans) -> double;
 
 [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, int element, int ion,
-                                              int upper, const LevelTransition &downtransition) -> double;
+                                              double upperstatweight, const LevelTransition &downtransition) -> double;
 
 [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, int element, int ion, const LevelTransition &uptrans,
                                             double epsilon_trans, double lowerstatweight) -> double;

--- a/macroatom.h
+++ b/macroatom.h
@@ -14,7 +14,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 
 [[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int upper_uniquelevelindex, double upper_statweight,
                                             double einstein_A, double epsilon_trans, double nnlevel_lower,
-                                            double statweight_lower, int lineindex, double t_current) -> double;
+                                            double statweight_lower, int alltransindex, double t_current) -> double;
 
 [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upperionlevel,
                                                int lowerionlevel, int nonemptymgi) -> double;

--- a/macroatom.h
+++ b/macroatom.h
@@ -10,8 +10,8 @@ void macroatom_close_file();
 void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 
 [[nodiscard]] auto rad_deexcitation_ratecoeff(int nonemptymgi, int lower_uniquelevelindex, double epsilon_trans,
-                                              float A_ul, double upperstatweight, double nnlevelupper, double t_current)
-    -> double;
+                                              float A_ul, double upperstatweight, double lowerstatweight,
+                                              double nnlevelupper, double t_current) -> double;
 
 [[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int upper_uniquelevelindex, double upper_statweight,
                                             const LevelTransition &uptrans, double epsilon_trans, double nnlevel_lower,
@@ -29,8 +29,8 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 [[nodiscard]] auto col_ionization_ratecoeff(float T_e, float nne, int element, int ion, int lower, int phixstargetindex,
                                             double epsilon_trans) -> double;
 
-[[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, int element, int ion,
-                                              double upperstatweight, const LevelTransition &downtransition) -> double;
+[[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, double upperstatweight,
+                                              double lowerstatweight, const LevelTransition &downtransition) -> double;
 
 [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, double upperstatweight,
                                             const LevelTransition &uptrans, double epsilon_trans,

--- a/macroatom.h
+++ b/macroatom.h
@@ -30,7 +30,8 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                             double epsilon_trans) -> double;
 
 [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, double upperstatweight,
-                                              double lowerstatweight, const LevelTransition &downtransition) -> double;
+                                              double lowerstatweight, float coll_str, float osc_strength,
+                                              bool forbidden) -> double;
 
 [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, double upperstatweight,
                                             const LevelTransition &uptrans, double epsilon_trans,

--- a/macroatom.h
+++ b/macroatom.h
@@ -9,7 +9,7 @@ void macroatom_close_file();
 
 void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 
-[[nodiscard]] auto rad_deexcitation_ratecoeff(int nonemptymgi, int element, int ion, int lower, double epsilon_trans,
+[[nodiscard]] auto rad_deexcitation_ratecoeff(int nonemptymgi, int lower_uniquelevelindex, double epsilon_trans,
                                               float A_ul, double upperstatweight, double nnlevelupper, double t_current)
     -> double;
 

--- a/macroatom.h
+++ b/macroatom.h
@@ -13,7 +13,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                               float A_ul, double upperstatweight, double nnlevelupper, double t_current)
     -> double;
 
-[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int element, int ion, const LevelTransition &uptrans,
+[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int upper_uniquelevelindex, const LevelTransition &uptrans,
                                             double epsilon_trans, double nnlevel_lower, double statweight_lower,
                                             int lineindex, double t_current) -> double;
 

--- a/macroatom.h
+++ b/macroatom.h
@@ -1,7 +1,6 @@
 #ifndef MACROATOM_H
 #define MACROATOM_H
 
-#include "globals.h"
 #include "packet.h"
 
 void macroatom_open_file(int my_rank);
@@ -14,7 +13,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                               double nnlevelupper, double t_current) -> double;
 
 [[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int upper_uniquelevelindex, double upper_statweight,
-                                            const LevelTransition &uptrans, double epsilon_trans, double nnlevel_lower,
+                                            double einstein_A, double epsilon_trans, double nnlevel_lower,
                                             double statweight_lower, int lineindex, double t_current) -> double;
 
 [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upperionlevel,

--- a/macroatom.h
+++ b/macroatom.h
@@ -33,8 +33,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                               double lowerstatweight, float coll_str, float osc_strength,
                                               bool forbidden) -> double;
 
-[[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, double upperstatweight,
-                                            const LevelTransition &uptrans, double epsilon_trans,
-                                            double lowerstatweight) -> double;
+[[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, double upperstatweight, int alltransindex,
+                                            double epsilon_trans, double lowerstatweight) -> double;
 
 #endif  // MACROATOM_H

--- a/macroatom.h
+++ b/macroatom.h
@@ -13,9 +13,9 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                               float A_ul, double upperstatweight, double nnlevelupper, double t_current)
     -> double;
 
-[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int upper_uniquelevelindex, const LevelTransition &uptrans,
-                                            double epsilon_trans, double nnlevel_lower, double statweight_lower,
-                                            int lineindex, double t_current) -> double;
+[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int upper_uniquelevelindex, double upper_statweight,
+                                            const LevelTransition &uptrans, double epsilon_trans, double nnlevel_lower,
+                                            double statweight_lower, int lineindex, double t_current) -> double;
 
 [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upperionlevel,
                                                int lowerionlevel, int nonemptymgi) -> double;
@@ -32,7 +32,8 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
 [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, int element, int ion,
                                               double upperstatweight, const LevelTransition &downtransition) -> double;
 
-[[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, int element, int ion, const LevelTransition &uptrans,
-                                            double epsilon_trans, double lowerstatweight) -> double;
+[[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, double upperstatweight,
+                                            const LevelTransition &uptrans, double epsilon_trans,
+                                            double lowerstatweight) -> double;
 
 #endif  // MACROATOM_H

--- a/macroatom.h
+++ b/macroatom.h
@@ -30,8 +30,7 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                             double epsilon_trans) -> double;
 
 [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float nne, double epsilon_trans, double upperstatweight,
-                                              double lowerstatweight, float coll_str, float osc_strength,
-                                              bool forbidden) -> double;
+                                              double lowerstatweight, int alltransindex) -> double;
 
 [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float nne, double upperstatweight, int alltransindex,
                                             double epsilon_trans, double lowerstatweight) -> double;

--- a/macroatom.h
+++ b/macroatom.h
@@ -13,8 +13,8 @@ void do_macroatom(Packet &pkt, const MacroAtomState &pktmastate);
                                               float A_ul, double upperstatweight, double nnlevelupper, double t_current)
     -> double;
 
-[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int element, int ion, int lower,
-                                            const LevelTransition &uptrans, double epsilon_trans, double nnlevel_lower,
+[[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, int element, int ion, const LevelTransition &uptrans,
+                                            double epsilon_trans, double nnlevel_lower, double statweight_lower,
                                             int lineindex, double t_current) -> double;
 
 [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float nne, int element, int upperion, int upperionlevel,

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -433,15 +433,16 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const int upper = uptrans.targetlevelindex;
       const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
       const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_level;
+      const auto upper_statweight = stat_weight(upper_uniquelevelindex);
 
-      const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, uptrans, epsilon_trans, nnlevel,
-                                                statweight, lineindex, t_mid) *
+      const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight, uptrans,
+                                                epsilon_trans, nnlevel, statweight, lineindex, t_mid) *
                        s_renorm[level];
       assert_always(R >= 0);
       assert_always(std::isfinite(R));
 
       const double C =
-          col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, statweight) * s_renorm[level];
+          col_excitation_ratecoeff(T_e, nne, upper_statweight, uptrans, epsilon_trans, statweight) * s_renorm[level];
       assert_always(C >= 0);
       assert_always(std::isfinite(C));
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -448,8 +448,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       assert_always(C >= 0);
       assert_always(std::isfinite(C));
 
-      const double NTC =
-          nonthermal::nt_excitation_ratecoeff(nonemptymgi, element, ion, level, i, lineindex) * s_renorm[level];
+      const double NTC = nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, lineindex) * s_renorm[level];
 
       const int lower_index = level_index;
       const int upper_index = get_nlte_vector_index(element, ion, upper);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -386,25 +386,26 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
   const auto T_e = grid::get_Te(nonemptymgi);
   const float nne = grid::get_nne(nonemptymgi);
   const int nlevels = get_nlevels(element, ion);
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   const auto levels = std::ranges::iota_view{0, nlevels};
   std::for_each(levels.begin(), levels.end(), [&](const auto level) {
     const int level_index = get_nlte_vector_index(element, ion, level);
-    const double epsilon_level = epsilon(element, ion, level);
-    const double statweight = stat_weight(element, ion, level);
-    const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
+    const auto uniquelevelindex = ionuniquelevelindexstart + level;
+    const double epsilon_level = epsilon(uniquelevelindex);
+    const double statweight = stat_weight(uniquelevelindex);
+    const auto nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
 
     // de-excitation
-    const int ndowntrans = get_ndowntrans(element, ion, level);
-    const auto leveldowntrans = std::span(get_downtranslist(element, ion, level), ndowntrans);
+    const int ndowntrans = get_ndowntrans(uniquelevelindex);
+    const auto leveldowntrans = std::span(get_downtranslist(uniquelevelindex), ndowntrans);
     std::for_each(leveldowntrans.begin(), leveldowntrans.end(), [&](const auto &downtransition) {
       const double A_ul = downtransition.einstein_A;
       const int lower = downtransition.targetlevelindex;
-      const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, ion, lower);
+      const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
 
-      const double epsilon_trans = epsilon_level - epsilon(element, ion, lower);
-
-      const double R = rad_deexcitation_ratecoeff(nonemptymgi, lowerionlower_uniquelevelindex, epsilon_trans, A_ul,
-                                                  statweight, nnlevel, t_mid) *
+      const double epsilon_trans = epsilon_level - epsilon(lower_uniquelevelindex);
+      const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
+                                                  nnlevel, t_mid) *
                        s_renorm[level];
       const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtransition) *
                        s_renorm[level];
@@ -423,17 +424,18 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     });
 
     // excitation
-    const int nuptrans = get_nuptrans(element, ion, level);
-    const auto *const leveluptranslist = get_uptranslist(element, ion, level);
+    const int nuptrans = get_nuptrans(uniquelevelindex);
+    const auto *const leveluptranslist = get_uptranslist(uniquelevelindex);
     const auto nuptransindices = std::ranges::iota_view{0, nuptrans};
     std::for_each(nuptransindices.begin(), nuptransindices.end(), [&](const auto i) {
       const auto &uptrans = leveluptranslist[i];
       const int lineindex = uptrans.lineindex;
       const int upper = uptrans.targetlevelindex;
-      const double epsilon_trans = epsilon(element, ion, upper) - epsilon_level;
+      const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
+      const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_level;
 
-      const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, uptrans, epsilon_trans, nnlevel, statweight,
-                                                lineindex, t_mid) *
+      const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, uptrans, epsilon_trans, nnlevel,
+                                                statweight, lineindex, t_mid) *
                        s_renorm[level];
       assert_always(R >= 0);
       assert_always(std::isfinite(R));

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -399,11 +399,12 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     std::for_each(leveldowntrans.begin(), leveldowntrans.end(), [&](const auto &downtransition) {
       const double A_ul = downtransition.einstein_A;
       const int lower = downtransition.targetlevelindex;
+      const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, ion, lower);
 
       const double epsilon_trans = epsilon_level - epsilon(element, ion, lower);
 
-      const double R = rad_deexcitation_ratecoeff(nonemptymgi, element, ion, lower, epsilon_trans, A_ul, statweight,
-                                                  nnlevel, t_mid) *
+      const double R = rad_deexcitation_ratecoeff(nonemptymgi, lowerionlower_uniquelevelindex, epsilon_trans, A_ul,
+                                                  statweight, nnlevel, t_mid) *
                        s_renorm[level];
       const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtransition) *
                        s_renorm[level];

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -405,8 +405,8 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const double R = rad_deexcitation_ratecoeff(nonemptymgi, element, ion, lower, epsilon_trans, A_ul, statweight,
                                                   nnlevel, t_mid) *
                        s_renorm[level];
-      const double C =
-          col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, level, downtransition) * s_renorm[level];
+      const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtransition) *
+                       s_renorm[level];
 
       const int upper_index = level_index;
       const int lower_index = get_nlte_vector_index(element, ion, lower);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -433,7 +433,6 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     const auto nuptransindices = std::ranges::iota_view{0, nuptrans};
     std::for_each(nuptransindices.begin(), nuptransindices.end(), [&](const auto i) {
       const auto alltransindex = alltrans_startup + i;
-      const int lineindex = globals::alltrans.lineindex[alltransindex];
       const int upper = globals::alltrans.targetlevelindex[alltransindex];
       const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
       const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_level;
@@ -441,7 +440,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
 
       const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight,
                                                 globals::alltrans.einstein_A[alltransindex], epsilon_trans, nnlevel,
-                                                statweight, lineindex, t_mid) *
+                                                statweight, alltransindex, t_mid) *
                        s_renorm[level];
       assert_always(R >= 0);
       assert_always(std::isfinite(R));
@@ -451,7 +450,8 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       assert_always(C >= 0);
       assert_always(std::isfinite(C));
 
-      const double NTC = nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, lineindex) * s_renorm[level];
+      const double NTC =
+          nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, alltransindex) * s_renorm[level];
 
       const int lower_index = level_index;
       const int upper_index = get_nlte_vector_index(element, ion, upper);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -401,13 +401,13 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     const auto ndowntransindices = std::ranges::iota_view{0, ndowntrans};
     std::for_each(ndowntransindices.begin(), ndowntransindices.end(), [&](const auto &i) {
       const auto alltransindex = alltrans_startdown + i;
-      const int lower = globals::alltrans[alltransindex].targetlevelindex;
+      const int lower = globals::alltrans.targetlevelindex[alltransindex];
       const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
       const auto lower_statweight = stat_weight(lower_uniquelevelindex);
 
       const double epsilon_trans = epsilon_level - epsilon(lower_uniquelevelindex);
       const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans,
-                                                  globals::alltrans[alltransindex].einstein_A, statweight,
+                                                  globals::alltrans.einstein_A[alltransindex], statweight,
                                                   lower_statweight, nnlevel, t_mid) *
                        s_renorm[level];
       const double C =
@@ -433,15 +433,15 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     const auto nuptransindices = std::ranges::iota_view{0, nuptrans};
     std::for_each(nuptransindices.begin(), nuptransindices.end(), [&](const auto i) {
       const auto alltransindex = alltrans_startup + i;
-      const auto &uptrans = globals::alltrans[alltransindex];
-      const int lineindex = uptrans.lineindex;
-      const int upper = uptrans.targetlevelindex;
+      const int lineindex = globals::alltrans.lineindex[alltransindex];
+      const int upper = globals::alltrans.targetlevelindex[alltransindex];
       const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
       const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_level;
       const auto upper_statweight = stat_weight(upper_uniquelevelindex);
 
-      const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight, uptrans,
-                                                epsilon_trans, nnlevel, statweight, lineindex, t_mid) *
+      const double R = rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, upper_statweight,
+                                                globals::alltrans.einstein_A[alltransindex], epsilon_trans, nnlevel,
+                                                statweight, lineindex, t_mid) *
                        s_renorm[level];
       assert_always(R >= 0);
       assert_always(std::isfinite(R));

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -398,19 +398,18 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     // de-excitation
     const int ndowntrans = get_ndowntrans(uniquelevelindex);
     const auto leveldowntrans = std::span(get_downtranslist(uniquelevelindex), ndowntrans);
-    std::for_each(leveldowntrans.begin(), leveldowntrans.end(), [&](const auto &downtransition) {
-      const double A_ul = downtransition.einstein_A;
-      const int lower = downtransition.targetlevelindex;
+    std::for_each(leveldowntrans.begin(), leveldowntrans.end(), [&](const auto &downtrans) {
+      const int lower = downtrans.targetlevelindex;
       const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
       const auto lower_statweight = stat_weight(lower_uniquelevelindex);
 
       const double epsilon_trans = epsilon_level - epsilon(lower_uniquelevelindex);
-      const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
-                                                  lower_statweight, nnlevel, t_mid) *
+      const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans,
+                                                  downtrans.einstein_A, statweight, lower_statweight, nnlevel, t_mid) *
                        s_renorm[level];
-      const double C =
-          col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, downtransition) *
-          s_renorm[level];
+      const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight,
+                                                  downtrans.coll_str, downtrans.osc_strength, downtrans.forbidden) *
+                       s_renorm[level];
 
       const int upper_index = level_index;
       const int lower_index = get_nlte_vector_index(element, ion, lower);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -396,20 +396,23 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     const auto nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
 
     // de-excitation
+    const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
     const int ndowntrans = get_ndowntrans(uniquelevelindex);
-    const auto leveldowntrans = std::span(get_downtranslist(uniquelevelindex), ndowntrans);
-    std::for_each(leveldowntrans.begin(), leveldowntrans.end(), [&](const auto &downtrans) {
-      const int lower = downtrans.targetlevelindex;
+    const auto ndowntransindices = std::ranges::iota_view{0, ndowntrans};
+    std::for_each(ndowntransindices.begin(), ndowntransindices.end(), [&](const auto &i) {
+      const auto alltransindex = alltrans_startdown + i;
+      const int lower = globals::alltrans[alltransindex].targetlevelindex;
       const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
       const auto lower_statweight = stat_weight(lower_uniquelevelindex);
 
       const double epsilon_trans = epsilon_level - epsilon(lower_uniquelevelindex);
       const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans,
-                                                  downtrans.einstein_A, statweight, lower_statweight, nnlevel, t_mid) *
+                                                  globals::alltrans[alltransindex].einstein_A, statweight,
+                                                  lower_statweight, nnlevel, t_mid) *
                        s_renorm[level];
-      const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight,
-                                                  downtrans.coll_str, downtrans.osc_strength, downtrans.forbidden) *
-                       s_renorm[level];
+      const double C =
+          col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, alltransindex) *
+          s_renorm[level];
 
       const int upper_index = level_index;
       const int lower_index = get_nlte_vector_index(element, ion, lower);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -431,7 +431,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const int upper = uptrans.targetlevelindex;
       const double epsilon_trans = epsilon(element, ion, upper) - epsilon_level;
 
-      const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, level, uptrans, epsilon_trans, nnlevel,
+      const double R = rad_excitation_ratecoeff(nonemptymgi, element, ion, uptrans, epsilon_trans, nnlevel, statweight,
                                                 lineindex, t_mid) *
                        s_renorm[level];
       assert_always(R >= 0);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -402,13 +402,15 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const double A_ul = downtransition.einstein_A;
       const int lower = downtransition.targetlevelindex;
       const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
+      const auto lower_statweight = stat_weight(lower_uniquelevelindex);
 
       const double epsilon_trans = epsilon_level - epsilon(lower_uniquelevelindex);
       const double R = rad_deexcitation_ratecoeff(nonemptymgi, lower_uniquelevelindex, epsilon_trans, A_ul, statweight,
-                                                  nnlevel, t_mid) *
+                                                  lower_statweight, nnlevel, t_mid) *
                        s_renorm[level];
-      const double C = col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtransition) *
-                       s_renorm[level];
+      const double C =
+          col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, downtransition) *
+          s_renorm[level];
 
       const int upper_index = level_index;
       const int lower_index = get_nlte_vector_index(element, ion, lower);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -426,10 +426,11 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
 
     // excitation
     const int nuptrans = get_nuptrans(uniquelevelindex);
-    const auto *const leveluptranslist = get_uptranslist(uniquelevelindex);
+    const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
     const auto nuptransindices = std::ranges::iota_view{0, nuptrans};
     std::for_each(nuptransindices.begin(), nuptransindices.end(), [&](const auto i) {
-      const auto &uptrans = leveluptranslist[i];
+      const auto alltransindex = alltrans_startup + i;
+      const auto &uptrans = globals::alltrans[alltransindex];
       const int lineindex = uptrans.lineindex;
       const int upper = uptrans.targetlevelindex;
       const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
@@ -442,8 +443,8 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       assert_always(R >= 0);
       assert_always(std::isfinite(R));
 
-      const double C =
-          col_excitation_ratecoeff(T_e, nne, upper_statweight, uptrans, epsilon_trans, statweight) * s_renorm[level];
+      const double C = col_excitation_ratecoeff(T_e, nne, upper_statweight, alltransindex, epsilon_trans, statweight) *
+                       s_renorm[level];
       assert_always(C >= 0);
       assert_always(std::isfinite(C));
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1369,11 +1369,10 @@ auto nt_ionization_ratecoeff_sf(const int nonemptymgi, const int element, const 
 // epsilon_trans is in erg
 // returns the index of the first valid cross section point (en >= epsilon_trans)
 // all elements below this index are invalid and should not be used
-auto get_xs_excitation_vector(const int element, const int ion, const int lower, const int uptransindex,
-                              const double statweight_lower, const double epsilon_trans)
+auto get_xs_excitation_vector(const int alltransindex, const double statweight_lower, const double epsilon_trans)
     -> std::tuple<std::array<double, SFPTS>, int> {
   std::array<double, SFPTS> xs_excitation_vec{};
-  const auto &uptr = get_uptranslist(element, ion, lower)[uptransindex];
+  const auto &uptr = globals::alltrans[alltransindex];
   if (uptr.coll_str >= 0) {
     // collision strength is available, so use it
     // Li et al. 2012 equation 11
@@ -1426,12 +1425,11 @@ auto get_xs_excitation_vector(const int element, const int ion, const int lower,
 
 // Kozma & Fransson equation 9 divided by level population and epsilon_trans
 // returns the rate coefficient in s^-1 divided by deposition rate density in erg/cm^3/s
-auto calculate_nt_excitation_ratecoeff_perdeposition(const std::array<double, SFPTS> &yvec, const int element,
-                                                     const int ion, const int lower, const int uptransindex,
+auto calculate_nt_excitation_ratecoeff_perdeposition(const std::array<double, SFPTS> &yvec, const int alltransindex,
                                                      const double statweight_lower, const double epsilon_trans)
     -> double {
   const auto [xs_excitation_vec, xsstartindex] =
-      get_xs_excitation_vector(element, ion, lower, uptransindex, statweight_lower, epsilon_trans);
+      get_xs_excitation_vector(alltransindex, statweight_lower, epsilon_trans);
 
   if (xsstartindex >= 0) {
     const double y_xs_de =
@@ -1606,21 +1604,23 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
       const bool above_minionfraction = (nnion >= minionfraction * get_nnion_tot(nonemptymgi));
 
       for (int lower = 0; lower < nlevels; lower++) {
-        const double statweight_lower = stat_weight(element, ion, lower);
-        const int nuptrans = get_nuptrans(element, ion, lower);
-        const auto *const uptranslist = get_uptranslist(element, ion, lower);
-        const double nnlevel = get_levelpop(nonemptymgi, element, ion, lower);
-        const double epsilon_lower = epsilon(element, ion, lower);
+        const auto uniquelevelindex = get_uniquelevelindex(element, ion, lower);
+        const double statweight_lower = stat_weight(uniquelevelindex);
+        const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
+        const int nuptrans = get_nuptrans(uniquelevelindex);
+        const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+        const double epsilon_lower = epsilon(uniquelevelindex);
 
         for (int t = 0; t < nuptrans; t++) {
-          const int upper = uptranslist[t].targetlevelindex;
+          const int alltransindex = alltrans_startup + t;
+          const int upper = globals::alltrans[alltransindex].targetlevelindex;
           if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
             continue;
           }
 
           const double epsilon_trans = epsilon(element, ion, upper) - epsilon_lower;
-          const double ratecoeffperdeposition = calculate_nt_excitation_ratecoeff_perdeposition(
-              yfunc, element, ion, lower, t, statweight_lower, epsilon_trans);
+          const double ratecoeffperdeposition =
+              calculate_nt_excitation_ratecoeff_perdeposition(yfunc, alltransindex, statweight_lower, epsilon_trans);
           const double frac_excitation_thistrans = nnlevel * epsilon_trans * ratecoeffperdeposition;
           frac_excitation_ion += frac_excitation_thistrans;
 
@@ -1636,7 +1636,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
               tmp_excitation_list.push_back({
                   .frac_deposition = frac_excitation_thistrans,
                   .ratecoeffperdeposition = ratecoeffperdeposition,
-                  .lineindex = uptranslist[t].lineindex,
+                  .lineindex = globals::alltrans[alltransindex].lineindex,
               });
             }
           }  // NT_EXCITATION_ON
@@ -1814,13 +1814,15 @@ void sfmatrix_add_excitation(std::vector<double> &sfmatrixuppertri, const int no
 
   const auto lowers = std::ranges::iota_view{0, nlevels};
   std::for_each(lowers.begin(), lowers.end(), [&](const int lower) {
-    const double statweight_lower = stat_weight(element, ion, lower);
-    const double nnlevel = get_levelpop(nonemptymgi, element, ion, lower);
-    const double epsilon_lower = epsilon(element, ion, lower);
-    const int nuptrans = get_nuptrans(element, ion, lower);
-    const auto *const uptranslist = get_uptranslist(element, ion, lower);
+    const auto uniquelevelindex = get_uniquelevelindex(element, ion, lower);
+    const double statweight_lower = stat_weight(uniquelevelindex);
+    const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+    const double epsilon_lower = epsilon(uniquelevelindex);
+    const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
+    const int nuptrans = get_nuptrans(uniquelevelindex);
     for (int t = 0; t < nuptrans; t++) {
-      const int upper = uptranslist[t].targetlevelindex;
+      const int alltransindex = alltrans_startup + t;
+      const int upper = globals::alltrans[alltransindex].targetlevelindex;
       if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
         continue;
       }
@@ -1831,7 +1833,7 @@ void sfmatrix_add_excitation(std::vector<double> &sfmatrixuppertri, const int no
       }
 
       auto [vec_xs_excitation_deltae, xsstartindex] =
-          get_xs_excitation_vector(element, ion, lower, t, statweight_lower, epsilon_trans);
+          get_xs_excitation_vector(alltransindex, statweight_lower, epsilon_trans);
       if (xsstartindex >= 0) {
         cblas_dscal(SFPTS - xsstartindex, DELTA_E, vec_xs_excitation_deltae.data() + xsstartindex, 1);
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1734,11 +1734,13 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
         const auto nnlevel_lower = get_levelpop(nonemptymgi, lower_uniquelevelindex);
         const auto statweight_lower = stat_weight(lower_uniquelevelindex);
 
+        const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
         const auto uptransindex = get_uptransindex(element, ion, lower, upper);
         const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon(lower_uniquelevelindex);
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
-        const auto &uptrans = get_uptranslist(element, ion, lower)[uptransindex];
+        const auto alltransindex = alltrans_startup + uptransindex;
+        const auto &uptrans = globals::alltrans[alltransindex];
         const auto statweight_upper = stat_weight(upper_uniquelevelindex);
 
         const double t_mid = globals::timesteps[timestep].mid;
@@ -1747,7 +1749,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
                                      nnlevel_lower, statweight_lower, lineindex, t_mid);
 
         const double collexc_ratecoeff =
-            col_excitation_ratecoeff(T_e, nne, statweight_upper, uptrans, epsilon_trans, statweight_lower);
+            col_excitation_ratecoeff(T_e, nne, statweight_upper, alltransindex, epsilon_trans, statweight_lower);
 
         const double exc_ratecoeff = radexc_ratecoeff + collexc_ratecoeff + ntcollexc_ratecoeff;
         const auto coll_str = uptrans.coll_str;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1739,14 +1739,15 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
         const auto &uptrans = get_uptranslist(element, ion, lower)[uptransindex];
+        const auto statweight_upper = stat_weight(upper_uniquelevelindex);
 
         const double t_mid = globals::timesteps[timestep].mid;
         const double radexc_ratecoeff =
-            rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, uptrans, epsilon_trans, nnlevel_lower,
-                                     statweight_lower, lineindex, t_mid);
+            rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, statweight_upper, uptrans, epsilon_trans,
+                                     nnlevel_lower, statweight_lower, lineindex, t_mid);
 
         const double collexc_ratecoeff =
-            col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, stat_weight(element, ion, lower));
+            col_excitation_ratecoeff(T_e, nne, statweight_upper, uptrans, epsilon_trans, statweight_lower);
 
         const double exc_ratecoeff = radexc_ratecoeff + collexc_ratecoeff + ntcollexc_ratecoeff;
         const auto coll_str = uptrans.coll_str;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2688,9 +2688,9 @@ void nt_MPI_Bcast(const int nonemptymgi, const int root_node_id) {
   }
 }
 
-void nt_reset_stats() { nt_energy_deposited = 0.; }
+void reset_stats() { nt_energy_deposited = 0.; }
 
-void nt_print_stats(const double modelvolume, const double deltat) {
+void print_stats(const double modelvolume, const double deltat) {
   const double deposition_rate_density_montecarlo = nt_energy_deposited / EV / modelvolume / deltat;
 
   printout("nt_energy_deposited = %g [eV/s/cm^3]\n", deposition_rate_density_montecarlo);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -147,7 +147,7 @@ double nt_energy_deposited = 0;
 struct NonThermalExcitation {
   double frac_deposition;  // the fraction of the non-thermal deposition energy going to the excitation transition
   double ratecoeffperdeposition;  // the excitation rate coefficient divided by the deposition rate density
-  int lineindex;
+  int alltransindex;
 };
 
 // pointer to either local or node-shared memory excitation list of all cells
@@ -1517,18 +1517,6 @@ auto select_nt_ionization(const int nonemptymgi) -> std::tuple<int, int> {
   return {-1, -1};
 }
 
-auto get_uptransindex(const int element, const int ion, const int lower, const int upper) {
-  const int nuptrans = get_nuptrans(element, ion, lower);
-  const auto alltrans_startup = get_alltrans_startup(element, ion, lower);
-  for (int t = 0; t < nuptrans; t++) {
-    if (upper == globals::alltrans.targetlevelindex[alltrans_startup + t]) {
-      return t;
-    }
-  }
-  assert_always(false);
-  return -1;
-}
-
 void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool enable_sfexcitation,
                          const std::array<double, SFPTS> &yfunc) {
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
@@ -1643,7 +1631,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
               tmp_excitation_list.push_back({
                   .frac_deposition = frac_excitation_thistrans,
                   .ratecoeffperdeposition = ratecoeffperdeposition,
-                  .lineindex = globals::alltrans.lineindex[alltransindex],
+                  .alltransindex = alltransindex,
               });
             }
           }  // NT_EXCITATION_ON
@@ -1730,29 +1718,26 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
     for (int excitationindex = 0; excitationindex < ntransdisplayed; excitationindex++) {
       const auto &ntexc = tmp_excitation_list[excitationindex];
       if (ntexc.frac_deposition > 0.) {
-        const int lineindex = ntexc.lineindex;
-        const auto &line = globals::linelist[lineindex];
-        const int element = line.elementindex;
-        const int ion = line.ionindex;
-        const int lower = line.lowerlevelindex;
-        const int upper = line.upperlevelindex;
+        const auto alltransindex = ntexc.alltransindex;
+        const auto lineindex = globals::alltrans.lineindex[alltransindex];
+        const int element = globals::linelist[lineindex].elementindex;
+        const int ion = globals::linelist[lineindex].ionindex;
+        const int lower = globals::linelist[lineindex].lowerlevelindex;
+        const int upper = globals::linelist[lineindex].upperlevelindex;
         const auto lower_uniquelevelindex = get_uniquelevelindex(element, ion, lower);
         const auto upper_uniquelevelindex = get_uniquelevelindex(element, ion, upper);
         const auto nnlevel_lower = get_levelpop(nonemptymgi, lower_uniquelevelindex);
         const auto statweight_lower = stat_weight(lower_uniquelevelindex);
 
-        const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
-        const auto uptransindex = get_uptransindex(element, ion, lower, upper);
         const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon(lower_uniquelevelindex);
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
-        const auto alltransindex = alltrans_startup + uptransindex;
         const auto statweight_upper = stat_weight(upper_uniquelevelindex);
 
         const double t_mid = globals::timesteps[timestep].mid;
         const double radexc_ratecoeff = rad_excitation_ratecoeff(
             nonemptymgi, upper_uniquelevelindex, statweight_upper, globals::alltrans.einstein_A[alltransindex],
-            epsilon_trans, nnlevel_lower, statweight_lower, lineindex, t_mid);
+            epsilon_trans, nnlevel_lower, statweight_lower, alltransindex, t_mid);
 
         const double collexc_ratecoeff =
             col_excitation_ratecoeff(T_e, nne, statweight_upper, alltransindex, epsilon_trans, statweight_lower);
@@ -1771,7 +1756,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
 
     // sort the excitation list by ascending lineindex for fast lookup with a binary search
     std::ranges::SORT_OR_STABLE_SORT(get_cell_ntexcitations(nonemptymgi), std::ranges::less{},
-                                     &NonThermalExcitation::lineindex);
+                                     &NonThermalExcitation::alltransindex);
 
   }  // NT_EXCITATION_ON
 
@@ -2301,7 +2286,7 @@ __host__ __device__ auto nt_ionization_ratecoeff(const int nonemptymgi, const in
 }
 
 __host__ __device__ auto nt_excitation_ratecoeff(const int nonemptymgi, const int lowerlevel, const int upperlevel,
-                                                 const int lineindex) -> double {
+                                                 const int alltransindex) -> double {
   if constexpr (!NT_EXCITATION_ON) {
     return 0.;
   }
@@ -2314,8 +2299,9 @@ __host__ __device__ auto nt_excitation_ratecoeff(const int nonemptymgi, const in
 
   // binary search, assuming the excitation list is sorted by lineindex ascending
   const auto ntexclist = get_cell_ntexcitations(nonemptymgi);
-  const auto ntexcitation = std::ranges::lower_bound(ntexclist, lineindex, {}, &NonThermalExcitation::lineindex);
-  if (ntexcitation == ntexclist.end() || ntexcitation->lineindex != lineindex) {
+  const auto ntexcitation =
+      std::ranges::lower_bound(ntexclist, alltransindex, {}, &NonThermalExcitation::alltransindex);
+  if (ntexcitation == ntexclist.end() || ntexcitation->alltransindex != alltransindex) {
     return 0.;
   }
 
@@ -2388,10 +2374,9 @@ __host__ __device__ void do_ntlepton_deposit(Packet &pkt) {
       for (const auto &ntexcitation : get_cell_ntexcitations(nonemptymgi)) {
         const double frac_deposition_exc = ntexcitation.frac_deposition;
         if (zrand < frac_deposition_exc) {
-          const int lineindex = ntexcitation.lineindex;
+          const auto lineindex = globals::alltrans.lineindex[ntexcitation.alltransindex];
           const int element = globals::linelist[lineindex].elementindex;
           const int ion = globals::linelist[lineindex].ionindex;
-          // const int lower = linelist[lineindex].lowerlevelindex;
           const int upper = globals::linelist[lineindex].upperlevelindex;
 
           stats::increment(stats::COUNTER_MA_STAT_ACTIVATION_NTCOLLEXC);
@@ -2600,7 +2585,7 @@ void write_restart_data(FILE *gridsave_file) {
 
       for (const auto &excitation : get_cell_ntexcitations(nonemptymgi)) {
         fprintf(gridsave_file, "%la %la %d\n", excitation.frac_deposition, excitation.ratecoeffperdeposition,
-                excitation.lineindex);
+                excitation.alltransindex);
       }
     }
   }
@@ -2663,7 +2648,7 @@ void read_restart_data(FILE *gridsave_file) {
       for (int excitationindex = 0; excitationindex < frac_excitations_list_size_in; excitationindex++) {
         assert_always(fscanf(gridsave_file, "%la %la %d\n", &ntexclist[excitationindex].frac_deposition,
                              &ntexclist[excitationindex].ratecoeffperdeposition,
-                             &ntexclist[excitationindex].lineindex) == 3);
+                             &ntexclist[excitationindex].alltransindex) == 3);
       }
     }
   }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1729,18 +1729,21 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
         const int ion = line.ionindex;
         const int lower = line.lowerlevelindex;
         const int upper = line.upperlevelindex;
-        const auto nnlevel_lower = get_levelpop(nonemptymgi, element, ion, lower);
-        const auto statweight_lower = stat_weight(element, ion, lower);
+        const auto lower_uniquelevelindex = get_uniquelevelindex(element, ion, lower);
+        const auto upper_uniquelevelindex = get_uniquelevelindex(element, ion, upper);
+        const auto nnlevel_lower = get_levelpop(nonemptymgi, lower_uniquelevelindex);
+        const auto statweight_lower = stat_weight(lower_uniquelevelindex);
 
         const auto uptransindex = get_uptransindex(element, ion, lower, upper);
-        const double epsilon_trans = epsilon(element, ion, upper) - epsilon(element, ion, lower);
+        const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon(lower_uniquelevelindex);
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
         const auto &uptrans = get_uptranslist(element, ion, lower)[uptransindex];
 
         const double t_mid = globals::timesteps[timestep].mid;
-        const double radexc_ratecoeff = rad_excitation_ratecoeff(nonemptymgi, element, ion, uptrans, epsilon_trans,
-                                                                 nnlevel_lower, statweight_lower, lineindex, t_mid);
+        const double radexc_ratecoeff =
+            rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, uptrans, epsilon_trans, nnlevel_lower,
+                                     statweight_lower, lineindex, t_mid);
 
         const double collexc_ratecoeff =
             col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, stat_weight(element, ion, lower));

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -724,8 +724,9 @@ auto get_possible_nt_excitation_count() -> int {
       const int lower_nlevels = std::min(NTEXCITATION_MAXNLEVELS_LOWER, get_nlevels(element, ion));
       for (int lower = 0; lower < lower_nlevels; lower++) {
         const int nuptrans = get_nuptrans(element, ion, lower);
+        const auto alltrans_startup = get_alltrans_startup(element, ion, lower);
         for (int t = 0; t < nuptrans; t++) {
-          const int upper = get_uptranslist(element, ion, lower)[t].targetlevelindex;
+          const int upper = globals::alltrans.targetlevelindex[alltrans_startup + t];
           if (upper < NTEXCITATION_MAXNLEVELS_UPPER) {
             ntexcitationcount++;
           }
@@ -918,13 +919,15 @@ constexpr auto xs_excitation(const int element, const int ion, const int lower, 
     return 0.;
   }
 
-  const auto &uptrans = get_uptranslist(element, ion, lower)[uptransindex];
-  if (uptrans.coll_str >= 0) {
+  const auto alltrans_startup = get_alltrans_startup(element, ion, lower);
+  const auto alltransindex = alltrans_startup + uptransindex;
+  if (globals::alltrans.coll_str[alltransindex] >= 0) {
     // collision strength is available, so use it
     // Li et al. 2012 equation 11
-    return std::pow(H_ionpot / energy, 2) / lowerstatweight * uptrans.coll_str * PI * A_naught_squared;
+    return std::pow(H_ionpot / energy, 2) / lowerstatweight * globals::alltrans.coll_str[alltransindex] * PI *
+           A_naught_squared;
   }
-  if (!uptrans.forbidden) {
+  if (!globals::alltrans.forbidden[alltransindex]) {
     // permitted E1 electric dipole transitions
     const double U = energy / epsilon_trans;
 
@@ -935,7 +938,8 @@ constexpr auto xs_excitation(const int element, const int ion, const int lower, 
 
     constexpr double prefactor = 45.585750051;  // 8 * pi^2/sqrt(3)
     // Eq 4 of Mewe 1972, possibly from Seaton 1962?
-    return prefactor * A_naught_squared * std::pow(H_ionpot / epsilon_trans, 2) * uptrans.osc_strength * g_bar / U;
+    return prefactor * A_naught_squared * std::pow(H_ionpot / epsilon_trans, 2) *
+           globals::alltrans.osc_strength[alltransindex] * g_bar / U;
   }
   return 0.;
 }
@@ -1017,12 +1021,14 @@ auto N_e(const int nonemptymgi, const double energy, const std::array<double, SF
       const int nlevels = std::min(NTEXCITATION_MAXNLEVELS_LOWER, nlevels_all);
 
       for (int lower = 0; lower < nlevels; lower++) {
-        const auto uptranslist = get_uptransspan(element, ion, lower);
-        const double nnlevel = get_levelpop(nonemptymgi, element, ion, lower);
-        const double epsilon_lower = epsilon(element, ion, lower);
-        const auto statweight_lower = stat_weight(element, ion, lower);
-        for (int t = 0; t < std::ssize(uptranslist); t++) {
-          const int upper = uptranslist[t].targetlevelindex;
+        const auto uniquelevelindex = get_uniquelevelindex(element, ion, lower);
+        const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+        const double epsilon_lower = epsilon(uniquelevelindex);
+        const auto statweight_lower = stat_weight(uniquelevelindex);
+        const int nuptrans = get_nuptrans(uniquelevelindex);
+        const auto alltrans_startup = get_alltrans_startup(uniquelevelindex);
+        for (int t = 0; t < nuptrans; t++) {
+          const int upper = globals::alltrans.targetlevelindex[alltrans_startup + t];
           if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
             continue;
           }
@@ -1372,11 +1378,11 @@ auto nt_ionization_ratecoeff_sf(const int nonemptymgi, const int element, const 
 auto get_xs_excitation_vector(const int alltransindex, const double statweight_lower, const double epsilon_trans)
     -> std::tuple<std::array<double, SFPTS>, int> {
   std::array<double, SFPTS> xs_excitation_vec{};
-  const auto &uptr = globals::alltrans[alltransindex];
-  if (uptr.coll_str >= 0) {
+  if (globals::alltrans.coll_str[alltransindex] >= 0) {
     // collision strength is available, so use it
     // Li et al. 2012 equation 11
-    const double constantfactor = std::pow(H_ionpot, 2) / statweight_lower * uptr.coll_str * PI * A_naught_squared;
+    const double constantfactor =
+        std::pow(H_ionpot, 2) / statweight_lower * globals::alltrans.coll_str[alltransindex] * PI * A_naught_squared;
 
     const int en_startindex = get_energyindex_ev_gteq(epsilon_trans / EV);
 
@@ -1388,8 +1394,8 @@ auto get_xs_excitation_vector(const int alltransindex, const double statweight_l
     }
     return {xs_excitation_vec, en_startindex};
   }
-  if (!uptr.forbidden) {
-    const double trans_osc_strength = uptr.osc_strength;
+  if (!globals::alltrans.forbidden[alltransindex]) {
+    const double trans_osc_strength = globals::alltrans.osc_strength[alltransindex];
     // permitted E1 electric dipole transitions
 
     // constexpr double g_bar = 0.2;
@@ -1512,9 +1518,10 @@ auto select_nt_ionization(const int nonemptymgi) -> std::tuple<int, int> {
 }
 
 auto get_uptransindex(const int element, const int ion, const int lower, const int upper) {
-  const auto leveluptranslist = get_uptransspan(element, ion, lower);
-  for (int t = 0; t < std::ssize(leveluptranslist); t++) {
-    if (upper == leveluptranslist[t].targetlevelindex) {
+  const int nuptrans = get_nuptrans(element, ion, lower);
+  const auto alltrans_startup = get_alltrans_startup(element, ion, lower);
+  for (int t = 0; t < nuptrans; t++) {
+    if (upper == globals::alltrans.targetlevelindex[alltrans_startup + t]) {
       return t;
     }
   }
@@ -1613,7 +1620,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
 
         for (int t = 0; t < nuptrans; t++) {
           const int alltransindex = alltrans_startup + t;
-          const int upper = globals::alltrans[alltransindex].targetlevelindex;
+          const int upper = globals::alltrans.targetlevelindex[alltransindex];
           if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
             continue;
           }
@@ -1636,7 +1643,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
               tmp_excitation_list.push_back({
                   .frac_deposition = frac_excitation_thistrans,
                   .ratecoeffperdeposition = ratecoeffperdeposition,
-                  .lineindex = globals::alltrans[alltransindex].lineindex,
+                  .lineindex = globals::alltrans.lineindex[alltransindex],
               });
             }
           }  // NT_EXCITATION_ON
@@ -1740,19 +1747,18 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
 
         const double ntcollexc_ratecoeff = ntexc.ratecoeffperdeposition * deposition_rate_density;
         const auto alltransindex = alltrans_startup + uptransindex;
-        const auto &uptrans = globals::alltrans[alltransindex];
         const auto statweight_upper = stat_weight(upper_uniquelevelindex);
 
         const double t_mid = globals::timesteps[timestep].mid;
-        const double radexc_ratecoeff =
-            rad_excitation_ratecoeff(nonemptymgi, upper_uniquelevelindex, statweight_upper, uptrans, epsilon_trans,
-                                     nnlevel_lower, statweight_lower, lineindex, t_mid);
+        const double radexc_ratecoeff = rad_excitation_ratecoeff(
+            nonemptymgi, upper_uniquelevelindex, statweight_upper, globals::alltrans.einstein_A[alltransindex],
+            epsilon_trans, nnlevel_lower, statweight_lower, lineindex, t_mid);
 
         const double collexc_ratecoeff =
             col_excitation_ratecoeff(T_e, nne, statweight_upper, alltransindex, epsilon_trans, statweight_lower);
 
         const double exc_ratecoeff = radexc_ratecoeff + collexc_ratecoeff + ntcollexc_ratecoeff;
-        const auto coll_str = uptrans.coll_str;
+        const auto coll_str = globals::alltrans.coll_str[alltransindex];
 
         printout(
             "    frac_deposition %.3e Z=%2d ionstage %d lower %4d upper %4d rad_exc %.1e coll_exc %.1e nt_exc %.1e "
@@ -1822,7 +1828,7 @@ void sfmatrix_add_excitation(std::vector<double> &sfmatrixuppertri, const int no
     const int nuptrans = get_nuptrans(uniquelevelindex);
     for (int t = 0; t < nuptrans; t++) {
       const int alltransindex = alltrans_startup + t;
-      const int upper = globals::alltrans[alltransindex].targetlevelindex;
+      const int upper = globals::alltrans.targetlevelindex[alltransindex];
       if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
         continue;
       }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2294,16 +2294,14 @@ __host__ __device__ auto nt_ionization_ratecoeff(const int nonemptymgi, const in
   return nt_ionization_ratecoeff_wfapprox(nonemptymgi, element, ion);
 }
 
-__host__ __device__ auto nt_excitation_ratecoeff(const int nonemptymgi, const int element, const int ion,
-                                                 const int lowerlevel, const int uptransindex, const int lineindex)
-    -> double {
+__host__ __device__ auto nt_excitation_ratecoeff(const int nonemptymgi, const int lowerlevel, const int upperlevel,
+                                                 const int lineindex) -> double {
   if constexpr (!NT_EXCITATION_ON) {
     return 0.;
   }
   if (lowerlevel >= NTEXCITATION_MAXNLEVELS_LOWER) {
     return 0.;
   }
-  const int upperlevel = get_uptranslist(element, ion, lowerlevel)[uptransindex].targetlevelindex;
   if (upperlevel >= NTEXCITATION_MAXNLEVELS_UPPER) {
     return 0.;
   }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1732,6 +1732,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
         const int lower = line.lowerlevelindex;
         const int upper = line.upperlevelindex;
         const auto nnlevel_lower = get_levelpop(nonemptymgi, element, ion, lower);
+        const auto statweight_lower = stat_weight(element, ion, lower);
 
         const auto uptransindex = get_uptransindex(element, ion, lower, upper);
         const double epsilon_trans = epsilon(element, ion, upper) - epsilon(element, ion, lower);
@@ -1740,8 +1741,8 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
         const auto &uptrans = get_uptranslist(element, ion, lower)[uptransindex];
 
         const double t_mid = globals::timesteps[timestep].mid;
-        const double radexc_ratecoeff = rad_excitation_ratecoeff(nonemptymgi, element, ion, lower, uptrans,
-                                                                 epsilon_trans, nnlevel_lower, lineindex, t_mid);
+        const double radexc_ratecoeff = rad_excitation_ratecoeff(nonemptymgi, element, ion, uptrans, epsilon_trans,
+                                                                 nnlevel_lower, statweight_lower, lineindex, t_mid);
 
         const double collexc_ratecoeff =
             col_excitation_ratecoeff(T_e, nne, element, ion, uptrans, epsilon_trans, stat_weight(element, ion, lower));

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1017,12 +1017,11 @@ auto N_e(const int nonemptymgi, const double energy, const std::array<double, SF
       const int nlevels = std::min(NTEXCITATION_MAXNLEVELS_LOWER, nlevels_all);
 
       for (int lower = 0; lower < nlevels; lower++) {
-        const int nuptrans = get_nuptrans(element, ion, lower);
-        const auto *const uptranslist = get_uptranslist(element, ion, lower);
+        const auto uptranslist = get_uptransspan(element, ion, lower);
         const double nnlevel = get_levelpop(nonemptymgi, element, ion, lower);
         const double epsilon_lower = epsilon(element, ion, lower);
         const auto statweight_lower = stat_weight(element, ion, lower);
-        for (int t = 0; t < nuptrans; t++) {
+        for (int t = 0; t < std::ssize(uptranslist); t++) {
           const int upper = uptranslist[t].targetlevelindex;
           if (upper >= NTEXCITATION_MAXNLEVELS_UPPER) {
             continue;
@@ -1515,9 +1514,8 @@ auto select_nt_ionization(const int nonemptymgi) -> std::tuple<int, int> {
 }
 
 auto get_uptransindex(const int element, const int ion, const int lower, const int upper) {
-  const int nuptrans = get_nuptrans(element, ion, lower);
-  const auto *const leveluptranslist = get_uptranslist(element, ion, lower);
-  for (int t = 0; t < nuptrans; t++) {
+  const auto leveluptranslist = get_uptransspan(element, ion, lower);
+  for (int t = 0; t < std::ssize(leveluptranslist); t++) {
     if (upper == leveluptranslist[t].targetlevelindex) {
       return t;
     }

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -19,8 +19,7 @@ void calculate_deposition_rate_density(int nonemptymgi, int timestep, HeatingCoo
 [[nodiscard]] auto get_deposition_rate_density(int nonemptymgi) -> double;
 [[nodiscard]] auto get_nt_frac_heating(int nonemptymgi) -> float;
 
-[[nodiscard]] auto nt_excitation_ratecoeff(int nonemptymgi, int element, int ion, int lowerlevel, int uptransindex,
-                                           int lineindex) -> double;
+[[nodiscard]] auto nt_excitation_ratecoeff(int nonemptymgi, int lowerlevel, int upperlevel, int lineindex) -> double;
 void do_ntalpha_deposit(Packet &pkt);
 void do_ntlepton_deposit(Packet &pkt);
 void write_restart_data(FILE *gridsave_file);

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -19,7 +19,8 @@ void calculate_deposition_rate_density(int nonemptymgi, int timestep, HeatingCoo
 [[nodiscard]] auto get_deposition_rate_density(int nonemptymgi) -> double;
 [[nodiscard]] auto get_nt_frac_heating(int nonemptymgi) -> float;
 
-[[nodiscard]] auto nt_excitation_ratecoeff(int nonemptymgi, int lowerlevel, int upperlevel, int lineindex) -> double;
+[[nodiscard]] auto nt_excitation_ratecoeff(int nonemptymgi, int lowerlevel, int upperlevel, int alltransindex)
+    -> double;
 void do_ntalpha_deposit(Packet &pkt);
 void do_ntlepton_deposit(Packet &pkt);
 void write_restart_data(FILE *gridsave_file);

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -26,8 +26,8 @@ void do_ntlepton_deposit(Packet &pkt);
 void write_restart_data(FILE *gridsave_file);
 void read_restart_data(FILE *gridsave_file);
 void nt_MPI_Bcast(int nonemptymgi, int root_node_id);
-void nt_reset_stats();
-void nt_print_stats(double modelvolume, double deltat);
+void reset_stats();
+void print_stats(double modelvolume, double deltat);
 }  // namespace nonthermal
 
 #endif  // NONTHERMAL_H

--- a/packet.h
+++ b/packet.h
@@ -32,18 +32,16 @@ struct MacroAtomState {
 };
 
 struct Packet {
-  enum packet_type type {};  // type of packet (k-, r-, etc.)
   double prop_time{-1.};  // internal clock to track how far in time the packet has been propagated
-  int where{-1};  // The propagation grid cell that the packet is in.
-  int nscatterings{0};  // records number of electron scatterings a r-pkt undergone since it was emitted
   Vec3d pos{};  // Position of the packet (x,y,z).
   Vec3d dir{};  // Direction of propagation. (x,y,z). Always a unit vector.
-  double e_cmf{0.};  // The energy the packet carries in the co-moving frame.
-  double e_rf{0.};  // The energy the packet carries in the rest frame.
   double nu_cmf{0.};  // The frequency in the co-moving frame.
+  double e_cmf{0.};  // The energy the packet carries in the co-moving frame.
   double nu_rf{0.};  // The frequency in the rest frame.
+  double e_rf{0.};  // The energy the packet carries in the rest frame.
   int next_trans{-1};  // This keeps track of the next possible line interaction of a rpkt by storing
                        // its linelist index (to overcome numerical problems in propagating the rpkts).
+  int nscatterings{0};  // records number of electron scatterings a r-pkt undergone since it was emitted
   int emissiontype{EMTYPE_NOTSET};  // records how the packet was emitted if it is a r-pkt
   Vec3d em_pos{NAN};  // Position of the last emission (x,y,z).
   float em_time{-1.};
@@ -53,18 +51,20 @@ struct Packet {
                           // decaying pellets of the 52Fe chain (-6) and pellets which decayed before the
                           // onset of the simulation (-7)
                           // decay of a positron pellet (-10)
-  int trueemissiontype = EMTYPE_NOTSET;  // emission type coming from a kpkt to rpkt (last thermal emission)
-  float trueem_time{-1.};  // first thermal emission time [s]
   double absorptionfreq{};  // records nu_rf of packet at last absorption
   Vec3d stokes{1., 0., 0.};  // I, Q and U Stokes parameters
-  double tdecay{-1.};  // Time at which pellet decays
+  int trueemissiontype = EMTYPE_NOTSET;  // emission type coming from a kpkt to rpkt (last thermal emission)
+  float trueemissionvelocity{-1};
+  float trueem_time{-1.};  // first thermal emission time [s]
+  enum packet_type type {};  // type of packet (k-, r-, etc.)
+  int where{-1};  // The propagation grid cell that the packet is in.
   enum packet_type escape_type {};  // In which form when escaped from the grid.
   float escape_time{-1};  // time at which is passes out of the grid [s]
+  double tdecay{-1.};  // Time at which pellet decays
   int number{-1};  // A unique number to identify the packet
   bool originated_from_particlenotgamma{false};  // first-non-pellet packet type was gamma
   int pellet_decaytype{-1};  // index into decay::decaytypes
   int pellet_nucindex{-1};  // nuclide index of the decaying species
-  float trueemissionvelocity{-1};
 
   auto operator<=>(const Packet &rhs) const = default;
 };

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -1389,18 +1389,6 @@ auto calculate_iongamma_per_ionpop(const int nonemptymgi, const float T_e, const
           // use the cellcache but not the detailed bf estimators
           gamma_coeff_integral +=
               calculate_corrphotoioncoeff_integral(element, lowerion, lower, phixstargetindex, nonemptymgi);
-          // double gamma_coeff_integral_level_ch = globals::cellcache[cellcacheslotid]
-          //                                            .chelements[element]
-          //                                            .chions[lowerion]
-          //                                            .chlevels[lower]
-          //                                            .chphixstargets[phixstargetindex]
-          //                                            .corrphotoioncoeff;
-          // if (gamma_coeff_integral_level_ch >= 0) {
-          //   gamma_coeff_integral += gamma_coeff_integral_level_ch;
-          // } else {
-          //   gamma_coeff_integral +=
-          //       calculate_corrphotoioncoeff_integral(element, lowerion, lower, phixstargetindex, modelgridindex);
-          // }
         }
       }
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -868,6 +868,23 @@ auto get_nlevels_important(const int nonemptymgi, const int element, const int i
   return {nlevels_important, nnlevelsum};
 }
 
+auto interpolate_corrphotoioncoeff(const int element, const int ion, const int level, const int phixstargetindex,
+                                   const double T) -> double {
+  assert_always(USE_LUT_PHOTOION);
+  const int lowerindex = floor(log(T / MINTEMP) / T_step_log);
+  if (lowerindex < TABLESIZE - 1) {
+    const int upperindex = lowerindex + 1;
+    const double T_lower = MINTEMP * exp(lowerindex * T_step_log);
+    const double T_upper = MINTEMP * exp(upperindex * T_step_log);
+
+    const double f_upper = corrphotoioncoeffs[get_bflutindex(upperindex, element, ion, level, phixstargetindex)];
+    const double f_lower = corrphotoioncoeffs[get_bflutindex(lowerindex, element, ion, level, phixstargetindex)];
+
+    return (f_lower + ((f_upper - f_lower) / (T_upper - T_lower) * (T - T_lower)));
+  }
+  return corrphotoioncoeffs[get_bflutindex(TABLESIZE - 1, element, ion, level, phixstargetindex)];
+}
+
 }  // anonymous namespace
 
 void setup_photoion_luts() {
@@ -1136,23 +1153,6 @@ void ratecoefficients_init() {
   precalculate_ion_alpha_sp();
 
   printout("time after tabulation of rate coefficients %ld\n", std::time(nullptr));
-}
-
-auto interpolate_corrphotoioncoeff(const int element, const int ion, const int level, const int phixstargetindex,
-                                   const double T) -> double {
-  assert_always(USE_LUT_PHOTOION);
-  const int lowerindex = floor(log(T / MINTEMP) / T_step_log);
-  if (lowerindex < TABLESIZE - 1) {
-    const int upperindex = lowerindex + 1;
-    const double T_lower = MINTEMP * exp(lowerindex * T_step_log);
-    const double T_upper = MINTEMP * exp(upperindex * T_step_log);
-
-    const double f_upper = corrphotoioncoeffs[get_bflutindex(upperindex, element, ion, level, phixstargetindex)];
-    const double f_lower = corrphotoioncoeffs[get_bflutindex(lowerindex, element, ion, level, phixstargetindex)];
-
-    return (f_lower + ((f_upper - f_lower) / (T_upper - T_lower) * (T - T_lower)));
-  }
-  return corrphotoioncoeffs[get_bflutindex(TABLESIZE - 1, element, ion, level, phixstargetindex)];
 }
 
 auto get_corrphotoioncoeff_ana(int element, const int ion, const int level, const int phixstargetindex,

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -1176,8 +1176,8 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
 #if (SEPARATE_STIMRECOMB)
   if (use_cellcache) {
     const auto uniquelevelindex = get_uniquelevelindex(element, lowerion, level);
-    const auto allphisxtargetindex = globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex;
-    stimrecombcoeff = globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].stimrecombcoeff;
+    const auto allphisxtargetindex = get_allphixstargetindex(uniquelevelindex, phixstargetindex);
+    stimrecombcoeff = globals::cellcache[cellcacheslotid].allphixstargets_stimrecombcoeff[allphisxtargetindex];
   }
 #endif
 
@@ -1186,7 +1186,7 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
 
 #if (SEPARATE_STIMRECOMB)
     if (use_cellcache) {
-      globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].stimrecombcoeff = stimrecombcoeff;
+      globals::cellcache[cellcacheslotid].allphixstargets_stimrecombcoeff[allphisxtargetindex] = stimrecombcoeff;
     }
 #endif
   }
@@ -1219,10 +1219,9 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
   // LTE value. Because the T_e dependence of gammacorr is weak, this correction
   // correction may be evaluated at T_R!
   const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-  const auto allphisxtargetindex = globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex;
-  double gammacorr = (use_cellcache)
-                         ? globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].corrphotoioncoeff
-                         : -1;
+  const auto allphisxtargetindex = get_allphixstargetindex(uniquelevelindex, phixstargetindex);
+  double gammacorr =
+      (use_cellcache) ? globals::cellcache[cellcacheslotid].allphixstargets_corrphotoioncoeff[allphisxtargetindex] : -1;
 
   if (!use_cellcache || gammacorr < 0) {
     if (DETAILED_BF_ESTIMATORS_ON && globals::timestep >= DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP) {
@@ -1246,7 +1245,7 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
       }
     }
     if (use_cellcache) {
-      globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].corrphotoioncoeff = gammacorr;
+      globals::cellcache[cellcacheslotid].allphixstargets_corrphotoioncoeff[allphisxtargetindex] = gammacorr;
     }
   }
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -1245,7 +1245,8 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
         const double T_R = grid::get_TR(nonemptymgi);
 
         gammacorr = W * interpolate_corrphotoioncoeff(element, ion, level, phixstargetindex, T_R);
-        const int index_in_groundlevelcontestimator = get_ion_levels(element, ion)[level].closestgroundlevelcont;
+        const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+        const int index_in_groundlevelcontestimator = globals::alllevels_closestgroundlevelcont[uniquelevelindex];
         if (index_in_groundlevelcontestimator >= 0) {
           gammacorr *= globals::corrphotoionrenorm[(nonemptymgi * globals::nbfcontinua_ground) +
                                                    index_in_groundlevelcontestimator];

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -1173,12 +1173,9 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
   double stimrecombcoeff = -1.;
 #if (SEPARATE_STIMRECOMB)
   if (use_cellcache) {
-    stimrecombcoeff = globals::cellcache[cellcacheslotid]
-                          .chelements[element]
-                          .chions[lowerion]
-                          .chlevels[level]
-                          .chphixstargets[phixstargetindex]
-                          .stimrecombcoeff;
+    const auto uniquelevelindex = get_uniquelevelindex(element, lowerion, level);
+    const auto allphisxtargetindex = globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex;
+    stimrecombcoeff = globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].stimrecombcoeff;
   }
 #endif
 
@@ -1187,12 +1184,7 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
 
 #if (SEPARATE_STIMRECOMB)
     if (use_cellcache) {
-      globals::cellcache[cellcacheslotid]
-          .chelements[element]
-          .chions[lowerion]
-          .chlevels[level]
-          .chphixstargets[phixstargetindex]
-          .stimrecombcoeff = stimrecombcoeff;
+      globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].stimrecombcoeff = stimrecombcoeff;
     }
 #endif
   }
@@ -1223,13 +1215,11 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
   // The correction factor for stimulated emission in gammacorr is set to its
   // LTE value. Because the T_e dependence of gammacorr is weak, this correction
   // correction may be evaluated at T_R!
-  double gammacorr = (use_cellcache) ? globals::cellcache[cellcacheslotid]
-                                           .chelements[element]
-                                           .chions[ion]
-                                           .chlevels[level]
-                                           .chphixstargets[phixstargetindex]
-                                           .corrphotoioncoeff
-                                     : -1;
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  const auto allphisxtargetindex = globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex;
+  double gammacorr = (use_cellcache)
+                         ? globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].corrphotoioncoeff
+                         : -1;
 
   if (!use_cellcache || gammacorr < 0) {
     if (DETAILED_BF_ESTIMATORS_ON && globals::timestep >= DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP) {
@@ -1245,7 +1235,6 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
         const double T_R = grid::get_TR(nonemptymgi);
 
         gammacorr = W * interpolate_corrphotoioncoeff(element, ion, level, phixstargetindex, T_R);
-        const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
         const int index_in_groundlevelcontestimator = globals::alllevels.closestgroundlevelcont[uniquelevelindex];
         if (index_in_groundlevelcontestimator >= 0) {
           gammacorr *= globals::corrphotoionrenorm[(nonemptymgi * globals::nbfcontinua_ground) +
@@ -1254,12 +1243,7 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
       }
     }
     if (use_cellcache) {
-      globals::cellcache[cellcacheslotid]
-          .chelements[element]
-          .chions[ion]
-          .chlevels[level]
-          .chphixstargets[phixstargetindex]
-          .corrphotoioncoeff = gammacorr;
+      globals::cellcache[cellcacheslotid].challphixstargets[allphisxtargetindex].corrphotoioncoeff = gammacorr;
     }
   }
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -1176,8 +1176,8 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
 #if (SEPARATE_STIMRECOMB)
   if (use_cellcache) {
     const auto uniquelevelindex = get_uniquelevelindex(element, lowerion, level);
-    const auto allphisxtargetindex = get_allphixstargetindex(uniquelevelindex, phixstargetindex);
-    stimrecombcoeff = globals::cellcache[cellcacheslotid].allphixstargets_stimrecombcoeff[allphisxtargetindex];
+    const auto allphixstargetindex = get_allphixstargetindex(uniquelevelindex, phixstargetindex);
+    stimrecombcoeff = globals::cellcache[cellcacheslotid].allphixstargets_stimrecombcoeff[allphixstargetindex];
   }
 #endif
 
@@ -1186,7 +1186,7 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
 
 #if (SEPARATE_STIMRECOMB)
     if (use_cellcache) {
-      globals::cellcache[cellcacheslotid].allphixstargets_stimrecombcoeff[allphisxtargetindex] = stimrecombcoeff;
+      globals::cellcache[cellcacheslotid].allphixstargets_stimrecombcoeff[allphixstargetindex] = stimrecombcoeff;
     }
 #endif
   }

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -1246,7 +1246,7 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
 
         gammacorr = W * interpolate_corrphotoioncoeff(element, ion, level, phixstargetindex, T_R);
         const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-        const int index_in_groundlevelcontestimator = globals::alllevels_closestgroundlevelcont[uniquelevelindex];
+        const int index_in_groundlevelcontestimator = globals::alllevels.closestgroundlevelcont[uniquelevelindex];
         if (index_in_groundlevelcontestimator >= 0) {
           gammacorr *= globals::corrphotoionrenorm[(nonemptymgi * globals::nbfcontinua_ground) +
                                                    index_in_groundlevelcontestimator];

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -767,7 +767,9 @@ auto calculate_corrphotoioncoeff_integral(int element, const int ion, const int 
   constexpr double epsrelwarning = 1e-1;
   constexpr double epsabs = 0.;
 
-  const double E_threshold = get_phixs_threshold(element, ion, level, phixstargetindex);
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+
+  const double E_threshold = get_phixs_threshold(uniquelevelindex, phixstargetindex);
   const double nu_threshold = ONEOVERH * E_threshold;
   const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
 
@@ -777,9 +779,9 @@ auto calculate_corrphotoioncoeff_integral(int element, const int ion, const int 
   const double departure_ratio = 0.;  // zero the stimulated recomb contribution
 #else
   // stimulated recombination is negative photoionisation
-  const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
+  const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
   const double nne = grid::get_nne(nonemptymgi);
-  const int upperionlevel = get_phixsupperlevel(element, ion, level, phixstargetindex);
+  const int upperionlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex);
   const double sf = calculate_sahafact(element, ion, level, upperionlevel, T_e, H * nu_threshold);
   const double nnupperionlevel = get_levelpop(nonemptymgi, element, ion + 1, upperionlevel);
   double departure_ratio = nnlevel > 0. ? nnupperionlevel / nnlevel * nne * sf : 1.;  // put that to phixslist
@@ -790,7 +792,7 @@ auto calculate_corrphotoioncoeff_integral(int element, const int ion, const int 
   const auto intparas = GSLIntegralParasGammaCorr{
       .nu_edge = nu_threshold,
       .departure_ratio = departure_ratio,
-      .photoion_xs = get_phixs_table(element, ion, level),
+      .photoion_xs = get_phixs_table(uniquelevelindex),
       .T_e = T_e,
       .nonemptymgi = nonemptymgi,
   };
@@ -820,7 +822,7 @@ auto calculate_corrphotoioncoeff_integral(int element, const int ion, const int 
     }
   }
 
-  gammacorr *= FOURPI * get_phixsprobability(element, ion, level, phixstargetindex);
+  gammacorr *= FOURPI * get_phixsprobability(uniquelevelindex, phixstargetindex);
 
   return gammacorr;
 }
@@ -1196,17 +1198,18 @@ auto get_stimrecombcoeff(int element, const int lowerion, const int level, const
 __host__ __device__ auto get_bfcoolingcoeff(const int element, const int ion, const int level,
                                             const int phixstargetindex, const float T_e) -> double {
   const int lowerindex = floor(log(T_e / MINTEMP) / T_step_log);
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
   if (lowerindex < TABLESIZE - 1) {
     const int upperindex = lowerindex + 1;
     const double T_lower = MINTEMP * exp(lowerindex * T_step_log);
     const double T_upper = MINTEMP * exp(upperindex * T_step_log);
 
-    const double f_upper = bfcooling_coeffs[get_bflutindex(upperindex, element, ion, level, phixstargetindex)];
-    const double f_lower = bfcooling_coeffs[get_bflutindex(lowerindex, element, ion, level, phixstargetindex)];
+    const double f_upper = bfcooling_coeffs[get_bflutindex(upperindex, uniquelevelindex, phixstargetindex)];
+    const double f_lower = bfcooling_coeffs[get_bflutindex(lowerindex, uniquelevelindex, phixstargetindex)];
 
     return (f_lower + ((f_upper - f_lower) / (T_upper - T_lower) * (T_e - T_lower)));
   }
-  return bfcooling_coeffs[get_bflutindex(TABLESIZE - 1, element, ion, level, phixstargetindex)];
+  return bfcooling_coeffs[get_bflutindex(TABLESIZE - 1, uniquelevelindex, phixstargetindex)];
 }
 
 // Return the photoionisation rate coefficient (corrected for stimulated emission)

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -926,47 +926,43 @@ void setup_photoion_luts() {
 
 __host__ __device__ auto select_continuum_nu(int element, const int lowerion, const int lower, const int upperionlevel,
                                              float T_e) -> double {
-  // this function should only be called in the cellcache mode (packet prop, not update grid)
-  assert_testmodeonly(use_cellcache);
   const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lower);
   const int phixstargetindex = get_phixtargetindex(lower_uniquelevelindex, upperionlevel);
-  const auto allphixstargetindex = get_allphixstargetindex(lower_uniquelevelindex, phixstargetindex);
-
-  const int npieces = globals::NPHIXSPOINTS;
-  auto *integrals = &globals::cellcache[cellcacheslotid].alpha_sp_E_integrals[allphixstargetindex * npieces];
-
   const double E_threshold = get_phixs_threshold(lower_uniquelevelindex, phixstargetindex);
   const double nu_threshold = ONEOVERH * E_threshold;
+
   const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
-  const double deltanu = (nu_max_phixs - nu_threshold) / npieces;
+
+  const int npieces = globals::NPHIXSPOINTS;
 
   const GSLIntegrationParas intparas = {
       .nu_edge = nu_threshold, .T = T_e, .photoion_xs = get_phixs_table(lower_uniquelevelindex)};
 
+  const double zrand = 1. - rng_uniform();  // Make sure that 0 < zrand <= 1
+
+  const double deltanu = (nu_max_phixs - nu_threshold) / npieces;
   double error{NAN};
 
 #if !USE_SIMPSON_INTEGRATOR
   gsl_error_handler_t *previous_handler = gsl_set_error_handler(gsl_error_handler_printout);
 #endif
 
-  if (integrals[0] < 0.) {
-    integrator<alpha_sp_E_integrand_gsl>(intparas, nu_threshold, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
-                                         GSL_INTEG_GAUSS31, &integrals[0], &error);
-  }
-  const auto total_alpha_sp = integrals[0];
+  double total_alpha_sp = 0.;
+  integrator<alpha_sp_E_integrand_gsl>(intparas, nu_threshold, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
+                                       GSL_INTEG_GAUSS31, &total_alpha_sp, &error);
 
   double alpha_sp_old = total_alpha_sp;
   double alpha_sp = total_alpha_sp;
-  const double zrand = 1. - rng_uniform();  // Make sure that 0 < zrand <= 1
+
   int i = 1;
   for (i = 1; i < npieces; i++) {
     alpha_sp_old = alpha_sp;
-    if (integrals[i] < 0.) {
-      const double xlow = nu_threshold + (i * deltanu);
-      integrator<alpha_sp_E_integrand_gsl>(intparas, xlow, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
-                                           GSL_INTEG_GAUSS31, &integrals[i], &error);
-    }
-    alpha_sp = integrals[i];
+    const double xlow = nu_threshold + (i * deltanu);
+
+    // Spontaneous recombination and bf-cooling coefficient don't depend on the radiation field
+    integrator<alpha_sp_E_integrand_gsl>(intparas, xlow, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
+                                         GSL_INTEG_GAUSS31, &alpha_sp, &error);
+
     if (zrand >= alpha_sp / total_alpha_sp) {
       break;
     }

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -761,8 +761,8 @@ auto integrand_corrphotoioncoeff_custom_radfield(const double nu, void *const vo
   return ONEOVERH * sigma_bf / nu * Jnu * corrfactor;
 }
 
-auto calculate_corrphotoioncoeff_integral(int element, const int ion, const int level, const int phixstargetindex,
-                                          int nonemptymgi) -> double {
+auto calculate_corrphotoioncoeff_integral(const int element, const int ion, const int level, const int phixstargetindex,
+                                          const int nonemptymgi) -> double {
   constexpr double epsrel = 1e-3;
   constexpr double epsrelwarning = 1e-1;
   constexpr double epsabs = 0.;

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -925,8 +925,9 @@ void setup_photoion_luts() {
 
 __host__ __device__ auto select_continuum_nu(int element, const int lowerion, const int lower, const int upperionlevel,
                                              float T_e) -> double {
-  const int phixstargetindex = get_phixtargetindex(element, lowerion, lower, upperionlevel);
-  const double E_threshold = get_phixs_threshold(element, lowerion, lower, phixstargetindex);
+  const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lower);
+  const int phixstargetindex = get_phixtargetindex(lower_uniquelevelindex, upperionlevel);
+  const double E_threshold = get_phixs_threshold(lower_uniquelevelindex, phixstargetindex);
   const double nu_threshold = ONEOVERH * E_threshold;
 
   const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
@@ -934,7 +935,7 @@ __host__ __device__ auto select_continuum_nu(int element, const int lowerion, co
   const int npieces = globals::NPHIXSPOINTS;
 
   const GSLIntegrationParas intparas = {
-      .nu_edge = nu_threshold, .T = T_e, .photoion_xs = get_phixs_table(element, lowerion, lower)};
+      .nu_edge = nu_threshold, .T = T_e, .photoion_xs = get_phixs_table(lower_uniquelevelindex)};
 
   const double zrand = 1. - rng_uniform();  // Make sure that 0 < zrand <= 1
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -868,8 +868,7 @@ auto get_nlevels_important(const int nonemptymgi, const int element, const int i
   return {nlevels_important, nnlevelsum};
 }
 
-auto interpolate_corrphotoioncoeff(const int element, const int ion, const int level, const int phixstargetindex,
-                                   const double T) -> double {
+auto interpolate_corrphotoioncoeff(const int uniquelevelindex, const int phixstargetindex, const double T) -> double {
   assert_always(USE_LUT_PHOTOION);
   const int lowerindex = floor(log(T / MINTEMP) / T_step_log);
   if (lowerindex < TABLESIZE - 1) {
@@ -877,12 +876,12 @@ auto interpolate_corrphotoioncoeff(const int element, const int ion, const int l
     const double T_lower = MINTEMP * exp(lowerindex * T_step_log);
     const double T_upper = MINTEMP * exp(upperindex * T_step_log);
 
-    const double f_upper = corrphotoioncoeffs[get_bflutindex(upperindex, element, ion, level, phixstargetindex)];
-    const double f_lower = corrphotoioncoeffs[get_bflutindex(lowerindex, element, ion, level, phixstargetindex)];
+    const double f_upper = corrphotoioncoeffs[get_bflutindex(upperindex, uniquelevelindex, phixstargetindex)];
+    const double f_lower = corrphotoioncoeffs[get_bflutindex(lowerindex, uniquelevelindex, phixstargetindex)];
 
     return (f_lower + ((f_upper - f_lower) / (T_upper - T_lower) * (T - T_lower)));
   }
-  return corrphotoioncoeffs[get_bflutindex(TABLESIZE - 1, element, ion, level, phixstargetindex)];
+  return corrphotoioncoeffs[get_bflutindex(TABLESIZE - 1, uniquelevelindex, phixstargetindex)];
 }
 
 }  // anonymous namespace
@@ -1165,8 +1164,8 @@ auto get_corrphotoioncoeff_ana(int element, const int ion, const int level, cons
   // correction may be evaluated at T_R!
   const double W = grid::get_W(nonemptymgi);
   const double T_R = grid::get_TR(nonemptymgi);
-
-  return W * interpolate_corrphotoioncoeff(element, ion, level, phixstargetindex, T_R);
+  const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+  return W * interpolate_corrphotoioncoeff(uniquelevelindex, phixstargetindex, T_R);
 }
 
 // Returns the stimulated recombination rate coefficient. multiply by upper level population and nne to get rate
@@ -1237,7 +1236,7 @@ __host__ __device__ auto get_corrphotoioncoeff(const int element, const int ion,
         const double W = grid::get_W(nonemptymgi);
         const double T_R = grid::get_TR(nonemptymgi);
 
-        gammacorr = W * interpolate_corrphotoioncoeff(element, ion, level, phixstargetindex, T_R);
+        gammacorr = W * interpolate_corrphotoioncoeff(uniquelevelindex, phixstargetindex, T_R);
         const int index_in_groundlevelcontestimator = globals::alllevels.closestgroundlevelcont[uniquelevelindex];
         if (index_in_groundlevelcontestimator >= 0) {
           gammacorr *= globals::corrphotoionrenorm[(nonemptymgi * globals::nbfcontinua_ground) +

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -926,43 +926,47 @@ void setup_photoion_luts() {
 
 __host__ __device__ auto select_continuum_nu(int element, const int lowerion, const int lower, const int upperionlevel,
                                              float T_e) -> double {
+  // this function should only be called in the cellcache mode (packet prop, not update grid)
+  assert_testmodeonly(use_cellcache);
   const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lower);
   const int phixstargetindex = get_phixtargetindex(lower_uniquelevelindex, upperionlevel);
-  const double E_threshold = get_phixs_threshold(lower_uniquelevelindex, phixstargetindex);
-  const double nu_threshold = ONEOVERH * E_threshold;
-
-  const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
+  const auto allphixstargetindex = get_allphixstargetindex(lower_uniquelevelindex, phixstargetindex);
 
   const int npieces = globals::NPHIXSPOINTS;
+  auto *integrals = &globals::cellcache[cellcacheslotid].alpha_sp_E_integrals[allphixstargetindex * npieces];
+
+  const double E_threshold = get_phixs_threshold(lower_uniquelevelindex, phixstargetindex);
+  const double nu_threshold = ONEOVERH * E_threshold;
+  const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
+  const double deltanu = (nu_max_phixs - nu_threshold) / npieces;
 
   const GSLIntegrationParas intparas = {
       .nu_edge = nu_threshold, .T = T_e, .photoion_xs = get_phixs_table(lower_uniquelevelindex)};
 
-  const double zrand = 1. - rng_uniform();  // Make sure that 0 < zrand <= 1
-
-  const double deltanu = (nu_max_phixs - nu_threshold) / npieces;
   double error{NAN};
 
 #if !USE_SIMPSON_INTEGRATOR
   gsl_error_handler_t *previous_handler = gsl_set_error_handler(gsl_error_handler_printout);
 #endif
 
-  double total_alpha_sp = 0.;
-  integrator<alpha_sp_E_integrand_gsl>(intparas, nu_threshold, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
-                                       GSL_INTEG_GAUSS31, &total_alpha_sp, &error);
+  if (integrals[0] < 0.) {
+    integrator<alpha_sp_E_integrand_gsl>(intparas, nu_threshold, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
+                                         GSL_INTEG_GAUSS31, &integrals[0], &error);
+  }
+  const auto total_alpha_sp = integrals[0];
 
   double alpha_sp_old = total_alpha_sp;
   double alpha_sp = total_alpha_sp;
-
+  const double zrand = 1. - rng_uniform();  // Make sure that 0 < zrand <= 1
   int i = 1;
   for (i = 1; i < npieces; i++) {
     alpha_sp_old = alpha_sp;
-    const double xlow = nu_threshold + (i * deltanu);
-
-    // Spontaneous recombination and bf-cooling coefficient don't depend on the radiation field
-    integrator<alpha_sp_E_integrand_gsl>(intparas, xlow, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
-                                         GSL_INTEG_GAUSS31, &alpha_sp, &error);
-
+    if (integrals[i] < 0.) {
+      const double xlow = nu_threshold + (i * deltanu);
+      integrator<alpha_sp_E_integrand_gsl>(intparas, xlow, nu_max_phixs, 0, CONTINUUM_NU_INTEGRAL_ACCURACY,
+                                           GSL_INTEG_GAUSS31, &integrals[i], &error);
+    }
+    alpha_sp = integrals[i];
     if (zrand >= alpha_sp / total_alpha_sp) {
       break;
     }

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -661,9 +661,10 @@ void precalculate_ion_alpha_sp() {
         const int nionisinglevels = get_nlevels_ionising(element, ion);
         double zeta = 0.;
         for (int level = 0; level < nionisinglevels; level++) {
-          const auto nphixstargets = get_nphixstargets(element, ion, level);
+          const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+          const auto nphixstargets = get_nphixstargets(uniquelevelindex);
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-            const double zeta_level = get_spontrecombcoeff(element, ion, level, phixstargetindex, T_e);
+            const double zeta_level = get_spontrecombcoeff(uniquelevelindex, phixstargetindex, T_e);
             zeta += zeta_level;
           }
         }
@@ -981,8 +982,8 @@ __host__ __device__ auto select_continuum_nu(int element, const int lowerion, co
 }
 
 // Return the rate coefficient for spontaneous recombination.
-__host__ __device__ auto get_spontrecombcoeff(int element, const int ion, const int level, const int phixstargetindex,
-                                              float T_e) -> double {
+__host__ __device__ auto get_spontrecombcoeff(const int uniquelevelindex, const int phixstargetindex, float T_e)
+    -> double {
   double Alpha_sp{NAN};
   const int lowerindex = floor(log(T_e / MINTEMP) / T_step_log);
   assert_always(lowerindex >= 0);
@@ -991,11 +992,11 @@ __host__ __device__ auto get_spontrecombcoeff(int element, const int ion, const 
     const double T_lower = MINTEMP * exp(lowerindex * T_step_log);
     const double T_upper = MINTEMP * exp(upperindex * T_step_log);
 
-    const double f_upper = spontrecombcoeffs[get_bflutindex(upperindex, element, ion, level, phixstargetindex)];
-    const double f_lower = spontrecombcoeffs[get_bflutindex(lowerindex, element, ion, level, phixstargetindex)];
+    const double f_upper = spontrecombcoeffs[get_bflutindex(upperindex, uniquelevelindex, phixstargetindex)];
+    const double f_lower = spontrecombcoeffs[get_bflutindex(lowerindex, uniquelevelindex, phixstargetindex)];
     Alpha_sp = (f_lower + (f_upper - f_lower) / (T_upper - T_lower) * (T_e - T_lower));
   } else {
-    Alpha_sp = spontrecombcoeffs[get_bflutindex(TABLESIZE - 1, element, ion, level, phixstargetindex)];
+    Alpha_sp = spontrecombcoeffs[get_bflutindex(TABLESIZE - 1, uniquelevelindex, phixstargetindex)];
   }
   return Alpha_sp;
 }

--- a/ratecoeff.h
+++ b/ratecoeff.h
@@ -17,7 +17,7 @@ void ratecoefficients_init();
 void setup_photoion_luts();
 
 [[nodiscard]] auto select_continuum_nu(int element, int lowerion, int lower, int upperionlevel, float T_e) -> double;
-[[nodiscard]] auto get_spontrecombcoeff(int element, int ion, int level, int phixstargetindex, float T_e) -> double;
+[[nodiscard]] auto get_spontrecombcoeff(int uniquelevelindex, int phixstargetindex, float T_e) -> double;
 [[nodiscard]] auto get_stimrecombcoeff(int element, int lowerion, int level, int phixstargetindex, int nonemptymgi)
     -> double;
 

--- a/ratecoeff.h
+++ b/ratecoeff.h
@@ -17,10 +17,6 @@ void ratecoefficients_init();
 void setup_photoion_luts();
 
 [[nodiscard]] auto select_continuum_nu(int element, int lowerion, int lower, int upperionlevel, float T_e) -> double;
-
-[[nodiscard]] auto interpolate_corrphotoioncoeff(int element, int ion, int level, int phixstargetindex, double T)
-    -> double;
-
 [[nodiscard]] auto get_spontrecombcoeff(int element, int ion, int level, int phixstargetindex, float T_e) -> double;
 [[nodiscard]] auto get_stimrecombcoeff(int element, int lowerion, int level, int phixstargetindex, int nonemptymgi)
     -> double;

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -437,7 +437,7 @@ void rpkt_event_continuum(Packet &pkt, const Rpkt_continuum_absorptioncoeffs &ch
 
     // generate a virtual packet
     if constexpr (VPKT_ON) {
-      vpkt_call_estimators(pkt, TYPE_RPKT);
+      vpkt::call_estimators(pkt, TYPE_RPKT);
     }
 
     // pkt.nu_cmf = 3.7474058e+14;

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -481,14 +481,11 @@ void rpkt_event_continuum(Packet &pkt, const Rpkt_continuum_absorptioncoeffs &ch
     const int level = globals::allcont[allcontindex].level;
     const int phixstargetindex = globals::allcont[allcontindex].phixstargetindex;
 
-    // printout("[debug] rpkt_event:   bound-free: element %d, ion+1 %d, upper %d, ion %d, lower %d\n", element, ion +
-    // 1, 0, ion, level); printout("[debug] rpkt_event:   bound-free: nu_edge %g, nu %g\n", nu_edge, nu);
-
     if constexpr (TRACK_ION_STATS) {
       stats::increment_ion_stats_contabsorption(pkt, nonemptymgi, element, ion);
     }
 
-    // and decide whether we go to ionisation energy
+    // decide whether we go to ionisation energy or to the thermal pool
     if (rng_uniform() < nu_edge / nu) {
       stats::increment(stats::COUNTER_MA_STAT_ACTIVATION_BF);
       stats::increment(stats::COUNTER_INTERACTIONS);
@@ -500,11 +497,8 @@ void rpkt_event_continuum(Packet &pkt, const Rpkt_continuum_absorptioncoeffs &ch
       const int upper = get_phixsupperlevel(element, ion, level, phixstargetindex);
 
       do_macroatom(pkt, {.element = element, .ion = ion + 1, .level = upper, .activatingline = -99});
-    }
-    // or to the thermal pool
-    else {
+    } else {
       // transform to k-pkt
-      // printout("[debug] rpkt_event:   bound-free: transform to k-pkt\n");
       stats::increment(stats::COUNTER_K_STAT_FROM_BF);
       stats::increment(stats::COUNTER_INTERACTIONS);
       pkt.type = TYPE_KPKT;

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -437,7 +437,7 @@ void save_grid_and_packets(const int nts, std::span<const Packet> packets) {
     // save packet state at start of current timestep (before propagation)
     write_temp_packetsfile(nts, globals::my_rank, packets);
 
-    vpkt_write_timestep(nts, globals::my_rank, false);
+    vpkt::write_timestep(nts, globals::my_rank, false);
 
     const auto time_write_packets_finished_thisrank = std::time(nullptr);
 
@@ -483,7 +483,7 @@ void save_grid_and_packets(const int nts, std::span<const Packet> packets) {
 
     // delete temp packets files from previous timestep now that all restart data for the new timestep is available
     remove_temp_packetsfile(nts - 1, my_rank);
-    vpkt_remove_temp_file(nts - 1, my_rank);
+    vpkt::remove_temp_vpkt_file(nts - 1, my_rank);
   }
 }
 
@@ -632,16 +632,17 @@ auto do_timestep(const int nts, const int titer, std::span<Packet> packets, cons
 
     if (VPKT_ON) {
       printout("During timestep %d on MPI process %d, %d virtual packets were generated and %d escaped.\n", nts,
-               my_rank, nvpkt_created, nvpkt_esc_from_rpkt + nvpkt_esc_from_kpkt + nvpkt_esc_from_macroatom);
+               my_rank, vpkt::nvpkt_created,
+               vpkt::nvpkt_esc_from_rpkt + vpkt::nvpkt_esc_from_kpkt + vpkt::nvpkt_esc_from_macroatom);
       printout(
           "%d virtual packets came from an electron scattering event, %d from a kpkt deactivation and %d from a "
           "macroatom deactivation.\n",
-          nvpkt_esc_from_rpkt, nvpkt_esc_from_kpkt, nvpkt_esc_from_macroatom);
+          vpkt::nvpkt_esc_from_rpkt, vpkt::nvpkt_esc_from_kpkt, vpkt::nvpkt_esc_from_macroatom);
 
-      nvpkt_created = 0;
-      nvpkt_esc_from_rpkt = 0;
-      nvpkt_esc_from_kpkt = 0;
-      nvpkt_esc_from_macroatom = 0;
+      vpkt::nvpkt_created = 0;
+      vpkt::nvpkt_esc_from_rpkt = 0;
+      vpkt::nvpkt_esc_from_kpkt = 0;
+      vpkt::nvpkt_esc_from_macroatom = 0;
     }
 
     if constexpr (RECORD_LINESTAT) {
@@ -667,7 +668,7 @@ auto do_timestep(const int nts, const int titer, std::span<Packet> packets, cons
       // snprintf(filename, MAXFILENAMELENGTH, "packets%.2d_%.4d.out", middle_iteration, my_rank);
       write_packets(filename, packets);
 
-      vpkt_write_timestep(nts, my_rank, true);
+      vpkt::write_timestep(nts, my_rank, true);
 
       printout("time after write final packets file %ld\n", std::time(nullptr));
 
@@ -691,10 +692,10 @@ auto main(int argc, char *argv[]) -> int {
   assert_always(!DETAILED_BF_ESTIMATORS_ON || !USE_LUT_PHOTOION);
 
   if constexpr (VPKT_ON) {
-    nvpkt_created = 0;
-    nvpkt_esc_from_rpkt = 0;
-    nvpkt_esc_from_kpkt = 0;
-    nvpkt_esc_from_macroatom = 0;
+    vpkt::nvpkt_created = 0;
+    vpkt::nvpkt_esc_from_rpkt = 0;
+    vpkt::nvpkt_esc_from_kpkt = 0;
+    vpkt::nvpkt_esc_from_macroatom = 0;
   }
 
   MPI_Init(&argc, &argv);
@@ -823,14 +824,14 @@ auto main(int argc, char *argv[]) -> int {
 
   bool terminate_early = false;
 
-  time_init();
+  setup_timesteps();
 
   if (my_rank == 0) {
     write_timestep_file();
   }
 
   printout("time grid_init %ld\n", std::time(nullptr));
-  grid::grid_init(my_rank);
+  grid::init_grid(my_rank);
 
   printout("Simulation propagates %g packets per process (total %g with nprocs %d)\n", 1. * globals::npkts,
            1. * globals::npkts * globals::nprocs, globals::nprocs);
@@ -874,7 +875,7 @@ auto main(int argc, char *argv[]) -> int {
   }
 
   // initialise or read in virtual packet spectra
-  vpkt_init(globals::timestep, my_rank, globals::simulation_continued_from_saved);
+  vpkt::init(globals::timestep, my_rank, globals::simulation_continued_from_saved);
 
   while (globals::timestep < globals::timestep_finish && !terminate_early) {
     MPI_Barrier(MPI_COMM_WORLD);

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -113,17 +113,24 @@ void printout_tracemission_stats() {
         const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
         const double B_lu = statweight_target / statweight_lower * B_ul;
 
-        const int nupperdowntrans = get_ndowntrans(element, ion, upper);
-        const auto *downtranslist = get_downtranslist(element, ion, upper);
-        const auto *downtransition = std::find_if(downtranslist, downtranslist + nupperdowntrans,
-                                                  [=](const auto &downtr) { return downtr.targetlevelindex == lower; });
-        assert_always(downtransition != (downtranslist + nupperdowntrans));
+        const auto upper_uniquelevelindex = get_uniquelevelindex(element, ion, upper);
+
+        const auto alltrans_startdown = get_alltrans_startdown(upper_uniquelevelindex);
+        const auto ndowntrans = get_ndowntrans(upper_uniquelevelindex);
+        int downtransid = -1;
+        for (int alltransindex = alltrans_startdown; alltransindex < alltrans_startdown + ndowntrans; alltransindex++) {
+          if (globals::alltrans.targetlevelindex[alltransindex] == lower) {
+            downtransid = alltransindex;
+            break;
+          }
+        }
+        assert_always(downtransid != -1);
 
         printout("%7.2e (%5.1f%%) %4d %9d %5d %5d %8.1f %8.2e %4d %7.1f %7.1f %7.1e %7.1e\n", encontrib,
                  100 * encontrib / totalenergy, get_atomicnumber(element), get_ionstage(element, ion),
                  globals::linelist[lineindex].upperlevelindex, globals::linelist[lineindex].lowerlevelindex,
-                 downtransition->coll_str, globals::linelist[lineindex].einstein_A,
-                 static_cast<int>(downtransition->forbidden), linelambda, v_rad, B_lu, B_ul);
+                 globals::alltrans.coll_str[downtransid], globals::linelist[lineindex].einstein_A,
+                 static_cast<int>(globals::alltrans.forbidden[downtransid]), linelambda, v_rad, B_lu, B_ul);
       } else {
         break;
       }

--- a/stats.cc
+++ b/stats.cc
@@ -164,7 +164,7 @@ void pkt_action_counters_reset() {
     eventstats[i] = 0;
   }
 
-  nonthermal::nt_reset_stats();
+  nonthermal::reset_stats();
   globals::nesc = 0;
 }
 
@@ -215,7 +215,7 @@ void pkt_action_counters_printout(const int nts) {
   printout("timestep %d: nt_stat_to_ionization = %td\n", nts, get_counter(COUNTER_NT_STAT_TO_IONIZATION));
   printout("timestep %d: nt_stat_to_excitation = %td\n", nts, get_counter(COUNTER_NT_STAT_TO_EXCITATION));
   printout("timestep %d: nt_stat_to_kpkt = %td\n", nts, get_counter(COUNTER_NT_STAT_TO_KPKT));
-  nonthermal::nt_print_stats(modelvolume, deltat);
+  nonthermal::print_stats(modelvolume, deltat);
 
   printout("timestep %d: escounter = %td\n", nts, get_counter(COUNTER_ESCOUNTER));
   printout("timestep %d: cellcrossing  = %td\n", nts, get_counter(COUNTER_CELLCROSSINGS));

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -114,10 +114,10 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
                                 const double nne) -> double {
   double C_deexc = 0.;
   const int nlevels = get_nlevels(element, ion);
-
+  const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   for (int level = 0; level < nlevels; level++) {
     const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-    const double epsilon_level = epsilon(element, ion, level);
+    const double epsilon_level = epsilon(ionuniquelevelindexstart + level);
 
     // Collisional heating: deexcitation to same ionization stage
     const int ndowntrans = get_ndowntrans(element, ion, level);
@@ -125,7 +125,7 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
     for (int i = 0; i < ndowntrans; i++) {
       const auto &downtransition = leveldowntranslist[i];
       const int lower = downtransition.targetlevelindex;
-      const double epsilon_trans = epsilon_level - epsilon(element, ion, lower);
+      const double epsilon_trans = epsilon_level - epsilon(ionuniquelevelindexstart + lower);
       const double C = nnlevel *
                        col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, level, downtransition) *
                        epsilon_trans;

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -116,22 +116,22 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
   const int nlevels = get_nlevels(element, ion);
   const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
   for (int level = 0; level < nlevels; level++) {
-    const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-    const double epsilon_level = epsilon(ionuniquelevelindexstart + level);
-    const double statweight = stat_weight(ionuniquelevelindexstart + level);
+    const auto uniquelevelindex = ionuniquelevelindexstart + level;
+    const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+    const double epsilon_level = epsilon(uniquelevelindex);
+    const double statweight = stat_weight(uniquelevelindex);
 
     // Collisional heating: deexcitation to same ionization stage
-    const int ndowntrans = get_ndowntrans(element, ion, level);
-    const auto *const leveldowntranslist = get_downtranslist(element, ion, level);
+    const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
+    const int ndowntrans = get_ndowntrans(uniquelevelindex);
     for (int i = 0; i < ndowntrans; i++) {
-      const auto &downtrans = leveldowntranslist[i];
-      const int lower = downtrans.targetlevelindex;
+      const auto alltransindex = alltrans_startdown + i;
+      const int lower = globals::alltrans[alltransindex].targetlevelindex;
       const double epsilon_trans = epsilon_level - epsilon(ionuniquelevelindexstart + lower);
       const auto lower_statweight = stat_weight(ionuniquelevelindexstart + lower);
-      const double C = nnlevel *
-                       col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight,
-                                                  downtrans.coll_str, downtrans.osc_strength, downtrans.forbidden) *
-                       epsilon_trans;
+      const double C =
+          nnlevel * col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, alltransindex) *
+          epsilon_trans;
       C_deexc += C;
     }
   }

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -118,6 +118,7 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
   for (int level = 0; level < nlevels; level++) {
     const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
     const double epsilon_level = epsilon(ionuniquelevelindexstart + level);
+    const double statweight = stat_weight(ionuniquelevelindexstart + level);
 
     // Collisional heating: deexcitation to same ionization stage
     const int ndowntrans = get_ndowntrans(element, ion, level);
@@ -127,7 +128,7 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
       const int lower = downtransition.targetlevelindex;
       const double epsilon_trans = epsilon_level - epsilon(ionuniquelevelindexstart + lower);
       const double C = nnlevel *
-                       col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, level, downtransition) *
+                       col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtransition) *
                        epsilon_trans;
       C_deexc += C;
     }

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -126,7 +126,7 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
     const int ndowntrans = get_ndowntrans(uniquelevelindex);
     for (int i = 0; i < ndowntrans; i++) {
       const auto alltransindex = alltrans_startdown + i;
-      const int lower = globals::alltrans[alltransindex].targetlevelindex;
+      const int lower = globals::alltrans.targetlevelindex[alltransindex];
       const double epsilon_trans = epsilon_level - epsilon(ionuniquelevelindexstart + lower);
       const auto lower_statweight = stat_weight(ionuniquelevelindexstart + lower);
       const double C =

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -169,9 +169,11 @@ void calculate_heating_rates(const int nonemptymgi, const double T_e, const doub
 
     for (int ion = 0; ion < nions - 1; ion++) {
       const int nbflevels = get_nlevels_ionising(element, ion);
+      const auto ionuniquelevelindexstart = globals::elements[element].ions[ion].uniquelevelindexstart;
       for (int level = 0; level < nbflevels; level++) {
-        const double nnlevel = get_levelpop(nonemptymgi, element, ion, level);
-        bfheating += nnlevel * bfheatingcoeffs[get_uniquelevelindex(element, ion, level)];
+        const auto uniquelevelindex = ionuniquelevelindexstart + level;
+        const double nnlevel = get_levelpop(nonemptymgi, uniquelevelindex);
+        bfheating += nnlevel * bfheatingcoeffs[uniquelevelindex];
       }
     }
   }

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -127,9 +127,10 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
       const auto &downtransition = leveldowntranslist[i];
       const int lower = downtransition.targetlevelindex;
       const double epsilon_trans = epsilon_level - epsilon(ionuniquelevelindexstart + lower);
-      const double C = nnlevel *
-                       col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, element, ion, statweight, downtransition) *
-                       epsilon_trans;
+      const auto lower_statweight = stat_weight(ionuniquelevelindexstart + lower);
+      const double C =
+          nnlevel * col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, downtransition) *
+          epsilon_trans;
       C_deexc += C;
     }
   }

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -283,7 +283,7 @@ void calculate_bfheatingcoeffs(int nonemptymgi, std::vector<double> &bfheatingco
 
           if constexpr (USE_LUT_BFHEATING) {
             const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-            const int index_in_groundlevelcontestimator = globals::alllevels_closestgroundlevelcont[uniquelevelindex];
+            const int index_in_groundlevelcontestimator = globals::alllevels.closestgroundlevelcont[uniquelevelindex];
             if (index_in_groundlevelcontestimator >= 0) {
               bfheatingcoeff *= globals::bfheatingestimator[(nonemptymgi * globals::nbfcontinua_ground) +
                                                             index_in_groundlevelcontestimator];

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -124,13 +124,14 @@ auto get_heating_ion_coll_deexc(const int nonemptymgi, const int element, const 
     const int ndowntrans = get_ndowntrans(element, ion, level);
     const auto *const leveldowntranslist = get_downtranslist(element, ion, level);
     for (int i = 0; i < ndowntrans; i++) {
-      const auto &downtransition = leveldowntranslist[i];
-      const int lower = downtransition.targetlevelindex;
+      const auto &downtrans = leveldowntranslist[i];
+      const int lower = downtrans.targetlevelindex;
       const double epsilon_trans = epsilon_level - epsilon(ionuniquelevelindexstart + lower);
       const auto lower_statweight = stat_weight(ionuniquelevelindexstart + lower);
-      const double C =
-          nnlevel * col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight, downtransition) *
-          epsilon_trans;
+      const double C = nnlevel *
+                       col_deexcitation_ratecoeff(T_e, nne, epsilon_trans, statweight, lower_statweight,
+                                                  downtrans.coll_str, downtrans.osc_strength, downtrans.forbidden) *
+                       epsilon_trans;
       C_deexc += C;
     }
   }

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -281,7 +281,8 @@ void calculate_bfheatingcoeffs(int nonemptymgi, std::vector<double> &bfheatingco
           assert_always(std::isfinite(bfheatingcoeff));
 
           if constexpr (USE_LUT_BFHEATING) {
-            const int index_in_groundlevelcontestimator = get_ion_levels(element, ion)[level].closestgroundlevelcont;
+            const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+            const int index_in_groundlevelcontestimator = globals::alllevels_closestgroundlevelcont[uniquelevelindex];
             if (index_in_groundlevelcontestimator >= 0) {
               bfheatingcoeff *= globals::bfheatingestimator[(nonemptymgi * globals::nbfcontinua_ground) +
                                                             index_in_groundlevelcontestimator];

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1194,21 +1194,17 @@ void cellcache_change_cell(const int nonemptymgi) {
         }
       }
     }
+  }
 
-    for (auto phixstarget : cacheslot.challphixstargets) {
-      phixstarget.corrphotoioncoeff = -99.;
+  for (auto &phixstarget : cacheslot.challphixstargets) {
+    phixstarget.corrphotoioncoeff = -99.;
 #if (SEPARATE_STIMRECOMB)
-      phixstarget.stimrecombcoeff = -99.;
+    phixstarget.stimrecombcoeff = -99.;
 #endif
-    }
+  }
 
-    for (int ion = 0; ion < nions; ion++) {
-      const int nlevels = get_nlevels(element, ion);
-      auto &chion = cacheslot.chelements[element].chions[ion];
-      for (int level = 0; level < nlevels; level++) {
-        chion.chlevels[level].processrates[MA_ACTION_INTERNALUPHIGHER] = -99.;
-      }
-    }
+  for (int uniquelevelindex = 0; uniquelevelindex < std::ssize(cacheslot.ch_all_levels); uniquelevelindex++) {
+    cacheslot.ch_all_levels[uniquelevelindex].processrates[MA_ACTION_INTERNALUPHIGHER] = -99.;
   }
 
   if (nonemptymgi >= 0) {

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1030,7 +1030,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     printout("timestep %d cell %d is treated in grey approximation (chi_grey %g [cm2/g], tau %g >= %g)\n", nts, mgi,
              grid::get_kappagrey(nonemptymgi), grey_optical_depth, globals::cell_is_optically_thick);
     grid::modelgrid[nonemptymgi].thick = 1;
-  } else if (VPKT_ON && (grey_optical_depth > cell_is_optically_thick_vpkt)) {
+  } else if (VPKT_ON && (grey_optical_depth > vpkt::cell_is_optically_thick_vpkt)) {
     grid::modelgrid[nonemptymgi].thick = 2;
   } else {
     grid::modelgrid[nonemptymgi].thick = 0;

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1196,11 +1196,9 @@ void cellcache_change_cell(const int nonemptymgi) {
     }
   }
 
-  for (auto &phixstarget : cacheslot.challphixstargets) {
-    phixstarget.corrphotoioncoeff = -99.;
-#if (SEPARATE_STIMRECOMB)
-    phixstarget.stimrecombcoeff = -99.;
-#endif
+  std::ranges::fill(cacheslot.allphixstargets_corrphotoioncoeff, -99.);
+  if constexpr (SEPARATE_STIMRECOMB) {
+    std::ranges::fill(cacheslot.allphixstargets_stimrecombcoeff, -99.);
   }
 
   for (int uniquelevelindex = 0; uniquelevelindex < std::ssize(cacheslot.ch_all_levels); uniquelevelindex++) {

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1205,8 +1205,6 @@ void cellcache_change_cell(const int nonemptymgi) {
     cacheslot.ch_all_levels[uniquelevelindex].processrates[MA_ACTION_INTERNALUPHIGHER] = -99.;
   }
 
-  std::ranges::fill(cacheslot.alpha_sp_E_integrals, -99.);
-
   if (nonemptymgi >= 0) {
     std::ranges::fill(cacheslot.ch_allcont_departureratios, -1.);
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1195,21 +1195,18 @@ void cellcache_change_cell(const int nonemptymgi) {
       }
     }
 
+    for (auto phixstarget : cacheslot.challphixstargets) {
+      phixstarget.corrphotoioncoeff = -99.;
+#if (SEPARATE_STIMRECOMB)
+      phixstarget.stimrecombcoeff = -99.;
+#endif
+    }
+
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels = get_nlevels(element, ion);
       auto &chion = cacheslot.chelements[element].chions[ion];
       for (int level = 0; level < nlevels; level++) {
-        const auto nphixstargets = get_nphixstargets(element, ion, level);
-        auto &chlevel = chion.chlevels[level];
-        for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-          chlevel.chphixstargets[phixstargetindex].corrphotoioncoeff = -99.;
-
-#if (SEPARATE_STIMRECOMB)
-          chlevel.chphixstargets[phixstargetindex].stimrecombcoeff = -99.;
-#endif
-        }
-
-        chlevel.processrates[MA_ACTION_INTERNALUPHIGHER] = -99.;
+        chion.chlevels[level].processrates[MA_ACTION_INTERNALUPHIGHER] = -99.;
       }
     }
   }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1205,6 +1205,8 @@ void cellcache_change_cell(const int nonemptymgi) {
     cacheslot.ch_all_levels[uniquelevelindex].processrates[MA_ACTION_INTERNALUPHIGHER] = -99.;
   }
 
+  std::ranges::fill(cacheslot.alpha_sp_E_integrals, -99.);
+
   if (nonemptymgi >= 0) {
     std::ranges::fill(cacheslot.ch_allcont_departureratios, -1.);
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -1180,8 +1180,10 @@ void cellcache_change_cell(const int nonemptymgi) {
       cacheslot
           .cooling_contrib[kpkt::get_coolinglistoffset(element, ion) + kpkt::get_ncoolingterms_ion(element, ion) - 1] =
           COOLING_UNDEFINED;
+    }
 
-      if (nonemptymgi >= 0) {
+    if (nonemptymgi >= 0) {
+      for (int ion = 0; ion < nions; ion++) {
         const int nlevels = get_nlevels(element, ion);
         auto &chion = cacheslot.chelements[element].chions[ion];
 #ifdef _OPENMP
@@ -1220,7 +1222,8 @@ void cellcache_change_cell(const int nonemptymgi) {
       const int element = globals::allcont[i].element;
       const int ion = globals::allcont[i].ion;
       const int level = globals::allcont[i].level;
-      const auto nnlevel = get_levelpop(nonemptymgi, element, ion, level);
+      const auto nnlevel =
+          globals::cellcache[cellcacheslotid].chelements[element].chions[ion].chlevels[level].population;
       cacheslot.ch_allcont_nnlevel[i] = nnlevel;
       cacheslot.ch_keep_this_cont[i] = nnlevel > 0 && keep_this_cont(element, ion, level, nonemptymgi, nnetot);
     }

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -22,6 +22,7 @@
 #include "sn3d.h"
 #include "vectors.h"
 
+namespace vpkt {
 namespace {
 
 struct StokesParams {
@@ -587,7 +588,7 @@ void read_vpkt_grid(const int my_rank, const int nts) {
 
 }  // anonymous namespace
 
-void vpkt_remove_temp_file(const int nts, const int my_rank) {
+void remove_temp_vpkt_file(const int nts, const int my_rank) {
   std::array<char[MAXFILENAMELENGTH], 3> filenames{};
   snprintf(filenames[0], MAXFILENAMELENGTH, "vspecpol_%.4d_ts%d.tmp", my_rank, nts);
   snprintf(filenames[1], MAXFILENAMELENGTH, "vpkt_grid_%.4d_ts%d.tmp", my_rank, nts);
@@ -601,7 +602,7 @@ void vpkt_remove_temp_file(const int nts, const int my_rank) {
   }
 }
 
-void read_parameterfile_vpkt() {
+void read_vpktparameterfile() {
   FILE *input_file = fopen_required("vpkt.txt", "r");
 
   // Nobs
@@ -784,7 +785,7 @@ void read_parameterfile_vpkt() {
   fclose(input_file);
 }
 
-void vpkt_write_timestep(const int nts, const int my_rank, const bool is_final) {
+void write_timestep(const int nts, const int my_rank, const bool is_final) {
   if constexpr (!VPKT_ON) {
     return;
   }
@@ -838,7 +839,7 @@ void vpkt_write_timestep(const int nts, const int my_rank, const bool is_final) 
   }
 }
 
-void vpkt_init(const int nts, const int my_rank, const bool continued_from_saved) {
+void init(const int nts, const int my_rank, const bool continued_from_saved) {
   if constexpr (!VPKT_ON) {
     return;
   }
@@ -889,7 +890,7 @@ void vpkt_init(const int nts, const int my_rank, const bool continued_from_saved
   }
 }
 
-auto vpkt_call_estimators(const Packet &pkt, const enum packet_type type_before_rpkt) -> void {
+auto call_estimators(const Packet &pkt, const enum packet_type type_before_rpkt) -> void {
   if constexpr (!VPKT_ON) {
     return;
   }
@@ -953,3 +954,4 @@ auto vpkt_call_estimators(const Packet &pkt, const enum packet_type type_before_
     vpkt_contrib_file.flush();
   }
 }
+}  // namespace vpkt

--- a/vpkt.h
+++ b/vpkt.h
@@ -4,12 +4,14 @@
 #include "constants.h"
 #include "packet.h"
 
-void read_parameterfile_vpkt();
-void vpkt_init(int nts, int my_rank, bool continued_from_saved);
-void vpkt_call_estimators(const Packet &pkt, enum packet_type type_before_rpkt);
-void vpkt_write_timestep(int nts, int my_rank, bool is_final);
+namespace vpkt {
 
-void vpkt_remove_temp_file(int nts, int my_rank);
+void read_vpktparameterfile();
+void init(int nts, int my_rank, bool continued_from_saved);
+void call_estimators(const Packet &pkt, enum packet_type type_before_rpkt);
+void write_timestep(int nts, int my_rank, bool is_final);
+
+void remove_temp_vpkt_file(int nts, int my_rank);
 
 constexpr int VGRID_NY = 50;
 constexpr int VGRID_NZ = 50;
@@ -33,5 +35,6 @@ inline int nvpkt_esc_from_kpkt{0};  // kpkt deactivation
 inline int nvpkt_esc_from_macroatom{0};  // macroatom deactivation
 
 inline double cell_is_optically_thick_vpkt;
+}  // namespace vpkt
 
 #endif  // VPKT_H


### PR DESCRIPTION
23% faster for 1D SFHo dynamical ejecta on Apple M4 Pro.
24% faster for sim2010 1D 960 core 2e7 packets on Virgo znver4.

compared to March 6 11c4a493 develop branch:
30% faster for 3D SFHo dynamical ejecta 960 core 1e8 packets on Virgo znver4