### PR TITLE
Prevent false sharing of frequently-accessed thread-shared variables

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cstddef>
+#include <new>
 #include <numbers>
 #include <string_view>
 
@@ -132,6 +133,23 @@ constexpr bool cellcache_singleslot = true;
 #else
 #define EXEC_PAR_UNSEQ
 #define EXEC_PAR
+#endif
+
+#if defined(__cpp_lib_hardware_interference_size) && __cpp_lib_hardware_interference_size >= 201603
+constexpr std::size_t DESTRUCTIVE_INTERFERENCE_SIZE = std::hardware_destructive_interference_size;
+#else
+constexpr std::size_t DESTRUCTIVE_INTERFERENCE_SIZE = 64;
+#endif
+
+// Give a hot thread-shared accumulator variable its own cache line to prevent false sharing in the CPU multithreaded
+// modes (OpenMP or C++ standard parallelism on multicore). Expands to nothing in single-threaded (MPI-only) and GPU
+// modes, where the cache-line contention between host threads doesn't exist and padding would only waste memory.
+#if (defined(_OPENMP) || defined(STDPAR_ON)) && !defined(GPU_ON)
+constexpr bool align_to_avoid_false_sharing = true;
+#define ALIGNAS_AVOID_FALSE_SHARING alignas(DESTRUCTIVE_INTERFERENCE_SIZE)
+#else
+constexpr bool align_to_avoid_false_sharing = false;
+#define ALIGNAS_AVOID_FALSE_SHARING
 #endif
 
 #ifdef _OPENMP

--- a/globals.h
+++ b/globals.h
@@ -62,32 +62,40 @@ struct Element {
 
 namespace globals {
 
+// The *_discrete, *_emission, and pellet_decays members are accumulated atomically by all threads during packet
+// propagation, so they are cache-line aligned in CPU multithreaded modes to keep them from false sharing with each
+// other and with the constantly-read start/width/mid members.
 struct TimeStep {
   double start{0.};  // time at start of this timestep. [s]
   double width{0.};  // Width of timestep. [s]
   double mid{0.};  // Mid time in step - computed logarithmically. [s]
   double gamma_dep{0.};  // cmf gamma ray energy deposition from packet trajectories [erg]
-  double gamma_dep_discrete{0.};  // cmf gamma ray energy deposition from absorption events [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double gamma_dep_discrete{
+      0.};  // cmf gamma ray energy deposition from absorption events [erg]
   double positron_dep{0.};  // cmf positron energy deposition from packet trajectories [erg]
-  double positron_dep_discrete{0.};  // cmf positron energy deposition from absorption events [erg]
-  double positron_emission{0.};  // cmf positron KE energy generation [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double positron_dep_discrete{
+      0.};  // cmf positron energy deposition from absorption events [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double positron_emission{0.};  // cmf positron KE energy generation [erg]
   double eps_positron_ana_power{0.};  // cmf positron KE energy generation rate analytical [erg/s]
   double electron_dep{0.};  // cmf electron energy deposition from packet trajectories [erg]
-  double electron_dep_discrete{0.};  // cmf electron energy deposition from absorption events [erg]
-  double electron_emission{0.};  // cmf electron KE energy generation [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double electron_dep_discrete{
+      0.};  // cmf electron energy deposition from absorption events [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double electron_emission{0.};  // cmf electron KE energy generation [erg]
   double eps_electron_ana_power{0.};  // cmf electron KE energy generation rate analytical [erg/s]
   double alpha_dep{0.};  // cmf alpha energy deposition from packet trajectories [erg]
-  double alpha_dep_discrete{0.};  // cmf alpha energy deposition from absorption events [erg]
-  double alpha_emission{0.};  // cmf alpha KE energy generation [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double alpha_dep_discrete{
+      0.};  // cmf alpha energy deposition from absorption events [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double alpha_emission{0.};  // cmf alpha KE energy generation [erg]
   double eps_alpha_ana_power{0.};  // cmf alpha KE energy generation rate analytical [erg/s]
-  double spfission_dep_discrete{0.};  // cmf spontaneous fission energy deposition from absorption events [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double spfission_dep_discrete{
+      0.};  // cmf spontaneous fission energy deposition from absorption events [erg]
   double eps_spfission_ana_power{0.};  // cmf spontaneous fission energy generation rate analytical [erg/s]
