### PR TITLE
Fix no LTE reset when NLTE_LIMIT_ION_STAGES_AFTER_FAILURE can not find solution

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1241,7 +1241,6 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
           first_ion_used++;  // increment the first ion used to the next ion
         } else {
           printout("  WARNING: can't remove bottom ion stage from NLTE solution, returning matrix solve fail\n");
-          return;
         }
       }
       if (!remove_bottom_ion_from_solution && !remove_top_ion_from_solution) {


### PR DESCRIPTION
There was a bug in the solve_nlte_pops_element function when NLTE_LIMIT_ION_STAGES_AFTER_FAILURE=True that meant when it was not possible to cut either the top or bottom ions the function was returning early before the populations of the element could be set to LTE. Have removed this return statement so the function behaves as intended.  