### PR TITLE
Convert model grid to structure of arrays

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -196,6 +196,7 @@ inline int opacity_case{};  // 0 grey, 1 for Fe-grp dependence.
 inline std::vector<float> ion_alpha_sp;  // alpha_sp for each ion and temperature table value
 
 inline std::span<float> allphixs{};
+
 struct AllTransitions {
   std::span<const int> lineindex;
   std::span<const int> targetlevelindex;
@@ -222,10 +223,11 @@ inline std::span<const double>
     allphixstargets_probability;  // fraction of phixs cross section leading to associated final level
 
 struct AllLevels {
-  // all of these arrays are indexed by uniquelevelindex, which can be derived from the element, ion, level
+  // these arrays are indexed by uniquelevelindex, which can be derived from the element, ion, level
 
   std::span<const double> epsilon;
   std::span<const float> statweight;
+
   // index into globals::alltrans for first down transition from each level
   std::span<const int> alltrans_startdown;
 

--- a/globals.h
+++ b/globals.h
@@ -15,92 +15,6 @@
 
 #include "artisoptions.h"
 
-struct TimeStep {
-  double start{0.};  // time at start of this timestep. [s]
-  double width{0.};  // Width of timestep. [s]
-  double mid{0.};  // Mid time in step - computed logarithmically. [s]
-  double gamma_dep{0.};  // cmf gamma ray energy deposition from packet trajectories [erg]
-  double gamma_dep_discrete{0.};  // cmf gamma ray energy deposition from absorption events [erg]
-  double positron_dep{0.};  // cmf positron energy deposition from packet trajectories [erg]
-  double positron_dep_discrete{0.};  // cmf positron energy deposition from absorption events [erg]
-  double positron_emission{0.};  // cmf positron KE energy generation [erg]
-  double eps_positron_ana_power{0.};  // cmf positron KE energy generation rate analytical [erg/s]
-  double electron_dep{0.};  // cmf electron energy deposition from packet trajectories [erg]
-  double electron_dep_discrete{0.};  // cmf electron energy deposition from absorption events [erg]
-  double electron_emission{0.};  // cmf electron KE energy generation [erg]
-  double eps_electron_ana_power{0.};  // cmf electron KE energy generation rate analytical [erg/s]
-  double alpha_dep{0.};  // cmf alpha energy deposition from packet trajectories [erg]
-  double alpha_dep_discrete{0.};  // cmf alpha energy deposition from absorption events [erg]
-  double alpha_emission{0.};  // cmf alpha KE energy generation [erg]
-  double eps_alpha_ana_power{0.};  // cmf alpha KE energy generation rate analytical [erg/s]
-  double gamma_emission{0.};  // gamma decay energy generation in this timestep [erg]
-  double qdot_betaminus{0.};  // energy generation from beta-minus decays (including neutrinos) [erg/s/g]
-  double qdot_alpha{0.};  // energy generation from alpha decays (including neutrinos) [erg/s/g]
-  double qdot_total{0.};  // energy generation from all decays (including neutrinos) [erg/s/g]
-  double cmf_lum{0.};  // cmf luminosity light curve [erg]
-  int pellet_decays{0};  // Number of pellets that decay in this time step.
-};
-
-struct BFListEntry {
-  int elementindex;
-  int ionindex;
-  int levelindex;
-  int phixstargetindex;
-};
-
-struct FullPhotoionTransition {
-  double nu_edge;
-  int element;
-  int ion;
-  int level;
-  int phixstargetindex;
-  int upperlevel;
-  int uniquelevelindex;
-  double probability;
-  int index_in_groundphixslist;
-  int bfestimindex;
-};
-
-struct GroundPhotoion {
-  double nu_edge;
-  int element;
-  int ion;
-};
-
-struct Ion {
-  int nlevels{0};  // Number of levels for this ionisation stage
-  int nlevels_excited_nlte{0};  // number of nlte levels for this ion
-  int allnltelevelsindexstart{-1};  // index into nlte_pops array for first excited nlte level
-  int nlevels_ionising{0};  // Number of levels which have a bf-continuum
-  int maxrecombininglevel{-1};  // level index of the highest level with a non-zero recombination rate
-  int nlevels_autoion{0};  // Number of levels that can autoionise
-  int nlevels_groundterm{0};
-  int coolingoffset{-1};
-  int ncoolingterms{0};
-  int uniquelevelindexstart{-1};  // index of the first level in the alllevels list
-  int groundcontindex{-1};
-  double ionpot{NAN};  // Ionisation threshold to the next ionstage
-};
-
-struct Element {
-  std::span<Ion> ions;  // subspan of the allions array for this element
-  int anumber{-1};  // Atomic number
-  int lowest_ionstage{-1};  // ionisation stage (charge - 1) of ion 0 for this element
-  int uniqueionindexstart{-1};  /// uniqueionindex index of the lowest ionisation stage of this element
-  float initstablemeannucmass = {0.};  // Atomic mass number in multiple of MH
-  bool has_nlte_levels{false};
-};
-
-struct TransitionLines {
-  std::span<const double> nu;  // Frequency of the line transition
-  std::span<const float> einstein_A;
-  std::span<const int> elementindex;  // It's a transition of element (not its atomic number,
-                                      // but the (x-1)th element included in the simulation.
-  std::span<const int> ionindex;  // The same for the elements ion
-  std::span<const int> upperlevelindex;  // And the participating upper
-  std::span<const int> lowerlevelindex;  // and lower levels
-};
-
 struct GSLIntegrationParas {
   double nu_edge;
   float T;
@@ -129,22 +43,56 @@ enum ma_action {
   MA_ACTION_COUNT = 9,
 };
 
-struct CellCache {
-  int nonemptymgi{-1};  // non-empty model grid index for this cache slot
-  std::vector<double> cooling_contrib;  // Cooling contributions by the different processes.
-  std::vector<double> alllevels_pops;
-  std::vector<std::array<double, MA_ACTION_COUNT>> alllevels_maprocessrates;  // rates for macroatom processes
-  std::vector<double> allmacroatomictransitions;  // cumulative macroatom transition rates for all levels
-  std::vector<double> allcont_departureratios;
-  std::vector<double> allcont_nnlevel;
-  std::vector<bool> allcont_keep;
-  double chi_ff_nnionpart{-1};
-  std::vector<double> allphixstargets_corrphotoioncoeff;
-  std::vector<double> allphixstargets_stimrecombcoeff;
+struct Ion {
+  int nlevels{0};  // Number of levels for this ionisation stage
+  int nlevels_excited_nlte{0};  // number of nlte levels for this ion
+  int allnltelevelsindexstart{-1};  // index into nlte_pops array for first excited nlte level
+  int nlevels_ionising{0};  // Number of levels which have a bf-continuum
+  int maxrecombininglevel{-1};  // level index of the highest level with a non-zero recombination rate
+  int nlevels_autoion{0};  // Number of levels that can autoionise
+  int nlevels_groundterm{0};
+  int coolingoffset{-1};
+  int ncoolingterms{0};
+  int uniquelevelindexstart{-1};  // index of the first level in the alllevels list
+  int groundcontindex{-1};
+  double ionpot{NAN};  // Ionisation threshold to the next ionstage
+};
+struct Element {
+  std::span<Ion> ions;  // subspan of the allions array for this element
+  int anumber{-1};  // Atomic number
+  int lowest_ionstage{-1};  // ionisation stage (charge - 1) of ion 0 for this element
+  int uniqueionindexstart{-1};  /// uniqueionindex index of the lowest ionisation stage of this element
+  float initstablemeannucmass = {0.};  // Atomic mass number in multiple of MH
+  bool has_nlte_levels{false};
 };
 
 namespace globals {
 
+struct TimeStep {
+  double start{0.};  // time at start of this timestep. [s]
+  double width{0.};  // Width of timestep. [s]
+  double mid{0.};  // Mid time in step - computed logarithmically. [s]
+  double gamma_dep{0.};  // cmf gamma ray energy deposition from packet trajectories [erg]
+  double gamma_dep_discrete{0.};  // cmf gamma ray energy deposition from absorption events [erg]
+  double positron_dep{0.};  // cmf positron energy deposition from packet trajectories [erg]
+  double positron_dep_discrete{0.};  // cmf positron energy deposition from absorption events [erg]
+  double positron_emission{0.};  // cmf positron KE energy generation [erg]
+  double eps_positron_ana_power{0.};  // cmf positron KE energy generation rate analytical [erg/s]
+  double electron_dep{0.};  // cmf electron energy deposition from packet trajectories [erg]
+  double electron_dep_discrete{0.};  // cmf electron energy deposition from absorption events [erg]
+  double electron_emission{0.};  // cmf electron KE energy generation [erg]
+  double eps_electron_ana_power{0.};  // cmf electron KE energy generation rate analytical [erg/s]
+  double alpha_dep{0.};  // cmf alpha energy deposition from packet trajectories [erg]
+  double alpha_dep_discrete{0.};  // cmf alpha energy deposition from absorption events [erg]
+  double alpha_emission{0.};  // cmf alpha KE energy generation [erg]
+  double eps_alpha_ana_power{0.};  // cmf alpha KE energy generation rate analytical [erg/s]
+  double gamma_emission{0.};  // gamma decay energy generation in this timestep [erg]
+  double qdot_betaminus{0.};  // energy generation from beta-minus decays (including neutrinos) [erg/s/g]
+  double qdot_alpha{0.};  // energy generation from alpha decays (including neutrinos) [erg/s/g]
+  double qdot_total{0.};  // energy generation from all decays (including neutrinos) [erg/s/g]
+  double cmf_lum{0.};  // cmf luminosity light curve [erg]
+  int pellet_decays{0};  // Number of pellets that decay in this time step.
+};
 inline std::vector<TimeStep> timesteps;
 
 // deposition estimators index by non-empty modelgridindex
@@ -272,23 +220,70 @@ inline AllLevels alllevels{};
 inline std::vector<Element> elements;
 inline std::span<Ion> allions;
 
-inline int nlines{-1};
+struct TransitionLines {
+  std::span<const double> nu;  // Frequency of the line transition
+  std::span<const float> einstein_A;
+  std::span<const int> elementindex;  // It's a transition of element (not its atomic number,
+                                      // but the (x-1)th element included in the simulation.
+  std::span<const int> ionindex;  // The same for the elements ion
+  std::span<const int> upperlevelindex;  // And the participating upper
+  std::span<const int> lowerlevelindex;  // and lower levels
+};
 inline TransitionLines linelist{};
+inline int nlines{-1};
+
+struct BFListEntry {
+  int elementindex;
+  int ionindex;
+  int levelindex;
+  int phixstargetindex;
+};
 inline std::vector<BFListEntry> bflist;
 
 inline std::vector<double> bfestim_nu_edge{};
-inline std::span<const double> allcont_nu_edge{};
+
+struct FullPhotoionTransition {
+  double nu_edge;
+  int element;
+  int ion;
+  int level;
+  int phixstargetindex;
+  int upperlevel;
+  int uniquelevelindex;
+  double probability;
+  int index_in_groundphixslist;
+  int bfestimindex;
+};
 inline std::span<const FullPhotoionTransition> allcont{};
+inline std::span<const double> allcont_nu_edge{};
 
 // for either USE_LUT_PHOTOION = true or !USE_LUT_BFHEATING = false
+struct GroundPhotoion {
+  double nu_edge;
+  int element;
+  int ion;
+};
 inline std::vector<GroundPhotoion> groundcont{};
 
 inline int nbfcontinua{-1};  // number of bf-continua
 inline int nbfcontinua_ground{-1};  // number of bf-continua from ground levels
 
-inline int NPHIXSPOINTS{-1};
-inline double NPHIXSNUINCREMENT{-1};
+inline int NPHIXSPOINTS{-1};  // number of photoionisation cross-section points per level
+inline double NPHIXSNUINCREMENT{-1};  // frequency increment between points as a fraction of nu_edge
 
+struct CellCache {
+  int nonemptymgi{-1};  // non-empty model grid index for this cache slot
+  std::vector<double> cooling_contrib;  // Cooling contributions by the different processes.
+  std::vector<double> alllevels_pops;
+  std::vector<std::array<double, MA_ACTION_COUNT>> alllevels_maprocessrates;  // rates for macroatom processes
+  std::vector<double> allmacroatomictransitions;  // cumulative macroatom transition rates for all levels
+  std::vector<double> allcont_departureratios;
+  std::vector<double> allcont_nnlevel;
+  std::vector<bool> allcont_keep;
+  double chi_ff_nnionpart{-1};
+  std::vector<double> allphixstargets_corrphotoioncoeff;
+  std::vector<double> allphixstargets_stimrecombcoeff;
+};
 inline std::vector<CellCache> cellcache{};
 
 inline MPI_Comm mpi_comm_node{MPI_COMM_NULL};

--- a/grid.cc
+++ b/grid.cc
@@ -370,17 +370,21 @@ void allocate_nonemptymodelcells() {
     }
   }
 
-  assert_always(modelgrid.data() == nullptr);
-  modelgrid = MPI_shared_malloc_span<ModelGridCell>(nonempty_npts_model, ModelGridCell{});
-  modelgrid_rho = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid_Te = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid_TJ = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid_TR = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid_W = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid_nne = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  assert_always(modelgrid.rho.data() == nullptr);
+  modelgrid.rho = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.Te = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.TJ = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.TR = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.W = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.nne = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.nnetot = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid.kappagrey = MPI_shared_malloc_span<float>(nonempty_npts_model, 0.);
+  modelgrid.grey_depth = MPI_shared_malloc_span<float>(nonempty_npts_model, 0.);
+  modelgrid.totalcooling = MPI_shared_malloc_span<double>(nonempty_npts_model, -1.);
+  modelgrid.thick = MPI_shared_malloc_span<int>(nonempty_npts_model, 0);
 
   printlnlog("[info] mem_usage: the modelgrid array occupies {:.3f} MB (node shared memory)",
-             std::ssize(modelgrid) * sizeof(modelgrid[0]) / 1024. / 1024.);
+             modelgrid.get_mem_usage() / 1024. / 1024.);
 
   allocate_nonemptycells_composition_cooling();
 
@@ -864,8 +868,8 @@ void read_grid_restart_data(const int timestep) {
     assert_always(fscanf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", &mgi_in, &T_R, &T_e, &W, &T_J,
                          &thick, &globals::dep_estimator_gamma[nonemptymgi],
                          &globals::dep_estimator_positron[nonemptymgi], &globals::dep_estimator_electron[nonemptymgi],
-                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid_nne[nonemptymgi],
-                         &modelgrid[nonemptymgi].nnetot) == 12);
+                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid.nne[nonemptymgi],
+                         &modelgrid.nnetot[nonemptymgi]) == 12);
 
     if (mgi_in != mgi) {
       printlnlog("[fatal] read_grid_restart_data: cell mismatch in reading input gridsave.dat ... abort");
@@ -886,7 +890,7 @@ void read_grid_restart_data(const int timestep) {
     set_Te(nonemptymgi, T_e);
     set_W(nonemptymgi, W);
     set_TJ(nonemptymgi, T_J);
-    modelgrid[nonemptymgi].thick = thick;
+    modelgrid.thick[nonemptymgi] = thick;
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {
@@ -953,7 +957,7 @@ void assign_initial_temperatures() {
       set_TJ(nonemptymgi, T_initial);
       set_TR(nonemptymgi, T_initial);
       set_W(nonemptymgi, 1.);
-      modelgrid[nonemptymgi].thick = 0;
+      modelgrid.thick[nonemptymgi] = 0;
     }
   }
   printlnlog("  cells below MINTEMP {:g}: {}", MINTEMP, cells_below_mintemp);
@@ -1450,19 +1454,19 @@ auto get_rho_tmin(const int modelgridindex) -> float { return modelgrid_input[mo
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_rho(const std::ptrdiff_t nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid_rho[nonemptymgi];
+  return modelgrid.rho[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nne(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid_nne[nonemptymgi];
+  return modelgrid.nne[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nnetot(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].nnetot;
+  return modelgrid.nnetot[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_ffegrp(const int modelgridindex) -> float {
@@ -1494,42 +1498,42 @@ void set_elem_abundance(const ptrdiff_t nonemptymgi, const int element, const fl
          static_cast<double>(grid::get_element_meanweight(nonemptymgi, element)) * grid::get_rho(nonemptymgi);
 }
 
-__host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return modelgrid[nonemptymgi].kappagrey; }
+__host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return modelgrid.kappagrey[nonemptymgi]; }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_Te(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid_Te[nonemptymgi];
+  return modelgrid.Te[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TR(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid_TR[nonemptymgi];
+  return modelgrid.TR[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TJ(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid_TJ[nonemptymgi];
+  return modelgrid.TJ[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_W(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid_W[nonemptymgi];
+  return modelgrid.W[nonemptymgi];
 }
 
 void set_rho(const int nonemptymgi, const float rho) {
   assert_always(rho >= 0.);
   assert_always(std::isfinite(rho));
-  modelgrid_rho[nonemptymgi] = rho;
+  modelgrid.rho[nonemptymgi] = rho;
 }
 
 void set_nne(const int nonemptymgi, const float nne) {
   assert_always(nne >= 0.);
   assert_always(std::isfinite(nne));
-  modelgrid_nne[nonemptymgi] = nne;
+  modelgrid.nne[nonemptymgi] = nne;
 }
 
 // Calculate and set the total density of electrons (free and bound) in grid cell. These are targets for Compton
@@ -1543,10 +1547,10 @@ void set_nnetot(const int nonemptymgi) {
 
   const auto f_nnetot = static_cast<float>(nnetot);
   assert_always(f_nnetot >= 0.);
-  modelgrid[nonemptymgi].nnetot = f_nnetot;
+  modelgrid.nnetot[nonemptymgi] = f_nnetot;
 }
 
-void set_kappagrey(const int nonemptymgi, const float kappagrey) { modelgrid[nonemptymgi].kappagrey = kappagrey; }
+void set_kappagrey(const int nonemptymgi, const float kappagrey) { modelgrid.kappagrey[nonemptymgi] = kappagrey; }
 
 void set_Te(const int nonemptymgi, const float Te) {
   if (Te > 0.) {
@@ -1561,14 +1565,14 @@ void set_Te(const int nonemptymgi, const float Te) {
     }
   }
 
-  modelgrid_Te[nonemptymgi] = Te;
+  modelgrid.Te[nonemptymgi] = Te;
 }
 
-void set_TR(const int nonemptymgi, const float TR) { modelgrid_TR[nonemptymgi] = TR; }
+void set_TR(const int nonemptymgi, const float TR) { modelgrid.TR[nonemptymgi] = TR; }
 
-void set_TJ(const int nonemptymgi, const float TJ) { modelgrid_TJ[nonemptymgi] = TJ; }
+void set_TJ(const int nonemptymgi, const float TJ) { modelgrid.TJ[nonemptymgi] = TJ; }
 
-void set_W(const int nonemptymgi, const float W) { modelgrid_W[nonemptymgi] = W; }
+void set_W(const int nonemptymgi, const float W) { modelgrid.W[nonemptymgi] = W; }
 
 auto get_model_type() -> GridType { return model_type; }
 
@@ -2146,10 +2150,10 @@ void write_grid_restart_data(const int timestep) {
 
     assert_always(globals::dep_estimator_gamma[nonemptymgi] >= 0.);
     fprintf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", mgi, get_TR(nonemptymgi), get_Te(nonemptymgi),
-            get_W(nonemptymgi), get_TJ(nonemptymgi), modelgrid[nonemptymgi].thick,
+            get_W(nonemptymgi), get_TJ(nonemptymgi), modelgrid.thick[nonemptymgi],
             globals::dep_estimator_gamma[nonemptymgi], globals::dep_estimator_positron[nonemptymgi],
             globals::dep_estimator_electron[nonemptymgi], globals::dep_estimator_alpha[nonemptymgi],
-            modelgrid_nne[nonemptymgi], modelgrid[nonemptymgi].nnetot);
+            modelgrid.nne[nonemptymgi], modelgrid.nnetot[nonemptymgi]);
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {

--- a/grid.cc
+++ b/grid.cc
@@ -370,21 +370,23 @@ void allocate_nonemptymodelcells() {
     }
   }
 
-  assert_always(modelgrid.rho.data() == nullptr);
-  modelgrid.rho = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.Te = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.TJ = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.TR = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.W = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.nne = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.nnetot = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
-  modelgrid.kappagrey = MPI_shared_malloc_span<float>(nonempty_npts_model, 0.);
-  modelgrid.grey_depth = MPI_shared_malloc_span<float>(nonempty_npts_model, 0.);
-  modelgrid.totalcooling = MPI_shared_malloc_span<double>(nonempty_npts_model, -1.);
-  modelgrid.thick = MPI_shared_malloc_span<int>(nonempty_npts_model, 0);
-
-  printlnlog("[info] mem_usage: the modelgrid array occupies {:.3f} MB (node shared memory)",
-             modelgrid.get_mem_usage() / 1024. / 1024.);
+  assert_always(rho_allcells.data() == nullptr);
+  rho_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  Te_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  TJ_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  TR_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  W_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  nne_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  nnetot_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  kappagrey_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, 0.);
+  grey_depth_allcells = MPI_shared_malloc_span<float>(nonempty_npts_model, 0.);
+  totalcooling_allcells = MPI_shared_malloc_span<double>(nonempty_npts_model, -1.);
+  thick_allcells = MPI_shared_malloc_span<int>(nonempty_npts_model, 0);
+  const auto modelgrid_mem_usage = nonempty_npts_model * (sizeof(float) * 9 + sizeof(double) + sizeof(int));
+  printlnlog(
+      "[info] mem_usage: the modelgrid properties (temperatures and electron densities) occupies {:.3f} MB (node "
+      "shared memory)",
+      modelgrid_mem_usage / 1024. / 1024.);
 
   allocate_nonemptycells_composition_cooling();
 
@@ -865,8 +867,8 @@ void read_grid_restart_data(const int timestep) {
     assert_always(fscanf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", &mgi_in, &T_R, &T_e, &W, &T_J,
                          &thick, &globals::dep_estimator_gamma[nonemptymgi],
                          &globals::dep_estimator_positron[nonemptymgi], &globals::dep_estimator_electron[nonemptymgi],
-                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid.nne[nonemptymgi],
-                         &modelgrid.nnetot[nonemptymgi]) == 12);
+                         &globals::dep_estimator_alpha[nonemptymgi], &nne_allcells[nonemptymgi],
+                         &nnetot_allcells[nonemptymgi]) == 12);
 
     if (mgi_in != mgi) {
       printlnlog("[fatal] read_grid_restart_data: cell mismatch in reading input gridsave.dat ... abort");
@@ -887,7 +889,7 @@ void read_grid_restart_data(const int timestep) {
     set_Te(nonemptymgi, T_e);
     set_W(nonemptymgi, W);
     set_TJ(nonemptymgi, T_J);
-    modelgrid.thick[nonemptymgi] = thick;
+    thick_allcells[nonemptymgi] = thick;
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {
@@ -954,7 +956,7 @@ void assign_initial_temperatures() {
       set_TJ(nonemptymgi, T_initial);
       set_TR(nonemptymgi, T_initial);
       set_W(nonemptymgi, 1.);
-      modelgrid.thick[nonemptymgi] = 0;
+      thick_allcells[nonemptymgi] = 0;
     }
   }
   printlnlog("  cells below MINTEMP {:g}: {}", MINTEMP, cells_below_mintemp);
@@ -1451,19 +1453,19 @@ auto get_rho_tmin(const int modelgridindex) -> float { return modelgrid_input[mo
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_rho(const std::ptrdiff_t nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.rho[nonemptymgi];
+  return rho_allcells[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nne(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.nne[nonemptymgi];
+  return nne_allcells[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nnetot(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.nnetot[nonemptymgi];
+  return nnetot_allcells[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_ffegrp(const int modelgridindex) -> float {
@@ -1495,42 +1497,42 @@ void set_elem_abundance(const ptrdiff_t nonemptymgi, const int element, const fl
          static_cast<double>(grid::get_element_meanweight(nonemptymgi, element)) * grid::get_rho(nonemptymgi);
 }
 
-__host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return modelgrid.kappagrey[nonemptymgi]; }
+__host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return kappagrey_allcells[nonemptymgi]; }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_Te(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.Te[nonemptymgi];
+  return Te_allcells[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TR(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.TR[nonemptymgi];
+  return TR_allcells[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TJ(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.TJ[nonemptymgi];
+  return TJ_allcells[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_W(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid.W[nonemptymgi];
+  return W_allcells[nonemptymgi];
 }
 
 void set_rho(const int nonemptymgi, const float rho) {
   assert_always(rho >= 0.);
   assert_always(std::isfinite(rho));
-  modelgrid.rho[nonemptymgi] = rho;
+  rho_allcells[nonemptymgi] = rho;
 }
 
 void set_nne(const int nonemptymgi, const float nne) {
   assert_always(nne >= 0.);
   assert_always(std::isfinite(nne));
-  modelgrid.nne[nonemptymgi] = nne;
+  nne_allcells[nonemptymgi] = nne;
 }
 
 // Calculate and set the total density of electrons (free and bound) in grid cell. These are targets for Compton
@@ -1544,10 +1546,10 @@ void set_nnetot(const int nonemptymgi) {
 
   const auto f_nnetot = static_cast<float>(nnetot);
   assert_always(f_nnetot >= 0.);
-  modelgrid.nnetot[nonemptymgi] = f_nnetot;
+  nnetot_allcells[nonemptymgi] = f_nnetot;
 }
 
-void set_kappagrey(const int nonemptymgi, const float kappagrey) { modelgrid.kappagrey[nonemptymgi] = kappagrey; }
+void set_kappagrey(const int nonemptymgi, const float kappagrey) { kappagrey_allcells[nonemptymgi] = kappagrey; }
 
 void set_Te(const int nonemptymgi, const float Te) {
   if (Te > 0.) {
@@ -1562,14 +1564,14 @@ void set_Te(const int nonemptymgi, const float Te) {
     }
   }
 
-  modelgrid.Te[nonemptymgi] = Te;
+  Te_allcells[nonemptymgi] = Te;
 }
 
-void set_TR(const int nonemptymgi, const float TR) { modelgrid.TR[nonemptymgi] = TR; }
+void set_TR(const int nonemptymgi, const float TR) { TR_allcells[nonemptymgi] = TR; }
 
-void set_TJ(const int nonemptymgi, const float TJ) { modelgrid.TJ[nonemptymgi] = TJ; }
+void set_TJ(const int nonemptymgi, const float TJ) { TJ_allcells[nonemptymgi] = TJ; }
 
-void set_W(const int nonemptymgi, const float W) { modelgrid.W[nonemptymgi] = W; }
+void set_W(const int nonemptymgi, const float W) { W_allcells[nonemptymgi] = W; }
 
 auto get_model_type() -> GridType { return model_type; }
 
@@ -2147,10 +2149,10 @@ void write_grid_restart_data(const int timestep) {
 
     assert_always(globals::dep_estimator_gamma[nonemptymgi] >= 0.);
     fprintf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", mgi, get_TR(nonemptymgi), get_Te(nonemptymgi),
-            get_W(nonemptymgi), get_TJ(nonemptymgi), modelgrid.thick[nonemptymgi],
+            get_W(nonemptymgi), get_TJ(nonemptymgi), thick_allcells[nonemptymgi],
             globals::dep_estimator_gamma[nonemptymgi], globals::dep_estimator_positron[nonemptymgi],
             globals::dep_estimator_electron[nonemptymgi], globals::dep_estimator_alpha[nonemptymgi],
-            modelgrid.nne[nonemptymgi], modelgrid.nnetot[nonemptymgi]);
+            nne_allcells[nonemptymgi], nnetot_allcells[nonemptymgi]);
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {

--- a/grid.cc
+++ b/grid.cc
@@ -372,6 +372,8 @@ void allocate_nonemptymodelcells() {
 
   assert_always(modelgrid.data() == nullptr);
   modelgrid = MPI_shared_malloc_span<ModelGridCell>(nonempty_npts_model, ModelGridCell{});
+  modelgrid_rho = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid_Te = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
   modelgrid_TJ = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
   modelgrid_TR = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
   modelgrid_W = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
@@ -1448,7 +1450,7 @@ auto get_rho_tmin(const int modelgridindex) -> float { return modelgrid_input[mo
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_rho(const std::ptrdiff_t nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].rho;
+  return modelgrid_rho[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nne(const int nonemptymgi) -> float {
@@ -1497,7 +1499,7 @@ __host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_Te(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].Te;
+  return modelgrid_Te[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TR(const int nonemptymgi) -> float {
@@ -1521,7 +1523,7 @@ __host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return 
 void set_rho(const int nonemptymgi, const float rho) {
   assert_always(rho >= 0.);
   assert_always(std::isfinite(rho));
-  modelgrid[nonemptymgi].rho = rho;
+  modelgrid_rho[nonemptymgi] = rho;
 }
 
 void set_nne(const int nonemptymgi, const float nne) {
@@ -1559,7 +1561,7 @@ void set_Te(const int nonemptymgi, const float Te) {
     }
   }
 
-  modelgrid[nonemptymgi].Te = Te;
+  modelgrid_Te[nonemptymgi] = Te;
 }
 
 void set_TR(const int nonemptymgi, const float TR) { modelgrid_TR[nonemptymgi] = TR; }

--- a/grid.cc
+++ b/grid.cc
@@ -769,12 +769,11 @@ auto read_model_columns(std::istream& fmodel) -> std::tuple<std::vector<std::str
 
   const ptrdiff_t num_nuclides = decay::get_num_nuclides();
 
-  const auto totalradioabundcount = (npts_model + 1) * num_nuclides;
   std::tie(initnucmassfrac_allcells, win_initnucmassfrac_allcells) =
-      MPI_shared_malloc_span_keepwin<float>(totalradioabundcount, 0.);
+      MPI_shared_malloc_span_keepwin<float>((npts_model + 1) * num_nuclides, 0.);
   printlnlog(
-      "[info] mem_usage: radioabundance data for {} nuclides for {} cells occupies {:.3f} MB (node shared memory)",
-      num_nuclides, npts_model, static_cast<double>(totalradioabundcount * sizeof(float)) / 1024. / 1024.);
+      "[info] mem_usage: input abundance data for {} nuclides for {} cells occupies {:.3f} MB (node shared memory)",
+      num_nuclides, npts_model, (initnucmassfrac_allcells.size() * sizeof(float)) / 1024. / 1024.);
 
   return {colnames, nucindexlist, one_line_per_cell};
 }
@@ -782,15 +781,14 @@ auto read_model_columns(std::istream& fmodel) -> std::tuple<std::vector<std::str
 auto get_inputcellvolume(const int mgi) -> double {
   if (get_model_type() == GridType::SPHERICAL1D) {
     const double v_inner = (mgi == 0) ? 0. : vout_model[mgi - 1];
-    // mass_in_shell = rho_model[mgi] * (pow(vout_model[mgi], 3) - pow(v_inner, 3)) * 4 * PI * pow(t_model, 3) / 3.;
     return (pow(vout_model[mgi], 3) - pow(v_inner, 3)) * 4 * PI * pow(globals::tmin, 3) / 3.;
   }
   if (get_model_type() == GridType::CYLINDRICAL2D) {
     const int n_r = mgi % ncoord_model[0];
-    const double dcoord_rcyl = globals::vmax * t_model / ncoord_model[0];  // dr 2D for input model
-    const double dcoord_z = 2. * globals::vmax * t_model / ncoord_model[1];  // dz 2D for input model
-    return pow(globals::tmin / t_model, 3) * dcoord_z * PI *
-           (pow((n_r + 1) * dcoord_rcyl, 2.) - pow(n_r * dcoord_rcyl, 2.));
+    const double delta_rcyl = globals::vmax * t_model / ncoord_model[0];
+    const double delta_z = 2. * globals::vmax * t_model / ncoord_model[1];
+    return pow(globals::tmin / t_model, 3) * delta_z * PI *
+           (pow((n_r + 1) * delta_rcyl, 2.) - pow(n_r * delta_rcyl, 2.));
   }
   if (get_model_type() == GridType::CARTESIAN3D) {
     // Assumes cells are cubes here - all same volume.

--- a/grid.cc
+++ b/grid.cc
@@ -372,6 +372,10 @@ void allocate_nonemptymodelcells() {
 
   assert_always(modelgrid.data() == nullptr);
   modelgrid = MPI_shared_malloc_span<ModelGridCell>(nonempty_npts_model, ModelGridCell{});
+  modelgrid_TJ = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid_TR = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid_W = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
+  modelgrid_nne = MPI_shared_malloc_span<float>(nonempty_npts_model, -1.);
 
   printlnlog("[info] mem_usage: the modelgrid array occupies {:.3f} MB (node shared memory)",
              std::ssize(modelgrid) * sizeof(modelgrid[0]) / 1024. / 1024.);
@@ -858,7 +862,7 @@ void read_grid_restart_data(const int timestep) {
     assert_always(fscanf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", &mgi_in, &T_R, &T_e, &W, &T_J,
                          &thick, &globals::dep_estimator_gamma[nonemptymgi],
                          &globals::dep_estimator_positron[nonemptymgi], &globals::dep_estimator_electron[nonemptymgi],
-                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid[nonemptymgi].nne,
+                         &globals::dep_estimator_alpha[nonemptymgi], &modelgrid_nne[nonemptymgi],
                          &modelgrid[nonemptymgi].nnetot) == 12);
 
     if (mgi_in != mgi) {
@@ -1450,7 +1454,7 @@ auto get_rho_tmin(const int modelgridindex) -> float { return modelgrid_input[mo
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nne(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].nne;
+  return modelgrid_nne[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_nnetot(const int nonemptymgi) -> float {
@@ -1499,19 +1503,19 @@ __host__ __device__ auto get_kappagrey(const int nonemptymgi) -> float { return 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TR(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].TR;
+  return modelgrid_TR[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_TJ(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].TJ;
+  return modelgrid_TJ[nonemptymgi];
 }
 
 [[gnu::pure]] [[nodiscard]] __host__ __device__ auto get_W(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);
   assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return modelgrid[nonemptymgi].W;
+  return modelgrid_W[nonemptymgi];
 }
 
 void set_rho(const int nonemptymgi, const float rho) {
@@ -1523,7 +1527,7 @@ void set_rho(const int nonemptymgi, const float rho) {
 void set_nne(const int nonemptymgi, const float nne) {
   assert_always(nne >= 0.);
   assert_always(std::isfinite(nne));
-  modelgrid[nonemptymgi].nne = nne;
+  modelgrid_nne[nonemptymgi] = nne;
 }
 
 // Calculate and set the total density of electrons (free and bound) in grid cell. These are targets for Compton
@@ -1558,11 +1562,11 @@ void set_Te(const int nonemptymgi, const float Te) {
   modelgrid[nonemptymgi].Te = Te;
 }
 
-void set_TR(const int nonemptymgi, const float TR) { modelgrid[nonemptymgi].TR = TR; }
+void set_TR(const int nonemptymgi, const float TR) { modelgrid_TR[nonemptymgi] = TR; }
 
-void set_TJ(const int nonemptymgi, const float TJ) { modelgrid[nonemptymgi].TJ = TJ; }
+void set_TJ(const int nonemptymgi, const float TJ) { modelgrid_TJ[nonemptymgi] = TJ; }
 
-void set_W(const int nonemptymgi, const float W) { modelgrid[nonemptymgi].W = W; }
+void set_W(const int nonemptymgi, const float W) { modelgrid_W[nonemptymgi] = W; }
 
 auto get_model_type() -> GridType { return model_type; }
 
@@ -2143,7 +2147,7 @@ void write_grid_restart_data(const int timestep) {
             get_W(nonemptymgi), get_TJ(nonemptymgi), modelgrid[nonemptymgi].thick,
             globals::dep_estimator_gamma[nonemptymgi], globals::dep_estimator_positron[nonemptymgi],
             globals::dep_estimator_electron[nonemptymgi], globals::dep_estimator_alpha[nonemptymgi],
-            modelgrid[nonemptymgi].nne, modelgrid[nonemptymgi].nnetot);
+            modelgrid_nne[nonemptymgi], modelgrid[nonemptymgi].nnetot);
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {

--- a/grid.cc
+++ b/grid.cc
@@ -787,12 +787,11 @@ auto get_inputcellvolume(const int mgi) -> double {
     const int n_r = mgi % ncoord_model[0];
     const double delta_rcyl = globals::vmax * t_model / ncoord_model[0];
     const double delta_z = 2. * globals::vmax * t_model / ncoord_model[1];
-    return pow(globals::tmin / t_model, 3) * delta_z * PI *
-           (pow((n_r + 1) * delta_rcyl, 2.) - pow(n_r * delta_rcyl, 2.));
+    return pow(globals::tmin / t_model, 3) * delta_z * PI * (pow((n_r + 1) * delta_rcyl, 2) - pow(n_r * delta_rcyl, 2));
   }
   if (get_model_type() == GridType::CARTESIAN3D) {
     // Assumes cells are cubes here - all same volume.
-    return pow((2 * globals::vmax * globals::tmin), 3.) / (ncoordgrid[0] * ncoordgrid[1] * ncoordgrid[2]);
+    return pow((2 * globals::vmax * globals::tmin), 3) / (ncoordgrid[0] * ncoordgrid[1] * ncoordgrid[2]);
   }
   assert_always(false);
   return NAN;

--- a/grid.h
+++ b/grid.h
@@ -17,10 +17,6 @@ namespace grid {
 
 struct ModelGridCell {
   float Te = -1.;
-  float TR = -1.;
-  float TJ = -1.;
-  float W = -1.;
-  float nne = -1.;
   float rho = -1.;
   // modelgrid nn_tot
   float nnetot = -1.;  // total electron density (free + bound).
@@ -33,13 +29,17 @@ struct ModelGridCell {
 };
 
 inline std::span<ModelGridCell> modelgrid{};
+inline std::span<float> modelgrid_TJ{};
+inline std::span<float> modelgrid_TR{};
+inline std::span<float> modelgrid_W{};
+inline std::span<float> modelgrid_nne{};
 
 inline ptrdiff_t ngrid{0};
 
 inline double mtot_input{0.};
 
 inline std::span<float> elem_meanweight_allcells{};
-inline std::span<float> elem_massfracs_allcells;  // mass fractions of elements in each cell for the current timestep
+inline std::span<float> elem_massfracs_allcells{};  // mass fractions of elements in each cell for the current timestep
 
 inline std::span<double> nltepops_allcells{};
 inline std::span<float> ion_groundlevelpops_allcells{};

--- a/grid.h
+++ b/grid.h
@@ -15,7 +15,7 @@
 
 namespace grid {
 
-struct ModelGridCell {
+struct ModelGridCells {
   std::span<float> rho;
   std::span<float> Te;
   std::span<float> TJ;
@@ -33,7 +33,7 @@ struct ModelGridCell {
   }
 };
 
-inline ModelGridCell modelgrid;
+inline ModelGridCells modelgrid;
 
 inline ptrdiff_t ngrid{0};
 

--- a/grid.h
+++ b/grid.h
@@ -15,25 +15,19 @@
 
 namespace grid {
 
-struct ModelGridCells {
-  std::span<float> rho;
-  std::span<float> Te;
-  std::span<float> TJ;
-  std::span<float> TR;
-  std::span<float> W;
-  std::span<float> nne;
-  std::span<float> nnetot;  // total electron density (free + bound).
-  std::span<float> kappagrey;
-  std::span<float> grey_depth;  // Grey optical depth to surface of the modelgridcell
-  std::span<double> totalcooling;
-  std::span<int> thick;
-
-  [[nodiscard]] auto get_mem_usage() const -> std::size_t {
-    return (rho.size() * sizeof(float) * 9) + (totalcooling.size() * sizeof(double)) + (thick.size() * sizeof(int));
-  }
-};
-
-inline ModelGridCells modelgrid;
+// these arrays are indexed by nonemptymgi
+inline std::span<float> rho_allcells;
+inline std::span<float> Te_allcells;
+inline std::span<float> TJ_allcells;
+inline std::span<float> TR_allcells;
+inline std::span<float> W_allcells;
+inline std::span<float> nne_allcells;
+inline std::span<float> nnetot_allcells;  // total electron density (free + bound).
+inline std::span<float> kappagrey_allcells;
+inline std::span<float> grey_depth_allcells;  // Grey optical depth to surface of the modelgridcell
+inline std::span<double> totalcooling_allcells;
+inline std::span<int>
+    thick_allcells;  // whether the cell is optically thick (1) or not (0), or (2) thick for vpkts only
 
 inline ptrdiff_t ngrid{0};
 

--- a/grid.h
+++ b/grid.h
@@ -16,9 +16,6 @@
 namespace grid {
 
 struct ModelGridCell {
-  float Te = -1.;
-  float rho = -1.;
-  // modelgrid nn_tot
   float nnetot = -1.;  // total electron density (free + bound).
   float kappagrey = 0.;
   float grey_depth = 0.;  // Grey optical depth to surface of the modelgridcell
@@ -29,6 +26,8 @@ struct ModelGridCell {
 };
 
 inline std::span<ModelGridCell> modelgrid{};
+inline std::span<float> modelgrid_rho{};
+inline std::span<float> modelgrid_Te{};
 inline std::span<float> modelgrid_TJ{};
 inline std::span<float> modelgrid_TR{};
 inline std::span<float> modelgrid_W{};

--- a/grid.h
+++ b/grid.h
@@ -16,22 +16,24 @@
 namespace grid {
 
 struct ModelGridCell {
-  float nnetot = -1.;  // total electron density (free + bound).
-  float kappagrey = 0.;
-  float grey_depth = 0.;  // Grey optical depth to surface of the modelgridcell
-                          // This is only stored to print it outside the OpenMP loop in update_grid to the
-                          // estimatorsfile so there is no need to communicate it via MPI so far!
-  double totalcooling = -1;
-  int thick = 0;
+  std::span<float> rho;
+  std::span<float> Te;
+  std::span<float> TJ;
+  std::span<float> TR;
+  std::span<float> W;
+  std::span<float> nne;
+  std::span<float> nnetot;  // total electron density (free + bound).
+  std::span<float> kappagrey;
+  std::span<float> grey_depth;  // Grey optical depth to surface of the modelgridcell
+  std::span<double> totalcooling;
+  std::span<int> thick;
+
+  [[nodiscard]] auto get_mem_usage() const -> std::size_t {
+    return (rho.size() * sizeof(float) * 9) + (totalcooling.size() * sizeof(double)) + (thick.size() * sizeof(int));
+  }
 };
 
-inline std::span<ModelGridCell> modelgrid{};
-inline std::span<float> modelgrid_rho{};
-inline std::span<float> modelgrid_Te{};
-inline std::span<float> modelgrid_TJ{};
-inline std::span<float> modelgrid_TR{};
-inline std::span<float> modelgrid_W{};
-inline std::span<float> modelgrid_nne{};
+inline ModelGridCell modelgrid;
 
 inline ptrdiff_t ngrid{0};
 

--- a/input.cc
+++ b/input.cc
@@ -762,11 +762,11 @@ void setup_phixs_list() {
     }
   }
   assert_always(nextgroundcontindex == globals::nbfcontinua_ground);
-  std::ranges::SORT_OR_STABLE_SORT(globals::groundcont, std::ranges::less{}, &GroundPhotoion::nu_edge);
+  std::ranges::SORT_OR_STABLE_SORT(globals::groundcont, std::ranges::less{}, &globals::GroundPhotoion::nu_edge);
 
-  auto allcont = MPI_shared_malloc_span<FullPhotoionTransition>(globals::nbfcontinua);
+  auto allcont = MPI_shared_malloc_span<globals::FullPhotoionTransition>(globals::nbfcontinua);
   printlnlog("[info] mem_usage: photoionisation list occupies {:.3f} MB",
-             globals::nbfcontinua * (sizeof(FullPhotoionTransition)) / 1024. / 1024.);
+             globals::nbfcontinua * (sizeof(globals::FullPhotoionTransition)) / 1024. / 1024.);
   int allcontindex = 0;
   for (int element = 0; element < get_nelements(); element++) {
     const int nions = get_nions(element);
@@ -826,7 +826,7 @@ void setup_phixs_list() {
     // indices above were temporary only. continuum index should be to the sorted list
     MPI_Barrier(globals::mpi_comm_node);
     if (globals::rank_in_node == 0) {
-      std::ranges::SORT_OR_STABLE_SORT(allcont, std::ranges::less{}, &FullPhotoionTransition::nu_edge);
+      std::ranges::SORT_OR_STABLE_SORT(allcont, std::ranges::less{}, &globals::FullPhotoionTransition::nu_edge);
     }
     MPI_Barrier(globals::mpi_comm_node);
 
@@ -1515,7 +1515,7 @@ void setup_cellcache() {
 
   for (int cellcachenum = 0; cellcachenum < num_cellcache_slots; cellcachenum++) {
     auto mem_usage_cellcache = 0zU;
-    mem_usage_cellcache += sizeof(CellCache);
+    mem_usage_cellcache += sizeof(globals::CellCache);
 
     printlnlog("[info] input: initializing cellcache for thread {} ...", cellcachenum);
 

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -282,7 +282,7 @@ void calculate_cooling_rates(const int nonemptymgi, HeatingCoolingRates* heating
       (static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()), get_includedions());
   const double C_total = std::accumulate(cellioncontribs.begin(), cellioncontribs.end(), 0.0);
 
-  grid::modelgrid.totalcooling[nonemptymgi] = C_total;
+  grid::totalcooling_allcells[nonemptymgi] = C_total;
 
   // only used in the T_e solver and write_to_estimators file
   if (heatingcoolingrates != nullptr) {
@@ -381,7 +381,7 @@ void setup_coolinglist() {
 __host__ __device__ void do_kpkt_blackbody(Packet& pkt) {
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.where);
 
-  if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() && grid::modelgrid.thick[nonemptymgi] != 1) {
+  if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() && grid::thick_allcells[nonemptymgi] != 1) {
     pkt.nu_cmf = sample_planck_times_expansion_opacity(nonemptymgi);
   } else {
     pkt.nu_cmf = sample_planck_montecarlo(grid::get_Te(nonemptymgi));
@@ -419,8 +419,8 @@ __host__ __device__ void do_kpkt(Packet& pkt, const double t2, const int nts) {
   stats::increment(stats::COUNTER_INTERACTIONS);
 
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.where);
-  assert_always(grid::modelgrid.totalcooling[nonemptymgi] > 0.);
-  const double rndcool_ion = rng_uniform() * grid::modelgrid.totalcooling[nonemptymgi];
+  assert_always(grid::totalcooling_allcells[nonemptymgi] > 0.);
+  const double rndcool_ion = rng_uniform() * grid::totalcooling_allcells[nonemptymgi];
 
   // Randomly select the occurring cooling process
   double coolingsum = 0.;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -282,7 +282,7 @@ void calculate_cooling_rates(const int nonemptymgi, HeatingCoolingRates* heating
       (static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()), get_includedions());
   const double C_total = std::accumulate(cellioncontribs.begin(), cellioncontribs.end(), 0.0);
 
-  grid::modelgrid[nonemptymgi].totalcooling = C_total;
+  grid::modelgrid.totalcooling[nonemptymgi] = C_total;
 
   // only used in the T_e solver and write_to_estimators file
   if (heatingcoolingrates != nullptr) {
@@ -381,7 +381,7 @@ void setup_coolinglist() {
 __host__ __device__ void do_kpkt_blackbody(Packet& pkt) {
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.where);
 
-  if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() && grid::modelgrid[nonemptymgi].thick != 1) {
+  if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() && grid::modelgrid.thick[nonemptymgi] != 1) {
     pkt.nu_cmf = sample_planck_times_expansion_opacity(nonemptymgi);
   } else {
     pkt.nu_cmf = sample_planck_montecarlo(grid::get_Te(nonemptymgi));
@@ -419,8 +419,8 @@ __host__ __device__ void do_kpkt(Packet& pkt, const double t2, const int nts) {
   stats::increment(stats::COUNTER_INTERACTIONS);
 
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.where);
-  assert_always(grid::modelgrid[nonemptymgi].totalcooling > 0.);
-  const double rndcool_ion = rng_uniform() * grid::modelgrid[nonemptymgi].totalcooling;
+  assert_always(grid::modelgrid.totalcooling[nonemptymgi] > 0.);
+  const double rndcool_ion = rng_uniform() * grid::modelgrid.totalcooling[nonemptymgi];
 
   // Randomly select the occurring cooling process
   double coolingsum = 0.;

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -67,7 +67,7 @@ struct nneSolutionParas {
   assert_testmodeonly(ion < get_nions(element));
 
   assert_testmodeonly(!globals::lte_iteration);
-  assert_testmodeonly(grid::modelgrid.thick[nonemptymgi] != 1);  // should use use phi_lte instead
+  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);  // should use use phi_lte instead
 
   assert_testmodeonly(!elem_has_nlte_levels(element));  // don't use this function if the NLTE solver is active
 
@@ -495,7 +495,7 @@ void set_groundlevelpops(const int nonemptymgi, const int element, const float n
 // Determine the electron number density for a given cell using one of
 // libgsl's root_solvers and calculates the depending level populations.
 auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
-  const bool force_saha = globals::lte_iteration || grid::modelgrid.thick[nonemptymgi] == 1;
+  const bool force_saha = globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1;
 
   const double nne_hi = grid::get_rho(nonemptymgi) / MH;
 

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -67,7 +67,7 @@ struct nneSolutionParas {
   assert_testmodeonly(ion < get_nions(element));
 
   assert_testmodeonly(!globals::lte_iteration);
-  assert_testmodeonly(grid::modelgrid[nonemptymgi].thick != 1);  // should use use phi_lte instead
+  assert_testmodeonly(grid::modelgrid.thick[nonemptymgi] != 1);  // should use use phi_lte instead
 
   assert_testmodeonly(!elem_has_nlte_levels(element));  // don't use this function if the NLTE solver is active
 
@@ -495,7 +495,7 @@ void set_groundlevelpops(const int nonemptymgi, const int element, const float n
 // Determine the electron number density for a given cell using one of
 // libgsl's root_solvers and calculates the depending level populations.
 auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
-  const bool force_saha = globals::lte_iteration || grid::modelgrid[nonemptymgi].thick == 1;
+  const bool force_saha = globals::lte_iteration || grid::modelgrid.thick[nonemptymgi] == 1;
 
   const double nne_hi = grid::get_rho(nonemptymgi) / MH;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -330,7 +330,7 @@ __host__ __device__ void do_macroatom(Packet& pkt, const MacroAtomState& pktmast
 
   const auto nne = grid::get_nne(nonemptymgi);
 
-  assert_testmodeonly(grid::modelgrid[nonemptymgi].thick != 1);  // macroatom should not be used in thick cells
+  assert_testmodeonly(grid::modelgrid.thick[nonemptymgi] != 1);  // macroatom should not be used in thick cells
 
   // calculate occupation number for active MA level ////////////////////////////////////
   // general QUESTION: is it better to calculate the n_1 (later the n_ionstage and

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -330,7 +330,7 @@ __host__ __device__ void do_macroatom(Packet& pkt, const MacroAtomState& pktmast
 
   const auto nne = grid::get_nne(nonemptymgi);
 
-  assert_testmodeonly(grid::modelgrid.thick[nonemptymgi] != 1);  // macroatom should not be used in thick cells
+  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);  // macroatom should not be used in thick cells
 
   // calculate occupation number for active MA level ////////////////////////////////////
   // general QUESTION: is it better to calculate the n_1 (later the n_ionstage and

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1303,7 +1303,7 @@ void nltepop_open_file(const int my_rank) {
 
 void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-  if (globals::lte_iteration || grid::modelgrid.thick[nonemptymgi] == 1) {  // NLTE solver hasn't been run yet
+  if (globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1) {  // NLTE solver hasn't been run yet
     return;
   }
 
@@ -1332,12 +1332,12 @@ void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
             nnlevelnlte = get_groundlevelpop(nonemptymgi, element, ion);
           } else {
             nnlevelnlte =
-                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::modelgrid.rho[nonemptymgi];
+                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::rho_allcells[nonemptymgi];
           }
         } else {
           // superlevel, so add the populations of all other levels in the superlevel
           const double slpopfactor = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion) *
-                                     grid::modelgrid.rho[nonemptymgi];
+                                     grid::rho_allcells[nonemptymgi];
 
           nnlevellte = 0;
           nlte_file << -1 << ' ';
@@ -1368,7 +1368,7 @@ void nltepop_write_restart_data(FILE* restart_file) {
 
   for (auto nonemptymgi = 0z; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-    fprintf(restart_file, "%d %la\n", modelgridindex, grid::modelgrid.totalcooling[nonemptymgi]);
+    fprintf(restart_file, "%d %la\n", modelgridindex, grid::totalcooling_allcells[nonemptymgi]);
     for (int element = 0; element < get_nelements(); element++) {
       for (int ion = 0; ion < get_nions(element); ion++) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
@@ -1402,7 +1402,7 @@ void nltepop_read_restart_data(FILE* restart_file) {
 
   for (auto nonemptymgi = 0z; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     int mgi_in = 0;
-    assert_always(fscanf(restart_file, "%d %la\n", &mgi_in, &grid::modelgrid.totalcooling[nonemptymgi]) == 2);
+    assert_always(fscanf(restart_file, "%d %la\n", &mgi_in, &grid::totalcooling_allcells[nonemptymgi]) == 2);
     assert_always(mgi_in == grid::get_mgi_of_nonemptymgi(nonemptymgi));
 
     for (int element = 0; element < get_nelements(); element++) {

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1332,12 +1332,12 @@ void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
             nnlevelnlte = get_groundlevelpop(nonemptymgi, element, ion);
           } else {
             nnlevelnlte =
-                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::modelgrid[nonemptymgi].rho;
+                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::modelgrid_rho[nonemptymgi];
           }
         } else {
           // superlevel, so add the populations of all other levels in the superlevel
           const double slpopfactor = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion) *
-                                     grid::modelgrid[nonemptymgi].rho;
+                                     grid::modelgrid_rho[nonemptymgi];
 
           nnlevellte = 0;
           nlte_file << -1 << ' ';

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1303,7 +1303,7 @@ void nltepop_open_file(const int my_rank) {
 
 void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-  if (globals::lte_iteration || grid::modelgrid[nonemptymgi].thick == 1) {  // NLTE solver hasn't been run yet
+  if (globals::lte_iteration || grid::modelgrid.thick[nonemptymgi] == 1) {  // NLTE solver hasn't been run yet
     return;
   }
 
@@ -1332,12 +1332,12 @@ void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
             nnlevelnlte = get_groundlevelpop(nonemptymgi, element, ion);
           } else {
             nnlevelnlte =
-                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::modelgrid_rho[nonemptymgi];
+                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::modelgrid.rho[nonemptymgi];
           }
         } else {
           // superlevel, so add the populations of all other levels in the superlevel
           const double slpopfactor = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion) *
-                                     grid::modelgrid_rho[nonemptymgi];
+                                     grid::modelgrid.rho[nonemptymgi];
 
           nnlevellte = 0;
           nlte_file << -1 << ' ';
@@ -1368,7 +1368,7 @@ void nltepop_write_restart_data(FILE* restart_file) {
 
   for (auto nonemptymgi = 0z; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-    fprintf(restart_file, "%d %la\n", modelgridindex, grid::modelgrid[nonemptymgi].totalcooling);
+    fprintf(restart_file, "%d %la\n", modelgridindex, grid::modelgrid.totalcooling[nonemptymgi]);
     for (int element = 0; element < get_nelements(); element++) {
       for (int ion = 0; ion < get_nions(element); ion++) {
         const int uniqueionindex = get_uniqueionindex(element, ion);
@@ -1402,7 +1402,7 @@ void nltepop_read_restart_data(FILE* restart_file) {
 
   for (auto nonemptymgi = 0z; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     int mgi_in = 0;
-    assert_always(fscanf(restart_file, "%d %la\n", &mgi_in, &grid::modelgrid[nonemptymgi].totalcooling) == 2);
+    assert_always(fscanf(restart_file, "%d %la\n", &mgi_in, &grid::modelgrid.totalcooling[nonemptymgi]) == 2);
     assert_always(mgi_in == grid::get_mgi_of_nonemptymgi(nonemptymgi));
 
     for (int element = 0; element < get_nelements(); element++) {

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2305,7 +2305,7 @@ __host__ __device__ void do_ntlepton_deposit(Packet& pkt) {
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
 
   // macroatom should not be activated in thick cells
-  if (NT_ON && NT_SOLVE_SPENCERFANO && grid::modelgrid.thick[nonemptymgi] != 1) {
+  if (NT_ON && NT_SOLVE_SPENCERFANO && grid::thick_allcells[nonemptymgi] != 1) {
     // here there is some probability to cause ionisation or excitation to a macroatom packet
     // instead of converting directly to k-packet (unless the heating channel is selected)
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2305,7 +2305,7 @@ __host__ __device__ void do_ntlepton_deposit(Packet& pkt) {
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
 
   // macroatom should not be activated in thick cells
-  if (NT_ON && NT_SOLVE_SPENCERFANO && grid::modelgrid[nonemptymgi].thick != 1) {
+  if (NT_ON && NT_SOLVE_SPENCERFANO && grid::modelgrid.thick[nonemptymgi] != 1) {
     // here there is some probability to cause ionisation or excitation to a macroatom packet
     // instead of converting directly to k-packet (unless the heating channel is selected)
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -939,7 +939,7 @@ void normalise_bf_estimators(const int nts, const int nts_prev, const int titer,
   const auto bfestimcount = globals::bfestimcount;
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
   for (auto nonemptymgi = 0z; nonemptymgi < nonempty_npts_model; nonemptymgi++) {
-    if (grid::modelgrid[nonemptymgi].thick == 1) {
+    if (grid::modelgrid.thick[nonemptymgi] == 1) {
       continue;
     }
     const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);

--- a/radfield.cc
+++ b/radfield.cc
@@ -939,7 +939,7 @@ void normalise_bf_estimators(const int nts, const int nts_prev, const int titer,
   const auto bfestimcount = globals::bfestimcount;
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
   for (auto nonemptymgi = 0z; nonemptymgi < nonempty_npts_model; nonemptymgi++) {
-    if (grid::modelgrid.thick[nonemptymgi] == 1) {
+    if (grid::thick_allcells[nonemptymgi] == 1) {
       continue;
     }
     const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -622,7 +622,7 @@ auto do_rpkt_step(Packet& pkt, const double t2) -> bool {
   // Get distance to the next physical event (continuum or bound-bound)
   double edist = -1;
   bool event_is_boundbound = true;
-  const bool thickcell = (nonemptymgi >= 0) && (grid::modelgrid[nonemptymgi].thick == 1);
+  const bool thickcell = (nonemptymgi >= 0) && (grid::modelgrid.thick[nonemptymgi] == 1);
   if (nonemptymgi < 0) {
     // for empty cells no physical event occurs. The packets just propagate.
     edist = std::numeric_limits<double>::max();
@@ -946,7 +946,7 @@ __host__ __device__ void emit_rpkt(Packet& pkt) {
 
 void calculate_chi_rpkt_cont(const double nu_cmf, Rpkt_continuum_absorptioncoeffs& chi_rpkt_cont,
                              const int nonemptymgi) {
-  assert_testmodeonly(grid::modelgrid[nonemptymgi].thick != 1);
+  assert_testmodeonly(grid::modelgrid.thick[nonemptymgi] != 1);
   if ((nonemptymgi == chi_rpkt_cont.nonemptymgi) && (globals::timestep == chi_rpkt_cont.timestep) &&
       (fabs((chi_rpkt_cont.nu / nu_cmf) - 1.0) < 1e-4)) {
     // calculated values are a match already

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -111,7 +111,7 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Rpkt_con
                         const double tau_rnd,  // random optical depth until which the packet travels
                         const double abort_dist,  // maximal travel distance before packet leaves cell or time step ends
                         const double nu_cmf_abort, const double dnu_on_dl, const double doppler,
-                        const TransitionLines& linelist) -> std::tuple<double, int, bool> {
+                        const globals::TransitionLines& linelist) -> std::tuple<double, int, bool> {
   auto pos = pkt.pos;
   auto nu_cmf = pkt.nu_cmf;
   auto e_cmf = pkt.e_cmf;

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -622,7 +622,7 @@ auto do_rpkt_step(Packet& pkt, const double t2) -> bool {
   // Get distance to the next physical event (continuum or bound-bound)
   double edist = -1;
   bool event_is_boundbound = true;
-  const bool thickcell = (nonemptymgi >= 0) && (grid::modelgrid.thick[nonemptymgi] == 1);
+  const bool thickcell = (nonemptymgi >= 0) && (grid::thick_allcells[nonemptymgi] == 1);
   if (nonemptymgi < 0) {
     // for empty cells no physical event occurs. The packets just propagate.
     edist = std::numeric_limits<double>::max();
@@ -946,7 +946,7 @@ __host__ __device__ void emit_rpkt(Packet& pkt) {
 
 void calculate_chi_rpkt_cont(const double nu_cmf, Rpkt_continuum_absorptioncoeffs& chi_rpkt_cont,
                              const int nonemptymgi) {
-  assert_testmodeonly(grid::modelgrid.thick[nonemptymgi] != 1);
+  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);
   if ((nonemptymgi == chi_rpkt_cont.nonemptymgi) && (globals::timestep == chi_rpkt_cont.timestep) &&
       (fabs((chi_rpkt_cont.nu / nu_cmf) - 1.0) < 1e-4)) {
     // calculated values are a match already

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -227,6 +227,10 @@ void mpi_communicate_grid_properties() {
     if (globals::rank_in_node == 0) {
       MPI_Bcast_safe(grid::modelgrid.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid_rho.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid_Te.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
       MPI_Bcast_safe(grid::modelgrid_TJ.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
       MPI_Bcast_safe(grid::modelgrid_TR.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -227,6 +227,14 @@ void mpi_communicate_grid_properties() {
     if (globals::rank_in_node == 0) {
       MPI_Bcast_safe(grid::modelgrid.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid_TJ.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid_TR.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid_W.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid_nne.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
 
       if (USE_LUT_PHOTOION && globals::nbfcontinua_ground > 0) {
         assert_always(globals::corrphotoionrenorm.data() != nullptr);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -225,19 +225,27 @@ void mpi_communicate_grid_properties() {
 
     MPI_Barrier(MPI_COMM_WORLD);
     if (globals::rank_in_node == 0) {
-      MPI_Bcast_safe(grid::modelgrid.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.rho.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid_rho.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.Te.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid_Te.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.TJ.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid_TJ.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.TR.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid_TR.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.W.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid_W.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.nne.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid_nne.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::modelgrid.nnetot.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid.kappagrey.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid.grey_depth.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid.totalcooling.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(grid::modelgrid.thick.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
 
       if (USE_LUT_PHOTOION && globals::nbfcontinua_ground > 0) {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -225,27 +225,27 @@ void mpi_communicate_grid_properties() {
 
     MPI_Barrier(MPI_COMM_WORLD);
     if (globals::rank_in_node == 0) {
-      MPI_Bcast_safe(grid::modelgrid.rho.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::rho_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.Te.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::Te_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.TJ.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::TJ_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.TR.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::TR_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.W.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::W_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.nne.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::nne_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.nnetot.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::nnetot_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.kappagrey.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::kappagrey_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.grey_depth.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::grey_depth_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.totalcooling.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::totalcooling_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
-      MPI_Bcast_safe(grid::modelgrid.thick.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+      MPI_Bcast_safe(grid::thick_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
                      globals::mpi_comm_internode);
 
       if (USE_LUT_PHOTOION && globals::nbfcontinua_ground > 0) {

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -48,8 +48,8 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
 
   estimators_file << "timestep " << timestep << " modelgridindex " << mgi << " titeration " << titer << " TR "
                   << grid::get_TR(nonemptymgi) << " Te " << T_e << " W " << grid::get_W(nonemptymgi) << " TJ "
-                  << grid::get_TJ(nonemptymgi) << " grey_depth " << grid::modelgrid.grey_depth[nonemptymgi] << " thick "
-                  << grid::modelgrid.thick[nonemptymgi] << " nne " << nne << " Ye " << Y_e << " tdays "
+                  << grid::get_TJ(nonemptymgi) << " grey_depth " << grid::grey_depth_allcells[nonemptymgi] << " thick "
+                  << grid::thick_allcells[nonemptymgi] << " nne " << nne << " Ye " << Y_e << " tdays "
                   << std::format("{:7.2f}", globals::timesteps[timestep].mid / DAY) << '\n';
 
   if (globals::total_nlte_levels > 0) {
@@ -400,7 +400,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
   if (globals::opacity_case < 4) {
     // various forms of grey opacity
-    grid::modelgrid.thick[nonemptymgi] = 1;
+    grid::thick_allcells[nonemptymgi] = 1;
 
     if (globals::opacity_case == 3) {
       const auto kappagrey =
@@ -425,15 +425,15 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     // W == 1 indicates that this modelgrid cell was treated grey in the
     // last timestep. Therefore it has no valid Gamma estimators and must
     // be treated in LTE at restart.
-    if (grid::modelgrid.thick[nonemptymgi] != 1 && grid::get_W(nonemptymgi) == 1) {
+    if (grid::thick_allcells[nonemptymgi] != 1 && grid::get_W(nonemptymgi) == 1) {
       printlnlog(
           "force modelgrid cell {} to grey/LTE thick = 1 for update grid since existing W == 1. (will not have gamma "
           "estimators)",
           mgi);
-      grid::modelgrid.thick[nonemptymgi] = 1;
+      grid::thick_allcells[nonemptymgi] = 1;
     }
 
-    printlnlog("mgi {} modelgrid.thick: {} (during grid update)", mgi, grid::modelgrid.thick[nonemptymgi]);
+    printlnlog("mgi {} thick_allcells: {} (during grid update)", mgi, grid::thick_allcells[nonemptymgi]);
 
     for (int element = 0; element < get_nelements(); element++) {
       calculate_cellpartfuncts(nonemptymgi, element);
@@ -461,7 +461,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 #endif
 
     // lte_iteration really means either ts 0 or nts < globals::num_lte_timesteps
-    if (globals::lte_iteration || grid::modelgrid.thick[nonemptymgi] == 1) {
+    if (globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1) {
       // LTE mode or grey mode (where temperature doesn't matter but is calculated anyway)
 
       const auto T_J = radfield::get_T_J_from_J(nonemptymgi);
@@ -523,29 +523,29 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
              mgi, compton_optical_depth_across_cell, grey_optical_depth_across_cell);
   printlnlog("radial_pos {:g}, distance_to_obs {:g}, tau_dist {:g}", radial_pos, dist_to_obs, grey_optical_depth);
 
-  grid::modelgrid.grey_depth[nonemptymgi] = grey_optical_depth;
+  grid::grey_depth_allcells[nonemptymgi] = grey_optical_depth;
 
   // grey_optical_depth = compton_optical_depth;
 
   if ((grey_optical_depth >= globals::cell_is_optically_thick) && (nts < globals::num_grey_timesteps)) {
     printlnlog("timestep {} cell {} is treated in grey approximation (chi_grey {:g} [cm2/g], tau {:g} >= {:g})", nts,
                mgi, grid::get_kappagrey(nonemptymgi), grey_optical_depth, globals::cell_is_optically_thick);
-    grid::modelgrid.thick[nonemptymgi] = 1;
+    grid::thick_allcells[nonemptymgi] = 1;
   } else if (VPKT_ON && (grey_optical_depth > vpkt::cell_is_optically_thick_vpkt)) {
-    grid::modelgrid.thick[nonemptymgi] = 2;
+    grid::thick_allcells[nonemptymgi] = 2;
   } else {
-    grid::modelgrid.thick[nonemptymgi] = 0;
+    grid::thick_allcells[nonemptymgi] = 0;
   }
 
-  if (grid::modelgrid.thick[nonemptymgi] == 1) {
+  if (grid::thick_allcells[nonemptymgi] == 1) {
     // cooling rates calculation can be skipped for thick cells
     // flag with negative numbers to indicate that the rates are invalid
-    grid::modelgrid.totalcooling[nonemptymgi] = -1.;
+    grid::totalcooling_allcells[nonemptymgi] = -1.;
     grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] = -1.;
   } else if (globals::simulation_continued_from_saved && nts == globals::timestep_initial) {
     // cooling rates were read from the gridsave file for this timestep
     // make sure they are valid
-    assert_always(grid::modelgrid.totalcooling[nonemptymgi] >= 0.);
+    assert_always(grid::totalcooling_allcells[nonemptymgi] >= 0.);
     assert_always(grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] >= 0.);
   } else {
     // Cooling rates depend only on cell properties, precalculate total cooling
@@ -562,7 +562,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
   }
 
   if constexpr (EXPANSIONOPACITIES_ON || RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
-    if (grid::modelgrid.thick[nonemptymgi] != 1) {
+    if (grid::thick_allcells[nonemptymgi] != 1) {
       calculate_expansion_opacities(nonemptymgi);
     }
   }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -48,8 +48,8 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
 
   estimators_file << "timestep " << timestep << " modelgridindex " << mgi << " titeration " << titer << " TR "
                   << grid::get_TR(nonemptymgi) << " Te " << T_e << " W " << grid::get_W(nonemptymgi) << " TJ "
-                  << grid::get_TJ(nonemptymgi) << " grey_depth " << grid::modelgrid[nonemptymgi].grey_depth << " thick "
-                  << grid::modelgrid[nonemptymgi].thick << " nne " << nne << " Ye " << Y_e << " tdays "
+                  << grid::get_TJ(nonemptymgi) << " grey_depth " << grid::modelgrid.grey_depth[nonemptymgi] << " thick "
+                  << grid::modelgrid.thick[nonemptymgi] << " nne " << nne << " Ye " << Y_e << " tdays "
                   << std::format("{:7.2f}", globals::timesteps[timestep].mid / DAY) << '\n';
 
   if (globals::total_nlte_levels > 0) {
@@ -400,7 +400,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
   if (globals::opacity_case < 4) {
     // various forms of grey opacity
-    grid::modelgrid[nonemptymgi].thick = 1;
+    grid::modelgrid.thick[nonemptymgi] = 1;
 
     if (globals::opacity_case == 3) {
       const auto kappagrey =
@@ -425,15 +425,15 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     // W == 1 indicates that this modelgrid cell was treated grey in the
     // last timestep. Therefore it has no valid Gamma estimators and must
     // be treated in LTE at restart.
-    if (grid::modelgrid[nonemptymgi].thick != 1 && grid::get_W(nonemptymgi) == 1) {
+    if (grid::modelgrid.thick[nonemptymgi] != 1 && grid::get_W(nonemptymgi) == 1) {
       printlnlog(
           "force modelgrid cell {} to grey/LTE thick = 1 for update grid since existing W == 1. (will not have gamma "
           "estimators)",
           mgi);
-      grid::modelgrid[nonemptymgi].thick = 1;
+      grid::modelgrid.thick[nonemptymgi] = 1;
     }
 
-    printlnlog("mgi {} modelgrid.thick: {} (during grid update)", mgi, grid::modelgrid[nonemptymgi].thick);
+    printlnlog("mgi {} modelgrid.thick: {} (during grid update)", mgi, grid::modelgrid.thick[nonemptymgi]);
 
     for (int element = 0; element < get_nelements(); element++) {
       calculate_cellpartfuncts(nonemptymgi, element);
@@ -461,7 +461,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 #endif
 
     // lte_iteration really means either ts 0 or nts < globals::num_lte_timesteps
-    if (globals::lte_iteration || grid::modelgrid[nonemptymgi].thick == 1) {
+    if (globals::lte_iteration || grid::modelgrid.thick[nonemptymgi] == 1) {
       // LTE mode or grey mode (where temperature doesn't matter but is calculated anyway)
 
       const auto T_J = radfield::get_T_J_from_J(nonemptymgi);
@@ -523,29 +523,29 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
              mgi, compton_optical_depth_across_cell, grey_optical_depth_across_cell);
   printlnlog("radial_pos {:g}, distance_to_obs {:g}, tau_dist {:g}", radial_pos, dist_to_obs, grey_optical_depth);
 
-  grid::modelgrid[nonemptymgi].grey_depth = grey_optical_depth;
+  grid::modelgrid.grey_depth[nonemptymgi] = grey_optical_depth;
 
   // grey_optical_depth = compton_optical_depth;
 
   if ((grey_optical_depth >= globals::cell_is_optically_thick) && (nts < globals::num_grey_timesteps)) {
     printlnlog("timestep {} cell {} is treated in grey approximation (chi_grey {:g} [cm2/g], tau {:g} >= {:g})", nts,
                mgi, grid::get_kappagrey(nonemptymgi), grey_optical_depth, globals::cell_is_optically_thick);
-    grid::modelgrid[nonemptymgi].thick = 1;
+    grid::modelgrid.thick[nonemptymgi] = 1;
   } else if (VPKT_ON && (grey_optical_depth > vpkt::cell_is_optically_thick_vpkt)) {
-    grid::modelgrid[nonemptymgi].thick = 2;
+    grid::modelgrid.thick[nonemptymgi] = 2;
   } else {
-    grid::modelgrid[nonemptymgi].thick = 0;
+    grid::modelgrid.thick[nonemptymgi] = 0;
   }
 
-  if (grid::modelgrid[nonemptymgi].thick == 1) {
+  if (grid::modelgrid.thick[nonemptymgi] == 1) {
     // cooling rates calculation can be skipped for thick cells
     // flag with negative numbers to indicate that the rates are invalid
-    grid::modelgrid[nonemptymgi].totalcooling = -1.;
+    grid::modelgrid.totalcooling[nonemptymgi] = -1.;
     grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] = -1.;
   } else if (globals::simulation_continued_from_saved && nts == globals::timestep_initial) {
     // cooling rates were read from the gridsave file for this timestep
     // make sure they are valid
-    assert_always(grid::modelgrid[nonemptymgi].totalcooling >= 0.);
+    assert_always(grid::modelgrid.totalcooling[nonemptymgi] >= 0.);
     assert_always(grid::ion_cooling_contribs_allcells[(nonemptymgi * get_includedions()) + 0] >= 0.);
   } else {
     // Cooling rates depend only on cell properties, precalculate total cooling
@@ -562,7 +562,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
   }
 
   if constexpr (EXPANSIONOPACITIES_ON || RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
-    if (grid::modelgrid[nonemptymgi].thick != 1) {
+    if (grid::modelgrid.thick[nonemptymgi] != 1) {
       calculate_expansion_opacities(nonemptymgi);
     }
   }

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -260,7 +260,7 @@ void do_packet(Packet& pkt, const double t2, const int nts) {
     case TYPE_KPKT: {
       const int mgi = grid::get_propcell_modelgridindex(pkt.where);
       const int nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
-      if (grid::modelgrid.thick[nonemptymgi] == 1 ||
+      if (grid::thick_allcells[nonemptymgi] == 1 ||
           (EXPANSIONOPACITIES_ON && RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value())) {
         kpkt::do_kpkt_blackbody(pkt);
       } else {
@@ -378,7 +378,7 @@ void update_packets(const int nts, std::span<Packet> packets) {
         const int nonemptymgi = (mgi < grid::get_npts_model()) ? grid::get_nonemptymgi_of_mgi(mgi) : -1;
         const bool cellcache_change_cell_required =
             (nonemptymgi >= 0 && globals::cellcache[cellcacheslotid].nonemptymgi != nonemptymgi &&
-             grid::modelgrid.thick[nonemptymgi] != 1);
+             grid::thick_allcells[nonemptymgi] != 1);
 
         if (cellcache_change_cell_required) {
           if (packetgroupstart != pktindex) {

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -260,7 +260,7 @@ void do_packet(Packet& pkt, const double t2, const int nts) {
     case TYPE_KPKT: {
       const int mgi = grid::get_propcell_modelgridindex(pkt.where);
       const int nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
-      if (grid::modelgrid[nonemptymgi].thick == 1 ||
+      if (grid::modelgrid.thick[nonemptymgi] == 1 ||
           (EXPANSIONOPACITIES_ON && RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value())) {
         kpkt::do_kpkt_blackbody(pkt);
       } else {
@@ -378,7 +378,7 @@ void update_packets(const int nts, std::span<Packet> packets) {
         const int nonemptymgi = (mgi < grid::get_npts_model()) ? grid::get_nonemptymgi_of_mgi(mgi) : -1;
         const bool cellcache_change_cell_required =
             (nonemptymgi >= 0 && globals::cellcache[cellcacheslotid].nonemptymgi != nonemptymgi &&
-             grid::modelgrid[nonemptymgi].thick != 1);
+             grid::modelgrid.thick[nonemptymgi] != 1);
 
         if (cellcache_change_cell_required) {
           if (packetgroupstart != pktindex) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -359,7 +359,7 @@ auto rlc_emiss_vpkt(const Packet& pkt, const double t_current, const double t_ar
       const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
 
       // kill vpkt with pass through a thick cell
-      if (grid::modelgrid.thick[nonemptymgi] != 0) {
+      if (grid::thick_allcells[nonemptymgi] != 0) {
         return false;
       }
     }
@@ -867,7 +867,7 @@ auto call_estimators(const Packet& pkt, const enum packet_type type_before_rpkt)
   // Cut on vpkts
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.where);
 
-  if (grid::modelgrid.thick[nonemptymgi] != 0) {
+  if (grid::thick_allcells[nonemptymgi] != 0) {
     return;
   }
 

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -359,7 +359,7 @@ auto rlc_emiss_vpkt(const Packet& pkt, const double t_current, const double t_ar
       const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
 
       // kill vpkt with pass through a thick cell
-      if (grid::modelgrid[nonemptymgi].thick != 0) {
+      if (grid::modelgrid.thick[nonemptymgi] != 0) {
         return false;
       }
     }
@@ -867,7 +867,7 @@ auto call_estimators(const Packet& pkt, const enum packet_type type_before_rpkt)
   // Cut on vpkts
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.where);
 
-  if (grid::modelgrid[nonemptymgi].thick != 0) {
+  if (grid::modelgrid.thick[nonemptymgi] != 0) {
     return;
   }
 


### PR DESCRIPTION
Probably no major performance increase since the update grid and packets work one cell at a time, but improves consistency of how we add components to model cells.