### PR TITLE
Add shared bin-index helpers to replace repeated cast idiom

### DIFF
--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -697,7 +697,7 @@ void zero_all_effionpot(const ptrdiff_t nonemptymgi) {
 [[nodiscard]] constexpr auto get_energyindex_ev_lteq(const double energy_ev) -> int
 // finds the highest energy point <= energy_ev
 {
-  const int index = std::floor((energy_ev - SF_EMIN) / DELTA_E);
+  const auto index = static_cast<int>(get_linearbinindex(energy_ev, SF_EMIN, DELTA_E));
 
   return std::clamp(index, 0, SFPTS - 1);
 }
@@ -713,9 +713,8 @@ void zero_all_effionpot(const ptrdiff_t nonemptymgi) {
 // interpolate the y flux values to get the value at a given energy
 // y has units of particles / cm2 / s / eV
 [[nodiscard]] constexpr auto get_y(const std::array<double, SFPTS>& yfunc, const double energy_ev) -> double {
-  // floor() so that energies below SF_EMIN give a negative index and return zero, instead of
-  // truncating toward zero and extrapolating below the first grid point
-  const int index = std::floor((energy_ev - SF_EMIN) / DELTA_E);
+  // energies below SF_EMIN give a negative index and return zero
+  const auto index = static_cast<int>(get_linearbinindex(energy_ev, SF_EMIN, DELTA_E));
 
   if (index < 0 || index >= (SFPTS - 1)) {
     return 0.;

--- a/radfield.cc
+++ b/radfield.cc
@@ -132,7 +132,7 @@ constexpr auto select_bin(const double nu) -> int {
     return RADFIELDBINCOUNT - 1;
   }
 
-  const int binindex = static_cast<int>((nu - RADFIELDBINS_NU_MIN) / radfieldbins_delta_nu);
+  const auto binindex = static_cast<int>(get_linearbinindex(nu, RADFIELDBINS_NU_MIN, radfieldbins_delta_nu));
 
   if (nu == get_bin_nu_upper(binindex)) {
     // exactly on the upper boundary of the bin, so add 1 to ensure we get the left-closed bin

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -23,6 +23,7 @@
 #include "packet.h"
 #include "radfield.h"
 #include "random.h"
+#include "sn3d.h"
 #include "stats.h"
 #include "vectors.h"
 #include "vpkt.h"
@@ -217,10 +218,9 @@ auto get_possible_event_expansion_opacity(const int nonemptymgi, Packet& pkt, co
   assert_always(get_cellcache(nonemptymgi).nonemptymgi == nonemptymgi);
   double dist = 0.;
   double tau = 0.;
-  // floor() before the cast, because truncation toward zero would put wavelengths up to one bin
-  // width below expopac_lambdamin into bin 0 instead of -1 (the continuum-only case)
-  const auto binindex_start = std::max(
-      static_cast<ptrdiff_t>(std::floor(((1e8 * CLIGHT / nu_cmf) - expopac_lambdamin) / expopac_deltalambda)), -1Z);
+  // -1 means below the wavelength grid, in which case there is continuum opacity but no expansion opacity
+  const auto binindex_start =
+      std::max(get_linearbinindex(1e8 * CLIGHT / nu_cmf, expopac_lambdamin, expopac_deltalambda), -1Z);
 
   for (auto binindex = binindex_start; binindex < expopac_nbins; binindex++) {
     // binindex could be -1, in which case we have only the continuum opacity and no expansion opacity

--- a/sn3d.h
+++ b/sn3d.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <csignal>
 #include <cstdarg>
 #include <cstddef>
@@ -70,6 +71,34 @@ constexpr void resize_exactly(std::vector<T>& vec, const size_t size) {
 template <double fractional_accuracy>
 inline auto ftol(const double a, const double b) -> bool {
   return std::abs(a - b) <= (fractional_accuracy * std::min(std::abs(a), std::abs(b)));
+}
+
+// Signed bin index of value on a grid spaced uniformly by binwidth, where bin 0 starts at minvalue.
+// Values below minvalue give negative indices and values past the last bin give indices >= nbins, so
+// the caller must range-check the result. Flooring matters here: a plain int cast would truncate toward
+// zero and misplace values up to one bin width below minvalue into bin 0.
+[[nodiscard]] constexpr auto get_linearbinindex(const double value, const double minvalue, const double binwidth)
+    -> ptrdiff_t {
+  const double fracindex = (value - minvalue) / binwidth;
+  // floor implemented with constexpr-legal operations (std::floor is not constant-evaluable on all
+  // of the supported standard libraries yet)
+  const auto truncated = static_cast<ptrdiff_t>(fracindex);
+  return (fracindex < static_cast<double>(truncated)) ? truncated - 1 : truncated;
+}
+
+static_assert(get_linearbinindex(1.5, 1., 1.) == 0);
+static_assert(get_linearbinindex(3., 1., 1.) == 2);
+static_assert(get_linearbinindex(1., 1., 1.) == 0);  // bins are left-closed
+static_assert(get_linearbinindex(0.5, 1., 1.) == -1);  // below the grid must not land in bin 0
+static_assert(get_linearbinindex(-5., 1., 2.) == -3);
+
+// Bin index of value on a grid of nbins bins spaced uniformly in the log of the value, where bin 0
+// starts at minvalue and each bin spans dlog in log space. The caller must ensure that value is within
+// the grid range (minvalue < value < maximum); the clamp only guards against floating-point rounding
+// placing an in-range value just outside [0, nbins-1].
+[[nodiscard]] inline auto get_logbinindex(const double value, const double minvalue, const double dlog,
+                                          const ptrdiff_t nbins) -> ptrdiff_t {
+  return std::clamp(static_cast<ptrdiff_t>(std::floor((std::log(value) - std::log(minvalue)) / dlog)), 0Z, nbins - 1);
 }
 
 #endif  // SN3D_H

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -567,7 +567,7 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra_I, Sp
     const auto nts = get_timestep(t_arrive);
 
     // a binary search into freq_lower would probably be faster than this double logarithm
-    const auto nnu = std::clamp(static_cast<ptrdiff_t>((log(pkt.nu_rf) - log(nu_min)) / dlognu), 0Z, MNUBINS - 1);
+    const auto nnu = get_logbinindex(pkt.nu_rf, nu_min, dlognu, MNUBINS);
 
     const double solidanglefactor = (dirbin >= 0) ? MABINS : 1.;
     const double deltaE = pkt.e_rf / globals::timesteps[nts].width / spectra_I.delta_freq[nnu] / 4.e12 / PI / PARSEC /
@@ -622,8 +622,7 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra_I, Sp
       }
 
       if (pkt.absorptionfreq > nu_min && pkt.absorptionfreq < nu_max) {
-        const auto nnu_abs =
-            std::clamp(static_cast<ptrdiff_t>((log(pkt.absorptionfreq) - log(nu_min)) / dlognu), 0Z, MNUBINS - 1);
+        const auto nnu_abs = get_logbinindex(pkt.absorptionfreq, nu_min, dlognu, MNUBINS);
         const double deltaE_absorption = pkt.e_rf / globals::timesteps[nts].width / spectra_I.delta_freq[nnu_abs] /
                                          4.e12 / PI / PARSEC / PARSEC / globals::nprocs_exspec * solidanglefactor;
         const int at = pkt.absorptiontype;

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -104,15 +104,12 @@ void add_to_vspecpol(const double nu_rf, const double e_rf, const double prob, c
                      const int obsdirindex, const int opachoiceindex, const double t_arrive) {
   // Need to decide in which (1) time and (2) frequency bin the vpkt is escaping
 
-  // range-check the doubles before casting, because the int cast truncates toward zero and would
-  // otherwise put values up to one bin width below the minimum into bin 0
   if (t_arrive <= VSPEC_TIMEMIN || t_arrive >= VSPEC_TIMEMAX || nu_rf <= VSPEC_NUMIN || nu_rf >= VSPEC_NUMAX) {
     return;
   }
 
-  const int nt =
-      std::clamp(static_cast<int>((log(t_arrive) - log(VSPEC_TIMEMIN)) / dlogt_vspec), 0, VSPEC_TIMEBINS - 1);
-  const int nnu = std::clamp(static_cast<int>((log(nu_rf) - log(VSPEC_NUMIN)) / dlognu_vspec), 0, VSPEC_NUBINS - 1);
+  const auto nt = static_cast<int>(get_logbinindex(t_arrive, VSPEC_TIMEMIN, dlogt_vspec, VSPEC_TIMEBINS));
+  const auto nnu = static_cast<int>(get_logbinindex(nu_rf, VSPEC_NUMIN, dlognu_vspec, VSPEC_NUBINS));
 
   const int ind_comb = (nspectraperobsdir * obsdirindex) + opachoiceindex;
   const double pktcontrib = e_rf / vspecpol[nt][ind_comb].delta_t / delta_freq_vspec[nnu] / 4.e12 / PI / PARSEC /
@@ -310,11 +307,9 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
         return true;
       };
       if constexpr (VPKT_USE_EXPANSION_OPACITIES) {
-        // floor() before the cast, because truncation toward zero would put wavelengths up to one bin
-        // width below expopac_lambdamin into bin 0 instead of -1 (the continuum-only case)
-        const auto binindex_start = std::max(
-            static_cast<ptrdiff_t>(std::floor(((1e8 * CLIGHT / nu_cmf) - expopac_lambdamin) / expopac_deltalambda)),
-            -1Z);
+        // -1 means below the wavelength grid, in which case there is continuum opacity but no expansion opacity
+        const auto binindex_start =
+            std::max(get_linearbinindex(1e8 * CLIGHT / nu_cmf, expopac_lambdamin, expopac_deltalambda), -1Z);
 
         if (binindex_start < expopac_nbins) {
           // trace line-by-line from nu_cmf to the next bin edge, because the expansion opacity bin at nu_cmf includes


### PR DESCRIPTION
## What changed

Adds two small grid bin-index helpers to `sn3d.h` and migrates the existing call sites to use them:

- **`get_linearbinindex(value, minvalue, binwidth)`** — signed, floored bin index for uniform grids. `constexpr`, with `static_assert` tests covering the boundary and below-grid cases.
- **`get_logbinindex(value, minvalue, dlog, nbins)`** — clamped bin index for log-uniform grids, preserving the exact `(log(v) - log(min)) / dlog` expression used by the call sites.

Migrated sites:
- `spectrum_lightcurve.cc` — flux and absorption frequency bins in `add_to_spec_res()`
- `vpkt.cc` — vspecpol time and frequency bins, expansion-opacity wavelength bin
- `rpkt.cc` — expansion-opacity wavelength bin
- `nonthermal.cc` — Spencer-Fano energy grid (`get_energyindex_ev_lteq()`, `get_y()`)
- `radfield.cc` — bin lookup in `select_bin()`

## Why

The idiom `static_cast<int>((value - min) / delta)` truncates toward zero, so values up to one bin width *below* the grid minimum silently land in bin 0 instead of a negative index. This bug class existed independently at several sites and was recently fixed one at a time (a2a0405a, 8717f0e2). A shared helper with compile-time tests removes the class permanently instead of relying on each new call site remembering to `floor()` first.

## Notes for review

- **Bit-identical to develop**: every migrated site either already floored or is guarded so the quotient is non-negative (where floor equals truncation), and the floating-point expressions are unchanged. Test checksums should be unaffected — CI passing unchanged is the verification.
- `get_linearbinindex()` implements floor with constexpr-legal truncate-and-correct operations because `std::floor` is not constant-evaluable on all supported standard libraries yet (fails on Apple libc++ under the `static_assert`s).
- Deliberately *not* migrated: `atomic.h:231` (needs the fractional position for interpolation), `atomic.h:216` (bit-compat classic-mode branch, callers guarantee `nu >= nu_edge`), and the escape-direction bins in `vectors.h` (different FP expression shape — rewriting would change rounding and churn every checksum for no benefit).
- `rpkt.cc` gains an `#include "sn3d.h"`; `sn3d.h` gains `<cmath>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)