### PR TITLE
Rename optical depth vars and refactor NLTE storage

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -289,7 +289,7 @@ inline int total_nlte_levels{0};
 
 inline bool simulation_continued_from_saved{false};
 inline int num_lte_timesteps{-1};
-inline double cell_is_optically_thick{NAN};
+inline double optical_depth_is_thick{NAN};
 inline int num_grey_timesteps{-1};
 inline int n_titer{1};
 inline bool lte_iteration{false};

--- a/grid.cc
+++ b/grid.cc
@@ -1522,7 +1522,9 @@ void set_elem_abundance(const ptrdiff_t nonemptymgi, const int element, const fl
          get_rho(nonemptymgi);
 }
 
-DEVICE_FUNC auto get_kappagrey(const int nonemptymgi) -> float { return kappagrey_allcells[nonemptymgi]; }
+[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_kappagrey(const int nonemptymgi) -> float {
+  return kappagrey_allcells[nonemptymgi];
+}
 
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_Te(const int nonemptymgi) -> float {
   assert_testmodeonly(nonemptymgi >= 0);

--- a/grid.h
+++ b/grid.h
@@ -34,7 +34,6 @@ inline MPI_shared_array<float> elem_meanweight_allcells;
 // mass fractions of elements in each cell for the current timestep
 inline MPI_shared_array<float> elem_massfracs_allcells;
 
-inline MPI_shared_array<double> nltepops_allcells;
 inline MPI_shared_array<float> ion_groundlevelpops_allcells;
 inline MPI_shared_array<float> ion_partfuncts_allcells;
 

--- a/input.cc
+++ b/input.cc
@@ -114,7 +114,7 @@ constexpr auto inputlinecomments = std::array{
     "16: simulation_continued_from_saved: (0: start new simulation, 1: continue from gridsave and packets files)",
     "17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.",
     "18: num_lte_timesteps",
-    "19: cell_is_optically_thick num_grey_timesteps",
+    "19: optical_depth_is_thick num_grey_timesteps",
     "20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)",
     "21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.",
     "22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d",
@@ -1776,10 +1776,10 @@ void read_parameterfile() {
 
   // Set up initial grey approximation?
   assert_always(get_noncommentline(file, line));
-  std::istringstream{line} >> globals::cell_is_optically_thick >> globals::num_grey_timesteps;
+  std::istringstream{line} >> globals::optical_depth_is_thick >> globals::num_grey_timesteps;
   printlnlog(
       "input: cells with Thomson optical depth > {:g} are treated in grey approximation for the first {} timesteps",
-      globals::cell_is_optically_thick, globals::num_grey_timesteps);
+      globals::optical_depth_is_thick, globals::num_grey_timesteps);
 
   // Limit the number of bf-continua
   assert_always(get_noncommentline(file, line));

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -22,7 +22,6 @@
 #include "nltepop.h"
 #include "nonthermal.h"
 #include "ratecoeff.h"
-#include "rpkt.h"
 #include "sn3d.h"
 
 namespace {
@@ -59,7 +58,8 @@ namespace {
   const auto T_e = grid::get_Te(nonemptymgi);
 
   // photoionisation plus collisional ionisation rate coefficient per ground level pop
-  const double Gamma_groundlevel = globals::gammaestimator[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)];
+  const double Gamma_groundlevel =
+      globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)];
 
   // Convert Gamma to the photoionisation rate per ion pop
   const double Gamma_ion = Gamma_groundlevel * stat_weight(element, ion, 0) / partfunc_ion;
@@ -268,8 +268,9 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 
       if constexpr (USE_LUT_PHOTOION) {
         for (int ion = 0; ion <= grid::get_elements_uppermost_ion(nonemptymgi, element); ion++) {
-          printout("element %d, ion %d, gammaionest %g\n", element, ion,
-                   globals::gammaestimator[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)]);
+          printout(
+              "element %d, ion %d, gammaionest %g\n", element, ion,
+              globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)]);
         }
       }
     }

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -141,30 +141,25 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
   if (elem_has_nlte_levels(element)) {
     if (is_nlte(element, ion, level)) {
       const double nltepop_over_rho = get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level);
-      if (nltepop_over_rho < 0.) {
-        // Case for when no NLTE level information is available yet
-        return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
+      if (nltepop_over_rho >= 0.) {
+        const double nn = nltepop_over_rho * grid::get_rho(nonemptymgi);
+        assert_testmodeonly(std::isfinite(nn));
+        assert_testmodeonly(nn >= 0.);
+        return {nn, true};
       }
-      const double nn = nltepop_over_rho * grid::get_rho(nonemptymgi);
-      assert_testmodeonly(std::isfinite(nn));
-      assert_testmodeonly(nn >= 0.);
-      return {nn, true};
+    } else {
+      // level is in the superlevel
+      assert_testmodeonly(level_isinsuperlevel(element, ion, level) || level_isautoionising(element, ion, level));
+
+      const double superlevelpop_over_rho = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion);
+      if (superlevelpop_over_rho >= 0.) {
+        const double nn = superlevelpop_over_rho * grid::get_rho(nonemptymgi) *
+                          superlevel_boltzmann(nonemptymgi, element, ion, level);
+        assert_testmodeonly(std::isfinite(nn));
+        assert_testmodeonly(nn >= 0.);
+        return {nn, true};
+      }
     }