-  double gamma_emission{0.};  // gamma decay energy generation in this timestep [erg]
+  ALIGNAS_AVOID_FALSE_SHARING double gamma_emission{0.};  // gamma decay energy generation in this timestep [erg]
   double qdot_betaminus{0.};  // energy generation from beta-minus decays (including neutrinos) [erg/s/g]
   double qdot_alpha{0.};  // energy generation from alpha decays (including neutrinos) [erg/s/g]
   double qdot_spfission{0.};  // energy generation from spontaneous fission decays (including neutrinos) [erg/s/g]
   double qdot_total{0.};  // energy generation from all decays (including neutrinos) [erg/s/g]
-  int pellet_decays{0};  // Number of pellets that decay in this time step.
+  ALIGNAS_AVOID_FALSE_SHARING int pellet_decays{0};  // Number of pellets that decay in this time step.
 };
 inline std::vector<TimeStep> timesteps;
 

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -535,15 +535,8 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
   std::abort();
 }
 
-namespace scoped_mutex_detail {
-#if defined(__cpp_lib_hardware_interference_size) && __cpp_lib_hardware_interference_size >= 201603
-inline constexpr std::size_t hardware_destructive_interference_size = std::hardware_destructive_interference_size;
-#else
-inline constexpr std::size_t hardware_destructive_interference_size = 64;
-#endif
-}  // namespace scoped_mutex_detail
-
-class alignas(scoped_mutex_detail::hardware_destructive_interference_size) PaddedMutex {
+// padded to a full cache line in CPU multithreaded modes so that adjacent mutexes in an array don't false share
+class ALIGNAS_AVOID_FALSE_SHARING PaddedMutex {
  private:
   int lock_{0};
 
@@ -559,10 +552,10 @@ class alignas(scoped_mutex_detail::hardware_destructive_interference_size) Padde
   }
 };
 
