### PR TITLE
Add compile time option to disable transition data checks

### DIFF
--- a/artisoptions_classic.h
+++ b/artisoptions_classic.h
@@ -7,6 +7,8 @@
 
 #include "constants.h"
 
+#undef BIG_GF4_LEGACY_COMPAT
+
 constexpr int MPKTS = 100000;
 
 constexpr auto GRID_TYPE = GridType::CARTESIAN3D;

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -1,4 +1,8 @@
 ```
+// Enable/ disable compatibility mode for the old big_gf-4 atomic data set. Removes restrictive checks for transition data
+#undef BIG_GF4_LEGACY_COMPAT
+
+
 // Number of energy packets per process (MPI rank). OpenMP threads share these packets
 constexpr int MPKTS;
 

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -1,5 +1,5 @@
 ```
-// Enable/ disable compatibility mode for the old big_gf-4 atomic data set. Removes restrictive checks for transition data
+// Enable/disable compatibility mode for the old big_gf-4 atomic data set. Removes restrictive checks for transition data.
 #undef BIG_GF4_LEGACY_COMPAT
 
 

--- a/input.cc
+++ b/input.cc
@@ -460,11 +460,10 @@ void read_ion_transitions(std::istream& ftransitiondata, const int ion_transitio
     }
     const int lower = lower_in - groundstate_index_in;
     const int upper = upper_in - groundstate_index_in;
-#ifdef BIG_GF4_LEGACY_COMPAT
     assert_always(lower >= 0);
+#ifdef BIG_GF4_LEGACY_COMPAT
     assert_always(upper >= 0);
 #else
-    assert_always(lower >= 0);
     assert_always(upper > lower);
     assert_always(lower >= prev_lower);
     assert_always(upper >= prev_upper || lower > prev_lower);

--- a/input.cc
+++ b/input.cc
@@ -460,10 +460,15 @@ void read_ion_transitions(std::istream& ftransitiondata, const int ion_transitio
     }
     const int lower = lower_in - groundstate_index_in;
     const int upper = upper_in - groundstate_index_in;
+#ifdef BIG_GF4_LEGACY_COMPAT
+    assert_always(lower >= 0);
+    assert_always(upper >= 0);
+#else
     assert_always(lower >= 0);
     assert_always(upper > lower);
     assert_always(lower >= prev_lower);
     assert_always(upper >= prev_upper || lower > prev_lower);
+#endif  // BIG_GF4_LEGACY_COMPAT
 
     // this entire block can be removed if we don't want to add in extra collisonal
     // transitions between levels


### PR DESCRIPTION
The old big_gf-4 atomic data set format is not compatible with the current transition data reader and fails the assertion checks. The less restrictive reader in #v2024.08 worked fine. This patch adds a compile flag to skip the more restrictive assertion checks of the latest version and instead uses the ones from #v2024.08.