-
-    // level is in the superlevel
-    assert_testmodeonly(level_isinsuperlevel(element, ion, level) || level_isautoionising(element, ion, level));
-
-    const double superlevelpop_over_rho = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion);
-    if (superlevelpop_over_rho < 0.) {
-      // Case for when no NLTE level information is available yet
-      return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
-    }
-
-    const double nn =
-        superlevelpop_over_rho * grid::get_rho(nonemptymgi) * superlevel_boltzmann(nonemptymgi, element, ion, level);
-    assert_testmodeonly(std::isfinite(nn));
-    assert_testmodeonly(nn >= 0.);
-    return {nn, true};
   }
 
   return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -58,8 +58,10 @@ namespace {
   const auto T_e = grid::get_Te(nonemptymgi);
 
   // photoionisation plus collisional ionisation rate coefficient per ground level pop
+  const auto groundcontindex = get_groundcontindex(element, ion);
   const double Gamma_groundlevel =
-      globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)];
+      groundcontindex >= 0 ? globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + groundcontindex]
+                           : 0.;
 
   // Convert Gamma to the photoionisation rate per ion pop
   const double Gamma_ion = Gamma_groundlevel * stat_weight(element, ion, 0) / partfunc_ion;
@@ -245,27 +247,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
   constexpr double nne_min = 0.;
   const auto f_nne_min = f_nne(nne_min);
   const auto f_nne_max = f_nne(nne_max);
-  if (f_nne_min * f_nne_max > 0) {
-    const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-    printout("n, nne_min, nne_max, T_R, T_e, W, rho %d, %g, %g, %g, %g, %g, %g\n", modelgridindex, nne_min, nne_max,
-             grid::get_TR(nonemptymgi), grid::get_Te(nonemptymgi), grid::get_W(nonemptymgi),
-             grid::get_rho(nonemptymgi));
-    printout("nne(nne_min) %g\n", f_nne_min);
-    printout("nne(nne_max) %g\n", f_nne_max);
-
-    for (int element = 0; element < get_nelements(); element++) {
-      printout("modelgridindex %d, element %d, uppermost_ion is %d\n", modelgridindex, element,
-               grid::get_elements_uppermost_ion(nonemptymgi, element));
-
-      if constexpr (USE_LUT_PHOTOION) {
-        for (int ion = 0; ion <= grid::get_elements_uppermost_ion(nonemptymgi, element); ion++) {
-          printout(
-              "element %d, ion %d, gammaionest %g\n", element, ion,
-              globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)]);
-        }
-      }
-    }
-  }
+  assert_always(f_nne_min * f_nne_max <= 0.);  // there should be a root in the interval
 
   constexpr double fractional_accuracy = 1e-3;
   constexpr auto maxit = 50U;

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -143,8 +143,6 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
       const double nltepop_over_rho = get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level);
       if (nltepop_over_rho >= 0.) {
         const double nn = nltepop_over_rho * grid::get_rho(nonemptymgi);
-        assert_testmodeonly(std::isfinite(nn));
-        assert_testmodeonly(nn >= 0.);
         return {nn, true};
       }
     } else {
@@ -155,8 +153,6 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
       if (superlevelpop_over_rho >= 0.) {
         const double nn = superlevelpop_over_rho * grid::get_rho(nonemptymgi) *
                           superlevel_boltzmann(nonemptymgi, element, ion, level);
-        assert_testmodeonly(std::isfinite(nn));
-        assert_testmodeonly(nn >= 0.);
         return {nn, true};
       }
     }

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
+#include <tuple>
 #include <vector>
 
 #include "artisoptions.h"