-static_assert(alignof(PaddedMutex) >= scoped_mutex_detail::hardware_destructive_interference_size);
-static_assert(alignof(PaddedMutex) % scoped_mutex_detail::hardware_destructive_interference_size == 0);
-static_assert(sizeof(PaddedMutex) >= scoped_mutex_detail::hardware_destructive_interference_size);
-static_assert(sizeof(PaddedMutex) % scoped_mutex_detail::hardware_destructive_interference_size == 0);
+static_assert(!align_to_avoid_false_sharing || alignof(PaddedMutex) >= DESTRUCTIVE_INTERFERENCE_SIZE);
+static_assert(!align_to_avoid_false_sharing || alignof(PaddedMutex) % DESTRUCTIVE_INTERFERENCE_SIZE == 0);
+static_assert(!align_to_avoid_false_sharing || sizeof(PaddedMutex) >= DESTRUCTIVE_INTERFERENCE_SIZE);
+static_assert(!align_to_avoid_false_sharing || sizeof(PaddedMutex) % DESTRUCTIVE_INTERFERENCE_SIZE == 0);
 
 class ScopedMutex {
  private:

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -161,7 +161,8 @@ constexpr auto rhsvec = []() {
 }();
 
 // Monte Carlo result - compare to analytical expectation
-double nt_energy_deposited = 0;
+// cache-line aligned because it is accumulated atomically by all threads during packet propagation
+ALIGNAS_AVOID_FALSE_SHARING double nt_energy_deposited = 0;
 
 struct NonThermalExcitation {
   double frac_deposition;  // the fraction of the non-thermal deposition energy going to the excitation transition

--- a/radfield.cc
+++ b/radfield.cc
@@ -707,8 +707,8 @@ DEVICE_FUNC void update_lineestimator(const int nonemptymgi, const int lineindex
 
   const int jblueindex = get_Jblueindex(lineindex);
   if (jblueindex >= 0) {
-    Jb_lu_raw[nonemptymgi][jblueindex].value += increment;
-    Jb_lu_raw[nonemptymgi][jblueindex].contribcount += 1;
+    atomicadd(Jb_lu_raw[nonemptymgi][jblueindex].value, increment);
+    atomicadd(Jb_lu_raw[nonemptymgi][jblueindex].contribcount, 1);
   }
 }
 

--- a/stats.cc
+++ b/stats.cc
@@ -30,7 +30,7 @@ std::array<EventCounter, static_cast<size_t>(Counter::COUNT)> eventstats{};
 DEVICE_FUNC void increment(const Counter i) { atomicadd(eventstats[std::to_underlying(i)].count, 1Z); }
 
 void pkt_action_counters_reset() {
-  std::ranges::fill(eventstats, EventCounter{});
+  std::ranges::fill(eventstats, EventCounter{0});
 
   nonthermal::reset_stats();
 }

--- a/stats.cc
+++ b/stats.cc
@@ -18,19 +18,24 @@ namespace stats {
 
 namespace {
 
-std::array<ptrdiff_t, static_cast<size_t>(Counter::COUNT)> eventstats{};
+// counters are frequently incremented by all threads, so give each one its own cache line to prevent false sharing
+struct EventCounter {
+  ALIGNAS_AVOID_FALSE_SHARING ptrdiff_t count{0};
+};
+
+std::array<EventCounter, static_cast<size_t>(Counter::COUNT)> eventstats{};
 
 }  // anonymous namespace
 
-DEVICE_FUNC void increment(const Counter i) { atomicadd(eventstats[std::to_underlying(i)], 1Z); }
+DEVICE_FUNC void increment(const Counter i) { atomicadd(eventstats[std::to_underlying(i)].count, 1Z); }
 
 void pkt_action_counters_reset() {
-  std::ranges::fill(eventstats, 0);
+  std::ranges::fill(eventstats, EventCounter{});
 
   nonthermal::reset_stats();
 }
 
-auto get_counter(const Counter i) -> ptrdiff_t { return eventstats[std::to_underlying(i)]; }
+auto get_counter(const Counter i) -> ptrdiff_t { return eventstats[std::to_underlying(i)].count; }
 
 void pkt_action_counters_printout(const int nts) {
   const double meaninteractions = static_cast<double>(get_counter(Counter::INTERACTIONS)) / MPKTS;

--- a/vpkt.h
+++ b/vpkt.h
@@ -27,10 +27,11 @@ constexpr double VSPEC_TIMEMAX = 8 * DAY;
 constexpr int VSPEC_TIMEBINS = 5;
 
 // number of virtual packets in a given timestep
-inline int nvpkt_created{0};
-inline int nvpkt_esc_from_rpkt{0};  // electron scattering event
-inline int nvpkt_esc_from_kpkt{0};  // kpkt deactivation
-inline int nvpkt_esc_from_macroatom{0};  // macroatom deactivation
+// separately cache-line aligned because they are incremented by all threads
+ALIGNAS_AVOID_FALSE_SHARING inline int nvpkt_created{0};
+ALIGNAS_AVOID_FALSE_SHARING inline int nvpkt_esc_from_rpkt{0};  // electron scattering event
+ALIGNAS_AVOID_FALSE_SHARING inline int nvpkt_esc_from_kpkt{0};  // kpkt deactivation
+ALIGNAS_AVOID_FALSE_SHARING inline int nvpkt_esc_from_macroatom{0};  // macroatom deactivation
 
 inline double optical_depth_is_thick_vpkt;
 }  // namespace vpkt


### PR DESCRIPTION
## Summary
This PR addresses false sharing issues in multithreaded CPU modes (OpenMP and C++ standard parallelism) by cache-line aligning frequently-accessed thread-shared variables that are atomically updated by all threads during packet propagation.

## Key Changes

- **Introduced cache-line alignment infrastructure** in `constants.h`:
  - Added `DESTRUCTIVE_INTERFERENCE_SIZE` constant (uses `std::hardware_destructive_interference_size` if available, defaults to 64 bytes)
  - Added `ALIGNAS_AVOID_FALSE_SHARING` macro that expands to `alignas(DESTRUCTIVE_INTERFERENCE_SIZE)` in CPU multithreaded modes and to nothing in single-threaded/GPU modes
  - Added `align_to_avoid_false_sharing` boolean flag to conditionally enable alignment only when needed

- **Applied cache-line alignment to hot variables**:
  - `globals.h`: Aligned discrete deposition, emission, and decay counter members in `TimeStep` struct
  - `mpi_logging.h`: Aligned `PaddedMutex` class and updated static assertions to be conditional
  - `stats.cc`: Wrapped counter array elements in `EventCounter` struct with aligned `count` member
  - `vpkt.h`: Aligned virtual packet creation counters
  - `nonthermal.cc`: Aligned `nt_energy_deposited` accumulator

- **Fixed thread-safety issues**:
  - `radfield.cc`: Changed non-atomic updates to `Jb_lu_raw` array elements to use `atomicadd()` for thread-safe accumulation

## Implementation Details

The alignment is only applied in CPU multithreaded modes (OpenMP or C++ standard parallelism) and not in GPU or MPI-only modes, where false sharing between host threads is not a concern and padding would waste memory. This is controlled by the `align_to_avoid_false_sharing` flag and the `ALIGNAS_AVOID_FALSE_SHARING` macro.

The `PaddedMutex` static assertions were updated to be conditional, allowing the class to maintain its alignment guarantees only when false-sharing avoidance is enabled.

https://claude.ai/code/session_01MQVrEjZp7pi8yNMRMiuGb1