### PR TITLE
Fix misleading comment and minor cleanups

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -889,6 +889,13 @@ void guttman_thermalisation(Packet& pkt) {
   }
   const double avg_column_density =
       std::accumulate(column_densities.cbegin(), column_densities.cend(), 0.) / std::ssize(column_densities);
+
+  if (avg_column_density <= 0.) {
+    // no material along any sampled direction, so the packet escapes without thermalising
+    absorb_or_escape_gamma(pkt, 0.);
+    return;
+  }
+
   const double t_gamma = sqrt(mean_gamma_opac * avg_column_density * t_0 * t_0);
 
   // compute the (discretized) integral

--- a/input.cc
+++ b/input.cc
@@ -335,7 +335,6 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
       const int upperion = upperionstage - get_ionstage(element, 0);
       const int lowerion = lowerionstage - get_ionstage(element, 0);
       const int lowerlevel = lowerlevel_in - groundstate_index_in;
-      assert_always(lowerionstage >= 0);
       assert_always(lowerlevel >= 0);
 
       // store only photoionisation crosssections for ions that are part of the current model atom

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -703,7 +703,7 @@ void zero_all_effionpot(const ptrdiff_t nonemptymgi) {
 }
 
 [[nodiscard]] constexpr auto get_energyindex_ev_gteq(const double energy_ev) -> int
-// finds the highest energy point <= energy_ev
+// finds the lowest energy point >= energy_ev
 {
   const int index = std::ceil((energy_ev - SF_EMIN) / DELTA_E);
 


### PR DESCRIPTION
Small correctness/robustness cleanups found while reviewing the code.

## Changes

- **`nonthermal.cc`** — `get_energyindex_ev_gteq()` carried a comment copy-pasted from `get_energyindex_ev_lteq()` ("finds the highest energy point <= energy_ev") that describes the *opposite* of what it does. The function uses `std::ceil` and its callers (e.g. the Auger loop bound, guarded by `assert_always(en < en_auger_ev)`) rely on it returning the lowest grid point `>= energy_ev`. Comment corrected; **no behaviour change**.

- **`gammapkt.cc`** — guard `guttman_thermalisation()` against `avg_column_density == 0`. If every sampled direction integrated to zero density, `column_densities[i] / avg_column_density` produced `0/0 = NaN`, which propagated into `f_gamma` and tripped `assert_always(f_gamma >= 0.)` inside `absorb_or_escape_gamma()`. The packet now escapes without thermalising (`f_gamma = 0`). Only affects a degenerate case that previously aborted.

- **`input.cc`** — remove a redundant `assert_always(lowerionstage >= 0)` in `read_phixs_file()`; `lowerionstage >= 1` is already asserted a few lines earlier, so this one can never fire.

## Impact

All three are behaviour-preserving on the normal path (comment-only, dead-assert removal, and a guard that only triggers in a case that previously crashed), so no test checksums should change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)