@@ -127,13 +128,14 @@ auto nne_solution_f(const double nne_assumed, const int nonemptymgi, const bool 
 }
 
 // return population and whether the population came from the nlte solver
-auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level) -> double {
+auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level)
+    -> std::tuple<double, bool> {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
 
   if (level == 0) {
-    return get_groundlevelpop(nonemptymgi, element, ion);
+    return {get_groundlevelpop(nonemptymgi, element, ion), false};
   }
 
   if (elem_has_nlte_levels(element)) {
@@ -141,9 +143,12 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
       const double nltepop_over_rho = get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level);
       if (nltepop_over_rho < 0.) {
         // Case for when no NLTE level information is available yet
-        return calculate_levelpop_boltzmann(nonemptymgi, element, ion, level);
+        return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
       }
-      return nltepop_over_rho * grid::get_rho(nonemptymgi);
+      const double nn = nltepop_over_rho * grid::get_rho(nonemptymgi);
+      assert_testmodeonly(std::isfinite(nn));
+      assert_testmodeonly(nn >= 0.);
+      return {nn, true};
     }
 
     // level is in the superlevel
@@ -152,15 +157,17 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
     const double superlevelpop_over_rho = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion);
     if (superlevelpop_over_rho < 0.) {
       // Case for when no NLTE level information is available yet
-      return calculate_levelpop_boltzmann(nonemptymgi, element, ion, level);
+      return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
     }
 
     const double nn =
         superlevelpop_over_rho * grid::get_rho(nonemptymgi) * superlevel_boltzmann(nonemptymgi, element, ion, level);
-    return nn;
+    assert_testmodeonly(std::isfinite(nn));
+    assert_testmodeonly(nn >= 0.);
+    return {nn, true};
   }
 
-  return calculate_levelpop_boltzmann(nonemptymgi, element, ion, level);
+  return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
 }
 
 // Calculate the partition function for ion=ion of element=element in a cell modelgridindex
@@ -187,7 +194,7 @@ auto calculate_partfunct(const int element, const int ion, const int nonemptymgi
   const int nlevels = get_nlevels(element, ion);
   const double groundpop = get_groundlevelpop(nonemptymgi, element, ion);
   for (int level = 1; level < nlevels; level++) {
-    const auto nn = calculate_levelpop_nominpop(nonemptymgi, element, ion, level);
+    const auto nn = std::get<0>(calculate_levelpop_nominpop(nonemptymgi, element, ion, level));
     U += nn / groundpop;
   }
   U *= stat_weight(element, ion, 0);
@@ -386,7 +393,15 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto calculate_levelpop(const int nonemptymgi, const int element, const int ion,
                                                                 const int level) -> double {
-  return std::max(calculate_levelpop_nominpop(nonemptymgi, element, ion, level), MINPOP);
+  const auto [nn, skipminpop] = calculate_levelpop_nominpop(nonemptymgi, element, ion, level);
+  if (!skipminpop && nn < MINPOP) {
+    if (grid::get_elem_abundance(nonemptymgi, element) > 0) {
+      return MINPOP;
+    }
+    return 0.;
+  }
+
+  return nn;
 }
 
 // The partition functions depend only on T_R and W. This means they don't

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -9,7 +9,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
-#include <tuple>
 #include <vector>
 
 #include "artisoptions.h"
@@ -128,14 +127,13 @@ auto nne_solution_f(const double nne_assumed, const int nonemptymgi, const bool 
 }
 
 // return population and whether the population came from the nlte solver
-auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level)
-    -> std::tuple<double, bool> {
+auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level) -> double {
   assert_testmodeonly(element < get_nelements());
   assert_testmodeonly(ion < get_nions(element));
   assert_testmodeonly(level < get_nlevels(element, ion));
 
   if (level == 0) {
-    return {get_groundlevelpop(nonemptymgi, element, ion), false};
+    return get_groundlevelpop(nonemptymgi, element, ion);
   }
 
   if (elem_has_nlte_levels(element)) {
@@ -143,12 +141,9 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
       const double nltepop_over_rho = get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level);
       if (nltepop_over_rho < 0.) {
         // Case for when no NLTE level information is available yet
-        return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
+        return calculate_levelpop_boltzmann(nonemptymgi, element, ion, level);
       }
-      const double nn = nltepop_over_rho * grid::get_rho(nonemptymgi);
-      assert_testmodeonly(std::isfinite(nn));
-      assert_testmodeonly(nn >= 0.);
-      return {nn, true};
+      return nltepop_over_rho * grid::get_rho(nonemptymgi);
     }
 
     // level is in the superlevel
