### PR TITLE
Fix unsafe_buffer_usage on chi_bf_sum using subspan instead of iterator arithmetic

### DIFF
--- a/ltepop.cc
+++ b/ltepop.cc
@@ -1,16 +1,16 @@
 #include "ltepop.h"
 
-#pragma clang unsafe_buffer_usage begin
-#include <boost/math/tools/toms748_solve.hpp>
-#include <cstdint>
-#pragma clang unsafe_buffer_usage end
-
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <tuple>
 #include <vector>
+
+#pragma clang unsafe_buffer_usage begin
+#include <boost/math/tools/toms748_solve.hpp>
+#pragma clang unsafe_buffer_usage end
 
 #include "artisoptions.h"
 #include "atomic.h"

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -470,14 +470,12 @@ void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
     // Determine in which continuum the bf-absorption occurs
     const double chi_bf_rand = rng_uniform() * chi_bf_inrest;
 
-#pragma clang unsafe_buffer_usage begin
-    // NOLINTBEGIN(*-pointer-arithmetic)
     // first chi_bf_sum[i] such that chi_bf_sum[i] > chi_bf_rand
-    const auto allcontindex = std::upper_bound(phixslist.chi_bf_sum.begin() + phixslist.allcontbegin,
-                                               phixslist.chi_bf_sum.begin() + phixslist.allcontend - 1, chi_bf_rand) -
-                              phixslist.chi_bf_sum.begin();
-    // NOLINTEND(*-pointer-arithmetic)
-#pragma clang unsafe_buffer_usage end
+    const auto allcontindex =
+        std::ranges::upper_bound(
+            phixslist.chi_bf_sum.subspan(phixslist.allcontbegin, phixslist.allcontend - phixslist.allcontbegin),
+            chi_bf_rand) -
+        phixslist.chi_bf_sum.begin();
     assert_testmodeonly(allcontindex < phixslist.allcontend);
 
     const double nu_edge = globals::allcont.nu_edge[allcontindex];

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -470,13 +470,13 @@ void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
     // Determine in which continuum the bf-absorption occurs
     const double chi_bf_rand = rng_uniform() * chi_bf_inrest;
 
-    // first chi_bf_sum[i] such that chi_bf_sum[i] > chi_bf_rand
+    // first chi_bf_sum[i] such that chi_bf_sum[i] > chi_bf_rand (or the last one if chi_bf_rand is larger than all
+    // chi_bf_sum) gives the index of the continuum
     const auto allcontindex =
         std::ranges::upper_bound(
-            phixslist.chi_bf_sum.subspan(phixslist.allcontbegin, phixslist.allcontend - phixslist.allcontbegin),
+            phixslist.chi_bf_sum.subspan(phixslist.allcontbegin, phixslist.allcontend - phixslist.allcontbegin - 1),
             chi_bf_rand) -
         phixslist.chi_bf_sum.begin();
-    assert_testmodeonly(allcontindex < phixslist.allcontend);
 
     const double nu_edge = globals::allcont.nu_edge[allcontindex];
     const int element = globals::allcont.element[allcontindex];


### PR DESCRIPTION
Replace manual pointer-arithmetic upper_bound over a pointer range with std::ranges::upper_bound on a chi_bf_sum.subspan for the continuum selection. This removes the clang unsafe_buffer_usage and NOLINT pointer-arithmetic annotations and computes the resulting index by subtracting chi_bf_sum.begin(), keeping the original assert and behavior while using safer, modern C++ ranges.