### PR TITLE
Make linelist a struct of arrays

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -114,14 +114,14 @@ struct Element {
   bool has_nlte_levels{false};
 };
 
-struct TransitionLine {
-  double nu;  // Frequency of the line transition
-  float einstein_A;
-  int elementindex;  // It's a transition of element (not its atomic number,
-                     // but the (x-1)th element included in the simulation.
-  int ionindex;  // The same for the elements ion
-  int upperlevelindex;  // And the participating upper
-  int lowerlevelindex;  // and lower levels
+struct TransitionLines {
+  std::span<const double> nu;  // Frequency of the line transition
+  std::span<const float> einstein_A;
+  std::span<const int> elementindex;  // It's a transition of element (not its atomic number,
+                                      // but the (x-1)th element included in the simulation.
+  std::span<const int> ionindex;  // The same for the elements ion
+  std::span<const int> upperlevelindex;  // And the participating upper
+  std::span<const int> lowerlevelindex;  // and lower levels
 };
 
 struct GSLIntegrationParas {
@@ -289,7 +289,7 @@ inline AllLevels alllevels{};
 inline std::vector<Element> elements;
 
 inline int nlines{-1};
-inline std::span<const TransitionLine> linelist{};
+inline TransitionLines linelist{};
 inline std::vector<BFListEntry> bflist;
 
 inline std::vector<double> bfestim_nu_edge{};

--- a/input.cc
+++ b/input.cc
@@ -1431,14 +1431,13 @@ void read_atomicdata_files() {
   globals::linelist.upperlevelindex = linelist_upperlevelindex;
   globals::linelist.lowerlevelindex = linelist_lowerlevelindex;
 
-  const double linelist_mem_MB =
-      (globals::nlines * sizeof(double)   // nu
-       + globals::nlines * sizeof(float)  // einstein_A
-       + globals::nlines * sizeof(int)    // elementindex
-       + globals::nlines * sizeof(int)    // ionindex
-       + globals::nlines * sizeof(int)    // upperlevelindex
-       + globals::nlines * sizeof(int))   // lowerlevelindex
-      / 1024. / 1024;
+  const double linelist_mem_MB = (globals::nlines * sizeof(double)  // nu
+                                  + globals::nlines * sizeof(float)  // einstein_A
+                                  + globals::nlines * sizeof(int)  // elementindex
+                                  + globals::nlines * sizeof(int)  // ionindex
+                                  + globals::nlines * sizeof(int)  // upperlevelindex
+                                  + globals::nlines * sizeof(int))  // lowerlevelindex
+                                 / 1024. / 1024;
   printout("[info] mem_usage: linelist occupies %.3f MB (node shared memory)\n", linelist_mem_MB);
 
   printout("establishing connection between transitions and sorted linelist...\n");

--- a/input.cc
+++ b/input.cc
@@ -1431,13 +1431,13 @@ void read_atomicdata_files() {
   globals::linelist.upperlevelindex = linelist_upperlevelindex;
   globals::linelist.lowerlevelindex = linelist_lowerlevelindex;
 
-  const double linelist_mem_MB = (globals::nlines * sizeof(double)  // nu
-                                  + globals::nlines * sizeof(float)  // einstein_A
-                                  + globals::nlines * sizeof(int)  // elementindex
-                                  + globals::nlines * sizeof(int)  // ionindex
-                                  + globals::nlines * sizeof(int)  // upperlevelindex
-                                  + globals::nlines * sizeof(int))  // lowerlevelindex
-                                 / 1024. / 1024;
+  const double linelist_mem_MB =
+      (globals::nlines * sizeof(double)  // nu
+       + globals::nlines * sizeof(float)  // einstein_A
+       + globals::nlines * sizeof(int) * 4  // elementindex, ionindex, upperlevelindex, lowerlevelindex
+       ) /
+      1024. / 1024;
+
   printout("[info] mem_usage: linelist occupies %.3f MB (node shared memory)\n", linelist_mem_MB);
 
   printout("establishing connection between transitions and sorted linelist...\n");

--- a/input.cc
+++ b/input.cc
@@ -1431,8 +1431,15 @@ void read_atomicdata_files() {
   globals::linelist.upperlevelindex = linelist_upperlevelindex;
   globals::linelist.lowerlevelindex = linelist_lowerlevelindex;
 
-  printout("[info] mem_usage: linelist occupies %.3f MB (node shared memory)\n",
-           globals::nlines * sizeof(TransitionLine) / 1024. / 1024);
+  const double linelist_mem_MB =
+      (globals::nlines * sizeof(double)   // nu
+       + globals::nlines * sizeof(float)  // einstein_A
+       + globals::nlines * sizeof(int)    // elementindex
+       + globals::nlines * sizeof(int)    // ionindex
+       + globals::nlines * sizeof(int)    // upperlevelindex
+       + globals::nlines * sizeof(int))   // lowerlevelindex
+      / 1024. / 1024;
+  printout("[info] mem_usage: linelist occupies %.3f MB (node shared memory)\n", linelist_mem_MB);
 
   printout("establishing connection between transitions and sorted linelist...\n");
 

--- a/input.cc
+++ b/input.cc
@@ -49,7 +49,7 @@ namespace {
 
 const int groundstate_index_in = 1;  // starting level index in the input files
 
-// only used temporarily during input
+// temporary for input before copy to globals::alltrans structure of arrays
 struct Transition {
   int lower;
   int upper;
@@ -63,6 +63,16 @@ struct Transition {
 struct PhotoionTarget {
   double probability;  // fraction of phixs cross section leading to this final level
   int levelindex;  // index of upper ion level after photoionisation
+};
+
+// temporary for reading before sorting and copy to globals::linelist structure of arrays
+struct TransitionLine {
+  double nu;
+  float einstein_A;
+  int elementindex;
+  int ionindex;
+  int upperlevelindex;
+  int lowerlevelindex;
 };
 
 constexpr std::array<std::string_view, 24> inputlinecomments = {
@@ -1391,17 +1401,36 @@ void read_atomicdata_files() {
   globals::alltrans.forbidden = alltrans_forbidden;
 
   // create a linelist shared on node and then copy data across, freeing the local copy
-  auto linelist = MPI_shared_malloc_span<TransitionLine>(globals::nlines);
+
+  auto linelist_nu = MPI_shared_malloc_span<double>(globals::nlines);
+  auto linelist_einstein_A = MPI_shared_malloc_span<float>(globals::nlines);
+  auto linelist_elementindex = MPI_shared_malloc_span<int>(globals::nlines);
+  auto linelist_ionindex = MPI_shared_malloc_span<int>(globals::nlines);
+  auto linelist_upperlevelindex = MPI_shared_malloc_span<int>(globals::nlines);
+  auto linelist_lowerlevelindex = MPI_shared_malloc_span<int>(globals::nlines);
 
   if (globals::rank_in_node == 0) {
     assert_always(std::ssize(temp_linelist) == globals::nlines);
-    std::ranges::copy(temp_linelist, linelist.begin());
+    for (int t = 0; t < globals::nlines; t++) {
+      linelist_nu[t] = temp_linelist[t].nu;
+      linelist_einstein_A[t] = temp_linelist[t].einstein_A;
+      linelist_elementindex[t] = temp_linelist[t].elementindex;
+      linelist_ionindex[t] = temp_linelist[t].ionindex;
+      linelist_upperlevelindex[t] = temp_linelist[t].upperlevelindex;
+      linelist_lowerlevelindex[t] = temp_linelist[t].lowerlevelindex;
+    }
   }
   temp_linelist.clear();
   temp_linelist.shrink_to_fit();
-
   MPI_Barrier(MPI_COMM_WORLD);
-  globals::linelist = linelist;
+
+  globals::linelist.nu = linelist_nu;
+  globals::linelist.einstein_A = linelist_einstein_A;
+  globals::linelist.elementindex = linelist_elementindex;
+  globals::linelist.ionindex = linelist_ionindex;
+  globals::linelist.upperlevelindex = linelist_upperlevelindex;
+  globals::linelist.lowerlevelindex = linelist_lowerlevelindex;
+
   printout("[info] mem_usage: linelist occupies %.3f MB (node shared memory)\n",
            globals::nlines * sizeof(TransitionLine) / 1024. / 1024);
 
@@ -1416,10 +1445,10 @@ void read_atomicdata_files() {
       continue;
     }
 
-    const int element = globals::linelist[lineindex].elementindex;
-    const int ion = globals::linelist[lineindex].ionindex;
-    const int lowerlevel = globals::linelist[lineindex].lowerlevelindex;
-    const int upperlevel = globals::linelist[lineindex].upperlevelindex;
+    const int element = globals::linelist.elementindex[lineindex];
+    const int ion = globals::linelist.ionindex[lineindex];
+    const int lowerlevel = globals::linelist.lowerlevelindex[lineindex];
+    const int upperlevel = globals::linelist.upperlevelindex[lineindex];
 
     // there is never more than one transition per pair of levels,
     // so find the first up and the first down transition that match: element, ion, lowerlevel, upperlevel

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1730,10 +1730,10 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const bool e
       if (ntexc.frac_deposition > 0.) {
         const auto alltransindex = ntexc.alltransindex;
         const auto lineindex = globals::alltrans.lineindex[alltransindex];
-        const int element = globals::linelist[lineindex].elementindex;
-        const int ion = globals::linelist[lineindex].ionindex;
-        const int lower = globals::linelist[lineindex].lowerlevelindex;
-        const int upper = globals::linelist[lineindex].upperlevelindex;
+        const int element = globals::linelist.elementindex[lineindex];
+        const int ion = globals::linelist.ionindex[lineindex];
+        const int lower = globals::linelist.lowerlevelindex[lineindex];
+        const int upper = globals::linelist.upperlevelindex[lineindex];
         const auto lower_uniquelevelindex = get_uniquelevelindex(element, ion, lower);
         const auto upper_uniquelevelindex = get_uniquelevelindex(element, ion, upper);
         const auto nnlevel_lower = get_levelpop(nonemptymgi, lower_uniquelevelindex);
@@ -2379,9 +2379,9 @@ __host__ __device__ void do_ntlepton_deposit(Packet& pkt) {
         const double frac_deposition_exc = ntexcitation.frac_deposition;
         if (zrand < frac_deposition_exc) {
           const auto lineindex = globals::alltrans.lineindex[ntexcitation.alltransindex];
-          const int element = globals::linelist[lineindex].elementindex;
-          const int ion = globals::linelist[lineindex].ionindex;
-          const int upper = globals::linelist[lineindex].upperlevelindex;
+          const int element = globals::linelist.elementindex[lineindex];
+          const int ion = globals::linelist.ionindex[lineindex];
+          const int upper = globals::linelist.upperlevelindex[lineindex];
 
           stats::increment(stats::COUNTER_MA_STAT_ACTIVATION_NTCOLLEXC);
           stats::increment(stats::COUNTER_INTERACTIONS);

--- a/radfield.cc
+++ b/radfield.cc
@@ -478,7 +478,7 @@ void write_to_file(const int nonemptymgi, const int timestep) {
       {
         const int jblueindex = -2 - binindex;  // -2 is the first detailed line, -3 is the second, etc
         const int lineindex = detailed_lineindicies[jblueindex];
-        const double nu_trans = globals::linelist[lineindex].nu;
+        const double nu_trans = globals::linelist.nu[lineindex];
         nu_lower = nu_trans;
         nu_upper = nu_trans;
         nuJ_out = -1.;
@@ -529,14 +529,14 @@ void init(const int my_rank, const int ndo_nonempty) {
 
   if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
     for (int i = 0; i < globals::nlines; i++) {
-      const int element = globals::linelist[i].elementindex;
+      const int element = globals::linelist.elementindex[i];
       const int Z = get_atomicnumber(element);
       if (Z == 26) {
-        const int lowerlevel = globals::linelist[i].lowerlevelindex;
+        const int lowerlevel = globals::linelist.lowerlevelindex[i];
         // const int upperlevel = linelist[i].upperlevelindex;
         // const int ion = linelist[i].ionindex;
         // const int ionstage = get_ionstage(element, ion);
-        const double A_ul = globals::linelist[i].einstein_A;
+        const double A_ul = globals::linelist.einstein_A[i];
 
         bool addline = false;
         // if (ionstage == 1 && lowerlevel == 6 && upperlevel == 55)

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -81,15 +81,17 @@ constexpr auto get_expopac_bin_nu_lower(const ptrdiff_t binindex) -> double {
   return 1e8 * CLIGHT / lambda_upper;
 }
 
-[[nodiscard]] auto get_tau_sobolev(const int nonemptymgi, const TransitionLine& line, const double t_current)
-    -> double {
-  const auto ionuniquelevelindexstart = globals::elements[line.elementindex].ions[line.ionindex].uniquelevelindexstart;
-  const int uniquelevelindex_lower = ionuniquelevelindexstart + line.lowerlevelindex;
-  const int uniquelevelindex_upper = ionuniquelevelindexstart + line.upperlevelindex;
+[[nodiscard]] auto get_tau_sobolev(const int nonemptymgi, const int lineindex, const double t_current) -> double {
+  const auto ionuniquelevelindexstart = globals::elements[globals::linelist.elementindex[lineindex]]
+                                            .ions[globals::linelist.ionindex[lineindex]]
+                                            .uniquelevelindexstart;
+  const int uniquelevelindex_lower = ionuniquelevelindexstart + globals::linelist.lowerlevelindex[lineindex];
+  const int uniquelevelindex_upper = ionuniquelevelindexstart + globals::linelist.upperlevelindex[lineindex];
 
   const double n_l = get_levelpop(nonemptymgi, uniquelevelindex_lower);
 
-  const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(line.nu, 3) * line.einstein_A;
+  const double B_ul =
+      CLIGHTSQUAREDOVERTWOH / pow(globals::linelist.nu[lineindex], 3) * globals::linelist.einstein_A[lineindex];
   const double B_lu = stat_weight(uniquelevelindex_upper) / stat_weight(uniquelevelindex_lower) * B_ul;
 
   const double n_u = get_levelpop(nonemptymgi, uniquelevelindex_upper);
@@ -102,7 +104,7 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Rpkt_con
                         const double tau_rnd,  // random optical depth until which the packet travels
                         const double abort_dist,  // maximal travel distance before packet leaves cell or time step ends
                         const double nu_cmf_abort, const double d_nu_on_d_l, const double doppler,
-                        const std::span<const TransitionLine> linelist) -> std::tuple<double, int, bool> {
+                        const TransitionLines& linelist) -> std::tuple<double, int, bool> {
   auto pos = pkt.pos;
   auto nu_cmf = pkt.nu_cmf;
   auto e_cmf = pkt.e_cmf;
@@ -119,7 +121,7 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Rpkt_con
     // create therefore new variables in packet, which contain next_lowerlevel, ...
 
     // returns negative value if nu_cmf > nu_trans
-    const int lineindex = closest_transition(nu_cmf, next_trans, linelist);
+    const int lineindex = closest_transition(nu_cmf, next_trans, linelist.nu);
 
     if (lineindex < 0) [[unlikely]] {
       // no line interaction possible - check whether continuum process occurs in cell
@@ -136,9 +138,8 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Rpkt_con
     }
 
     // line interaction is possible (nu_cmf > nu_trans)
-    const auto& line = globals::linelist[lineindex];
 
-    const double nu_trans = line.nu;
+    const double nu_trans = linelist.nu[lineindex];
 
     // helper variable to overcome numerical problems after line scattering
     // further scattering events should be located at lower frequencies to prevent
@@ -158,7 +159,7 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Rpkt_con
         return {std::numeric_limits<double>::max(), next_trans - 1, false};
       }
 
-      const double tau_line = get_tau_sobolev(nonemptymgi, line, prop_time);
+      const double tau_line = get_tau_sobolev(nonemptymgi, lineindex, prop_time);
 
       // printout("[debug] get_event:     tau_line %g\n", tau_line);
       // printout("[debug] get_event:       tau_rnd - tau > tau_cont\n");
@@ -167,9 +168,9 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Rpkt_con
         // bound-bound process occurs
         // printout("[debug] get_event: tau_rnd - tau <= tau_cont + tau_line: bb-process occurs\n");
 
-        mastate = {.element = line.elementindex,
-                   .ion = line.ionindex,
-                   .level = line.upperlevelindex,
+        mastate = {.element = linelist.elementindex[lineindex],
+                   .ion = linelist.ionindex[lineindex],
+                   .level = linelist.upperlevelindex[lineindex],
                    .activatingline = lineindex};
 
         if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
@@ -1049,9 +1050,9 @@ void calculate_expansion_opacities(const int nonemptymgi) {
   const auto t_mid = globals::timesteps[globals::timestep].mid;
 
   // find the first line with nu below the upper limit of the first bin
-  int lineindex = static_cast<int>(std::ranges::lower_bound(globals::linelist, get_expopac_bin_nu_upper(0),
-                                                            std::ranges::greater{}, &TransitionLine::nu) -
-                                   globals::linelist.begin());
+  int lineindex = static_cast<int>(
+      std::ranges::lower_bound(globals::linelist.nu, get_expopac_bin_nu_upper(0), std::ranges::greater{}) -
+      globals::linelist.nu.begin());
 
   double kappa_planck_cumulative = 0.;
 
@@ -1059,9 +1060,9 @@ void calculate_expansion_opacities(const int nonemptymgi) {
     double bin_linesum = 0.;
     const auto nu_lower = get_expopac_bin_nu_lower(binindex);
 
-    while (lineindex < globals::nlines && globals::linelist[lineindex].nu >= nu_lower) {
-      const auto tau_line = static_cast<float>(get_tau_sobolev(nonemptymgi, globals::linelist[lineindex], t_mid));
-      const auto linelambda = 1e8 * CLIGHT / globals::linelist[lineindex].nu;
+    while (lineindex < globals::nlines && globals::linelist.nu[lineindex] >= nu_lower) {
+      const auto tau_line = static_cast<float>(get_tau_sobolev(nonemptymgi, lineindex, t_mid));
+      const auto linelambda = 1e8 * CLIGHT / globals::linelist.nu[lineindex];
       bin_linesum += (linelambda / expopac_deltalambda) * -std::expm1(-tau_line);
       lineindex++;
     }

--- a/rpkt.h
+++ b/rpkt.h
@@ -83,16 +83,16 @@ void MPI_Bcast_binned_opacities(ptrdiff_t nonemptymgi, int root_node_id);
 // find the next transition lineindex redder than nu_cmf
 // for the propagation through non empty cells
 // return -1 if no transition can be reached
-constexpr auto closest_transition(const double nu_cmf, const int next_trans,
-                                  const std::span<const TransitionLine> linelist) -> int {
-  const int nlines = static_cast<int>(linelist.size());
+constexpr auto closest_transition(const double nu_cmf, const int next_trans, const std::span<const double>& linelistnu)
+    -> int {
+  const int nlines = static_cast<int>(linelistnu.size());
   if (next_trans > (nlines - 1)) {
     // packet is tagged as having no more line interactions
     return -1;
   }
   // if nu_cmf is smaller than the lowest frequency in the linelist,
   // no line interaction is possible: return negative value as a flag
-  if (nu_cmf < linelist[nlines - 1].nu) {
+  if (nu_cmf < linelistnu[nlines - 1]) {
     return -1;
   }
 
@@ -101,7 +101,7 @@ constexpr auto closest_transition(const double nu_cmf, const int next_trans,
     // current nu_cmf which might be smaller than globals::linelist[left].nu due to propagation errors
     return next_trans;
   }
-  if (nu_cmf >= linelist[0].nu) {
+  if (nu_cmf >= linelistnu[0]) {
     // if nu_cmf is larger than the highest frequency in the the linelist,
     // interaction with the first line occurs - no search
     return 0;
@@ -112,8 +112,8 @@ constexpr auto closest_transition(const double nu_cmf, const int next_trans,
 
   // will find the highest frequency (lowest index) line with nu_line <= nu_cmf
   // lower_bound matches the first element where the comparison function is false
-  const int matchindex = static_cast<int>(
-      std::ranges::lower_bound(linelist, nu_cmf, std::ranges::greater{}, &TransitionLine::nu) - linelist.begin());
+  const int matchindex =
+      static_cast<int>(std::ranges::lower_bound(linelistnu, nu_cmf, std::ranges::greater{}) - linelistnu.begin());
 
   if (matchindex >= nlines) [[unlikely]] {
     return -1;

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -76,27 +76,27 @@ void initialise_linestat_file() {
   linestat_file = fstream_required("linestat.out", std::ios::out | std::ios::trunc);
 
   for (int i = 0; i < globals::nlines; i++) {
-    linestat_file << CLIGHT / globals::linelist[i].nu << ' ';  // wavelength in cm
+    linestat_file << CLIGHT / globals::linelist.nu[i] << ' ';  // wavelength in cm
   }
   linestat_file << '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
-    linestat_file << get_atomicnumber(globals::linelist[i].elementindex) << ' ';
+    linestat_file << get_atomicnumber(globals::linelist.elementindex[i]) << ' ';
   }
   linestat_file << '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
-    linestat_file << get_ionstage(globals::linelist[i].elementindex, globals::linelist[i].ionindex) << ' ';
+    linestat_file << get_ionstage(globals::linelist.elementindex[i], globals::linelist.ionindex[i]) << ' ';
   }
   linestat_file << '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
-    linestat_file << (globals::linelist[i].upperlevelindex + 1) << ' ';
+    linestat_file << (globals::linelist.upperlevelindex[i] + 1) << ' ';
   }
   linestat_file << '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
-    linestat_file << (globals::linelist[i].lowerlevelindex + 1) << ' ';
+    linestat_file << (globals::linelist.lowerlevelindex[i] + 1) << ' ';
   }
   linestat_file << '\n';
 

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -105,9 +105,9 @@ void printout_tracemission_stats() {
       if (encontrib > 0.)  // lines that emit/absorb some energy
       {
         const int lineindex = traceemissionabsorption[i].lineindex;
-        const int element = globals::linelist[lineindex].elementindex;
-        const int ion = globals::linelist[lineindex].ionindex;
-        const double linelambda = 1e8 * CLIGHT / globals::linelist[lineindex].nu;
+        const int element = globals::linelist.elementindex[lineindex];
+        const int ion = globals::linelist.ionindex[lineindex];
+        const double linelambda = 1e8 * CLIGHT / globals::linelist.nu[lineindex];
         // flux-weighted average radial velocity of emission in km/s
         double v_rad{NAN};
         if (mode == 0) {
@@ -118,14 +118,14 @@ void printout_tracemission_stats() {
                   traceemissionabsorption[i].energyabsorbed / 1e5;
         }
 
-        const int lower = globals::linelist[lineindex].lowerlevelindex;
-        const int upper = globals::linelist[lineindex].upperlevelindex;
+        const int lower = globals::linelist.lowerlevelindex[lineindex];
+        const int upper = globals::linelist.upperlevelindex[lineindex];
 
         const double statweight_target = stat_weight(element, ion, upper);
         const double statweight_lower = stat_weight(element, ion, lower);
 
         const double nu_trans = (epsilon(element, ion, upper) - epsilon(element, ion, lower)) / H;
-        const double A_ul = globals::linelist[lineindex].einstein_A;
+        const double A_ul = globals::linelist.einstein_A[lineindex];
         const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nu_trans, 3) * A_ul;
         const double B_lu = statweight_target / statweight_lower * B_ul;
 
@@ -144,8 +144,8 @@ void printout_tracemission_stats() {
 
         printout("%7.2e (%5.1f%%) %4d %9d %5d %5d %8.1f %8.2e %4d %7.1f %7.1f %7.1e %7.1e\n", encontrib,
                  100 * encontrib / totalenergy, get_atomicnumber(element), get_ionstage(element, ion),
-                 globals::linelist[lineindex].upperlevelindex, globals::linelist[lineindex].lowerlevelindex,
-                 globals::alltrans.coll_str[downtransid], globals::linelist[lineindex].einstein_A,
+                 globals::linelist.upperlevelindex[lineindex], globals::linelist.lowerlevelindex[lineindex],
+                 globals::alltrans.coll_str[downtransid], globals::linelist.einstein_A[lineindex],
                  static_cast<int>(globals::alltrans.forbidden[downtransid]), linelambda, v_rad, B_lu, B_ul);
       } else {
         break;
@@ -163,8 +163,8 @@ auto get_proccount() -> int { return (2 * get_nelements() * get_max_nions()) + 1
 auto columnindex_from_emissiontype(const int et) -> int {
   if (et >= 0) {
     // bb-emission
-    const int element = globals::linelist[et].elementindex;
-    const int ion = globals::linelist[et].ionindex;
+    const int element = globals::linelist.elementindex[et];
+    const int ion = globals::linelist.ionindex[et];
     return (element * get_max_nions()) + ion;
   }
   if (et == EMTYPE_FREEFREE) {
@@ -576,8 +576,8 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra, Spec
         const int at = pkt.absorptiontype;
         if (at >= 0) {
           // bb-emission
-          const int element = globals::linelist[at].elementindex;
-          const int ion = globals::linelist[at].ionindex;
+          const int element = globals::linelist.elementindex[at];
+          const int ion = globals::linelist.ionindex[at];
           const auto absindex = get_absindex(nts, nnu_abs) + (element * get_max_nions()) + ion;
           atomicadd_always(spectra.absorptionalltimesteps[absindex], deltaE_absorption);
 

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -291,14 +291,14 @@ auto rlc_emiss_vpkt(const Packet& pkt, const double t_current, const double t_ar
 
       double ldist = 0;
       while (ldist < sdist) {
-        const int lineindex = closest_transition(vpkt.nu_cmf, vpkt.next_trans, globals::linelist);
+        const int lineindex = closest_transition(vpkt.nu_cmf, vpkt.next_trans, globals::linelist.nu);
 
         if (lineindex < 0) {
           // no more lines below the current frequency
           vpkt.next_trans = globals::nlines + 1;
           break;
         }
-        const double nutrans = globals::linelist[lineindex].nu;
+        const double nutrans = globals::linelist.nu[lineindex];
 
         vpkt.next_trans = lineindex + 1;
 
@@ -314,11 +314,11 @@ auto rlc_emiss_vpkt(const Packet& pkt, const double t_current, const double t_ar
 
         const double t_line = vpkt.prop_time + (ldist / CLIGHT);
 
-        const int element = globals::linelist[lineindex].elementindex;
-        const int ion = globals::linelist[lineindex].ionindex;
-        const int upper = globals::linelist[lineindex].upperlevelindex;
-        const int lower = globals::linelist[lineindex].lowerlevelindex;
-        const auto A_ul = globals::linelist[lineindex].einstein_A;
+        const int element = globals::linelist.elementindex[lineindex];
+        const int ion = globals::linelist.ionindex[lineindex];
+        const int upper = globals::linelist.upperlevelindex[lineindex];
+        const int lower = globals::linelist.lowerlevelindex[lineindex];
+        const auto A_ul = globals::linelist.einstein_A[lineindex];
 
         const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nutrans, 3) * A_ul;
         const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -318,9 +318,8 @@ auto rlc_emiss_vpkt(const Packet& pkt, const double t_current, const double t_ar
         const int ion = globals::linelist.ionindex[lineindex];
         const int upper = globals::linelist.upperlevelindex[lineindex];
         const int lower = globals::linelist.lowerlevelindex[lineindex];
-        const auto A_ul = globals::linelist.einstein_A[lineindex];
 
-        const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nutrans, 3) * A_ul;
+        const double B_ul = CLIGHTSQUAREDOVERTWOH / pow(nutrans, 3) * globals::linelist.einstein_A[lineindex];
         const double B_lu = stat_weight(element, ion, upper) / stat_weight(element, ion, lower) * B_ul;
 
         const auto n_u = calculate_levelpop(nonemptymgi, element, ion, upper);


### PR DESCRIPTION
Same or slightly (<2%) better performance on Virgo. Reduces memory per line from 32 bytes to 28 by avoiding struct padding. Will allow for future optimisation work (storing stat weight ratios or unique level indices).