@@ -157,17 +152,15 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
     const double superlevelpop_over_rho = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion);
     if (superlevelpop_over_rho < 0.) {
       // Case for when no NLTE level information is available yet
-      return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
+      return calculate_levelpop_boltzmann(nonemptymgi, element, ion, level);
     }
 
     const double nn =
         superlevelpop_over_rho * grid::get_rho(nonemptymgi) * superlevel_boltzmann(nonemptymgi, element, ion, level);
-    assert_testmodeonly(std::isfinite(nn));
-    assert_testmodeonly(nn >= 0.);
-    return {nn, true};
+    return nn;
   }
 
-  return {calculate_levelpop_boltzmann(nonemptymgi, element, ion, level), false};
+  return calculate_levelpop_boltzmann(nonemptymgi, element, ion, level);
 }
 
 // Calculate the partition function for ion=ion of element=element in a cell modelgridindex
@@ -194,7 +187,7 @@ auto calculate_partfunct(const int element, const int ion, const int nonemptymgi
   const int nlevels = get_nlevels(element, ion);
   const double groundpop = get_groundlevelpop(nonemptymgi, element, ion);
   for (int level = 1; level < nlevels; level++) {
-    const auto nn = std::get<0>(calculate_levelpop_nominpop(nonemptymgi, element, ion, level));
+    const auto nn = calculate_levelpop_nominpop(nonemptymgi, element, ion, level);
     U += nn / groundpop;
   }
   U *= stat_weight(element, ion, 0);
@@ -393,15 +386,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto calculate_levelpop(const int nonemptymgi, const int element, const int ion,
                                                                 const int level) -> double {
-  const auto [nn, skipminpop] = calculate_levelpop_nominpop(nonemptymgi, element, ion, level);
-  if (!skipminpop && nn < MINPOP) {
-    if (grid::get_elem_abundance(nonemptymgi, element) > 0) {
-      return MINPOP;
-    }
-    return 0.;
-  }
-
-  return nn;
+  return std::max(calculate_levelpop_nominpop(nonemptymgi, element, ion, level), MINPOP);
 }
 
 // The partition functions depend only on T_R and W. This means they don't

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -419,7 +419,7 @@ void print_level_rates(const int nonemptymgi, const int timestep, const int elem
 void nltepop_reset_element(const int nonemptymgi, const int element) {
   for (int ion = 0; ion < get_nions(element); ion++) {
     const int nlte_start = get_allnltelevelsindexstart(element, ion);
-    std::fill_n(&grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlte_start],
+    std::fill_n(&nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlte_start],
                 get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0), -1.);
   }
 }
@@ -745,15 +745,15 @@ void set_nlte_levelpop_over_rho(const int nonemptymgi, const int element, const 
                                 const double value) {
   assert_testmodeonly(level > 0);  // ground state is stored separately
   assert_testmodeonly(level <= get_nlevels_excited_nlte(element, ion));
-  grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + get_allnltelevelsindexstart(element, ion) +
-                          level - 1] = value;
+  nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + get_allnltelevelsindexstart(element, ion) + level -
+                    1] = value;
 }
 
 void set_nlte_superlevelpop_over_rho_over_slpartfunc(const int nonemptymgi, const int element, const int ion,
                                                      const double value) {
   assert_testmodeonly(ion_has_superlevel(element, ion));
   const int sl_nlte_index = get_allnltelevelsindexstart(element, ion) + get_nlevels_excited_nlte(element, ion);
-  grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + sl_nlte_index] = value;
+  nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + sl_nlte_index] = value;
 }
 
 void set_element_pops_lte(const int nonemptymgi, const int element) {
@@ -1412,13 +1412,12 @@ void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
           if (level == 0) {
             nnlevelnlte = get_groundlevelpop(nonemptymgi, element, ion);
           } else {
-            nnlevelnlte =
-                get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::rho_allcells[nonemptymgi];
+            nnlevelnlte = get_nlte_levelpop_over_rho(nonemptymgi, element, ion, level) * grid::get_rho(nonemptymgi);
           }
         } else {
           // superlevel, so add the populations of all other levels in the superlevel
-          const double slpopfactor = get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion) *
-                                     grid::rho_allcells[nonemptymgi];
+          const double slpopfactor =
+              get_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion) * grid::get_rho(nonemptymgi);
 
           nnlevellte = 0;
           nlte_file << -1 << ' ';
@@ -1460,7 +1459,7 @@ void nltepop_write_restart_data(FILE* restart_file) {
       }
     }
     for (int nlteindex = 0; nlteindex < globals::total_nlte_levels; nlteindex++) {
-      fprintf(restart_file, "%la ", grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlteindex]);
+      fprintf(restart_file, "%la ", nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlteindex]);
     }
   }
 }
@@ -1501,7 +1500,7 @@ void nltepop_read_restart_data(FILE* restart_file) {
     }
     for (int nlteindex = 0; nlteindex < globals::total_nlte_levels; nlteindex++) {
       assert_always(fscanf(restart_file, "%la ",
-                           &grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlteindex]) == 1);
+                           &nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlteindex]) == 1);
     }
   }
 }
@@ -1510,13 +1509,13 @@ DEVICE_FUNC auto get_nlte_levelpop_over_rho(const int nonemptymgi, const int ele
     -> double {
   assert_testmodeonly(level > 0);  // ground state is stored separately
   assert_testmodeonly(level <= get_nlevels_excited_nlte(element, ion));
-  return grid::nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) +
-                                 get_allnltelevelsindexstart(element, ion) + level - 1];
+  return nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) +
+                           get_allnltelevelsindexstart(element, ion) + level - 1];
 }
 
 [[nodiscard]] DEVICE_FUNC auto get_nlte_superlevelpop_over_rho_over_slpartfunc(const int nonemptymgi, const int element,
                                                                                const int ion) -> double {
   assert_testmodeonly(ion_has_superlevel(element, ion));
   const int sl_nlte_index = get_allnltelevelsindexstart(element, ion) + get_nlevels_excited_nlte(element, ion);
-  return grid::nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + sl_nlte_index];
+  return nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + sl_nlte_index];
 }

--- a/nltepop.h
+++ b/nltepop.h
@@ -4,6 +4,9 @@
 #include <cstdio>
 
 #include "constants.h"
+#include "mpi_logging.h"
+
+inline MPI_shared_array<double> nltepops_allcells;
 
 void solve_nlte_pops_element(int element, int nonemptymgi, int timestep, int nlte_iter);
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto superlevel_boltzmann(int nonemptymgi, int element, int ion, int level)

--- a/radfield.cc
+++ b/radfield.cc
@@ -614,10 +614,12 @@ void initialise_prev_titer_photoionestimators() {
       const int nions = get_nions(element);
       for (int ion = 0; ion < nions - 1; ion++) {
         if constexpr (USE_LUT_PHOTOION) {
-          globals::gammaestimator_save[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)] = -1.;
+          globals::gammaestimator_save[(nonemptymgi * globals::nbfcontinua_ground) +
+                                       get_groundcontindex(element, ion)] = -1.;
         }
         if constexpr (USE_ION_BFHEATING_ESTIMATORS) {
-          globals::bfheatingestimator_save[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)] = -1.;
+          globals::bfheatingestimator_save[(nonemptymgi * globals::nbfcontinua_ground) +
+                                           get_groundcontindex(element, ion)] = -1.;
         }
       }
     }

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -23,7 +23,6 @@
 #include "mpi_logging.h"
 #include "radfield.h"
 #include "random.h"
-#include "rpkt.h"
 
 namespace {
 constexpr double RATECOEFF_INTEGRAL_ACCURACY = 1e-3;
@@ -715,7 +714,8 @@ auto iongamma_is_zero(const int nonemptymgi, const int element, const int ion) -
   }
 
   if (!elem_has_nlte_levels(element)) {
-    return (globals::gammaestimator[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)] == 0);
+    return (globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)] ==
+            0);
   }
 
   const auto T_e = grid::get_Te(nonemptymgi);

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -714,8 +714,11 @@ auto iongamma_is_zero(const int nonemptymgi, const int element, const int ion) -
   }
 
   if (!elem_has_nlte_levels(element)) {
-    return (globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)] ==
-            0);
+    const auto groundcontindex = get_groundcontindex(element, ion);
+    if (groundcontindex < 0) {
+      return true;
+    }
+    return (globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + groundcontindex] == 0);
   }
 
   const auto T_e = grid::get_Te(nonemptymgi);

--- a/rpkt.h
+++ b/rpkt.h
@@ -9,12 +9,9 @@
 #include <span>
 
 #include "artisoptions.h"
-#include "atomic.h"
 #include "constants.h"
-#include "globals.h"
 #include "grid.h"
 #include "ltepop.h"
-#include "mpi_logging.h"
 #include "packet.h"
 
 class Phixslist {
@@ -145,15 +142,6 @@ auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
   }
 
   return matchindex;
-}
-
-[[gnu::pure]] [[nodiscard]] inline auto get_ionestimindex_nonemptymgi(const int nonemptymgi, const int element,
-                                                                      const int ion) -> int {
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element) - 1);
-  const int groundcontindex = get_groundcontindex(element, ion);
-  assert_always(groundcontindex >= 0);
-  return (nonemptymgi * globals::nbfcontinua_ground) + groundcontindex;
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto keep_this_cont(int element, const int ion, const int level,

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -372,8 +372,8 @@ void mpi_communicate_grid_properties() {
       }
 
       if (globals::total_nlte_levels > 0) {
-        MPI_Bcast_safe(grid::nltepops_allcells.subspan(root_nstart_nonempty * globals::total_nlte_levels,
-                                                       root_ndo_nonempty * globals::total_nlte_levels),
+        MPI_Bcast_safe(nltepops_allcells.subspan(root_nstart_nonempty * globals::total_nlte_levels,
+                                                 root_ndo_nonempty * globals::total_nlte_levels),
                        root_node_id, globals::mpi_comm_internode);
       }
 

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -125,8 +125,9 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const doub
           // recalculate the Gammas using the current level populations
           const int nions = get_nions(element);
           for (int ion = 0; ion < nions - 1; ion++) {
-            if (get_groundcontindex(element, ion) >= 0) {
-              globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)] =
+            const auto groundcontindex = get_groundcontindex(element, ion);
+            if (groundcontindex >= 0) {
+              globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + groundcontindex] =
                   calculate_iongamma_per_gspop(nonemptymgi, element, ion);
             }
           }

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -24,7 +24,6 @@
 #include "nonthermal.h"
 #include "radfield.h"
 #include "ratecoeff.h"
-#include "rpkt.h"
 #include "sn3d.h"
 
 namespace {
@@ -127,7 +126,7 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const doub
           const int nions = get_nions(element);
           for (int ion = 0; ion < nions - 1; ion++) {
             if (get_groundcontindex(element, ion) >= 0) {
-              globals::gammaestimator[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)] =
+              globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)] =
                   calculate_iongamma_per_gspop(nonemptymgi, element, ion);
             }
           }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -121,9 +121,9 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
       estimators_file << std::format("corrphotoionrenorm Z={:2d}", get_atomicnumber(element));
       for (int ion = 0; ion < nions - 1; ion++) {
         if (get_groundcontindex(element, ion) >= 0) {
-          estimators_file << std::format(
-              "  {}: {:9.3e}", get_ionstage(element, ion),
-              globals::corrphotoionrenorm[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)]);
+          estimators_file << std::format("  {}: {:9.3e}", get_ionstage(element, ion),
+                                         globals::corrphotoionrenorm[(nonemptymgi * globals::nbfcontinua_ground) +
+                                                                     get_groundcontindex(element, ion)]);
         }
       }
       estimators_file << '\n';
@@ -132,7 +132,7 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
         if (get_groundcontindex(element, ion) >= 0) {
           estimators_file << std::format(
               "  {}: {:9.3e}", get_ionstage(element, ion),
-              globals::gammaestimator[get_ionestimindex_nonemptymgi(nonemptymgi, element, ion)]);
+              globals::gammaestimator[(nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(element, ion)]);
         }
       }
       estimators_file << '\n';
@@ -495,11 +495,11 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
   // grey_optical_depth = compton_optical_depth;
 
-  if ((grey_optical_depth >= globals::cell_is_optically_thick) && (nts < globals::num_grey_timesteps)) {
+  if ((grey_optical_depth >= globals::optical_depth_is_thick) && (nts < globals::num_grey_timesteps)) {
     printlnlog("timestep {} cell {} is treated in grey approximation (chi_grey {:g} [cm2/g], tau {:g} >= {:g})", nts,
-               mgi, grid::get_kappagrey(nonemptymgi), grey_optical_depth, globals::cell_is_optically_thick);
+               mgi, grid::get_kappagrey(nonemptymgi), grey_optical_depth, globals::optical_depth_is_thick);
     grid::thick_allcells[nonemptymgi] = 1;
-  } else if (VPKT_ON && (grey_optical_depth > vpkt::cell_is_optically_thick_vpkt)) {
+  } else if (VPKT_ON && (grey_optical_depth > vpkt::optical_depth_is_thick_vpkt)) {
     grid::thick_allcells[nonemptymgi] = 2;
   } else {
     grid::thick_allcells[nonemptymgi] = 0;

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -723,16 +723,16 @@ void read_vpktparameterfile() {
                1e8 * CLIGHT / VSPEC_NUMIN_input[i]);
   }
 
-  // if dum7=1, vpkt are not created when cell optical depth is larger than cell_is_optically_thick_vpkt
+  // if dum7=1, vpkt are not created when cell optical depth is larger than optical_depth_is_thick_vpkt
   int override_thickcell_tau = 0;
-  assert_always(fscanf(input_file, "%d %lg \n", &override_thickcell_tau, &cell_is_optically_thick_vpkt) == 2);
+  assert_always(fscanf(input_file, "%d %lg \n", &override_thickcell_tau, &optical_depth_is_thick_vpkt) == 2);
 
   if (override_thickcell_tau == 1) {
-    printlnlog("vpkt.txt: cell_is_optically_thick_vpkt {:g}", cell_is_optically_thick_vpkt);
+    printlnlog("vpkt.txt: optical_depth_is_thick_vpkt {:g}", optical_depth_is_thick_vpkt);
   } else {
-    cell_is_optically_thick_vpkt = globals::cell_is_optically_thick;
-    printlnlog("vpkt.txt: cell_is_optically_thick_vpkt {:g} (inherited from cell_is_optically_thick)",
-               cell_is_optically_thick_vpkt);
+    optical_depth_is_thick_vpkt = globals::optical_depth_is_thick;
+    printlnlog("vpkt.txt: optical_depth_is_thick_vpkt {:g} (inherited from optical_depth_is_thick)",
+               optical_depth_is_thick_vpkt);
   }
 
   // Maximum optical depth. If a vpkt reaches dum7 is thrown away

--- a/vpkt.h
+++ b/vpkt.h
@@ -34,7 +34,7 @@ inline int nvpkt_esc_from_rpkt{0};  // electron scattering event
 inline int nvpkt_esc_from_kpkt{0};  // kpkt deactivation
 inline int nvpkt_esc_from_macroatom{0};  // macroatom deactivation
 
-inline double cell_is_optically_thick_vpkt;
+inline double optical_depth_is_thick_vpkt;
 }  // namespace vpkt
 
 #endif  // VPKT_H


### PR DESCRIPTION
Rename cell_is_optically_thick -> optical_depth_is_thick (and vpkt variant) for clarity and update all uses and input/log messages. Move nltepops_allcells declaration out of grid.h into nltepop.h and update all references to use the new symbol (remove grid:: qualifier). Replace the removed get_ionestimindex_nonemptymgi helper by explicit indexing into gamma/estimator arrays ((nonemptymgi * globals::nbfcontinua_ground) + get_groundcontindex(...)). Add [[gnu::pure]]/[[nodiscard]] to get_kappagrey and tidy its definition. Replace direct accesses to grid::rho_allcells with grid::get_rho where appropriate, and remove some now-unused includes. These changes improve naming consistency, encapsulation of NLTE data, and code clarity without changing runtime behavior.