### PR TITLE
Add decay Q-values for default nuclides

### DIFF
--- a/decay.cc
+++ b/decay.cc
@@ -781,8 +781,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().endecay_positron = 0.354 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.436;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.436;
-  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = 3.261697 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 3.261697 * MEV;
+const double q_ec = 3.261697 * MEV;
+nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
+nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Ni56
   nuclides.push_back({.z = 28, .a = 56, .meanlife = 8.80 * DAY});
@@ -794,8 +795,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().endecay_positron = 0.63 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.19;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1 - 0.19;
-  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = 4.566645 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 4.566645 * MEV;
+const double q_ec = 4.566645 * MEV;
+nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
+nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Cr48
   nuclides.push_back({.z = 24, .a = 48, .meanlife = 1.29602 * DAY});
@@ -807,8 +809,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.499;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.499;
   nuclides.back().endecay_positron = 0.290 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = 4.014947 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 4.014947 * MEV;
+const double q_ec = 4.014947 * MEV;
+nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
+nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Co57
   nuclides.push_back({.z = 27, .a = 57, .meanlife = 392.03 * DAY});

--- a/decay.cc
+++ b/decay.cc
@@ -781,9 +781,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().endecay_positron = 0.354 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.436;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.436;
-  const double q_ec = 3.261697 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
-  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
+  const double ni57_q_ec = 3.261697 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = ni57_q_ec;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = ni57_q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Ni56
   nuclides.push_back({.z = 28, .a = 56, .meanlife = 8.80 * DAY});
@@ -795,9 +795,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().endecay_positron = 0.63 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.19;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1 - 0.19;
-  const double q_ec = 4.566645 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
-  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
+  const double co56_q_ec = 4.566645 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = co56_q_ec;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = co56_q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Cr48
   nuclides.push_back({.z = 24, .a = 48, .meanlife = 1.29602 * DAY});
@@ -809,9 +809,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.499;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.499;
   nuclides.back().endecay_positron = 0.290 * MEV;
-  const double q_ec = 4.014947 * MEV;
-  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
-  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
+  const double v48_q_ec = 4.014947 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = v48_q_ec;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = v48_q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Co57
   nuclides.push_back({.z = 27, .a = 57, .meanlife = 392.03 * DAY});

--- a/decay.cc
+++ b/decay.cc
@@ -781,9 +781,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().endecay_positron = 0.354 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.436;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.436;
-const double q_ec = 3.261697 * MEV;
-nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
-nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
+  const double q_ec = 3.261697 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Ni56
   nuclides.push_back({.z = 28, .a = 56, .meanlife = 8.80 * DAY});
@@ -795,9 +795,9 @@ nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED)
   nuclides.back().endecay_positron = 0.63 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.19;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1 - 0.19;
-const double q_ec = 4.566645 * MEV;
-nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
-nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
+  const double q_ec = 4.566645 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Cr48
   nuclides.push_back({.z = 24, .a = 48, .meanlife = 1.29602 * DAY});
@@ -809,9 +809,9 @@ nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED)
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.499;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.499;
   nuclides.back().endecay_positron = 0.290 * MEV;
-const double q_ec = 4.014947 * MEV;
-nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
-nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
+  const double q_ec = 4.014947 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = q_ec;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = q_ec - (2. * ME * CLIGHTSQUARED);
 
   // Co57
   nuclides.push_back({.z = 27, .a = 57, .meanlife = 392.03 * DAY});

--- a/decay.cc
+++ b/decay.cc
@@ -781,38 +781,49 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.back().endecay_positron = 0.354 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.436;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.436;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = 3.261697 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 3.261697 * MEV;
 
   // Ni56
   nuclides.push_back({.z = 28, .a = 56, .meanlife = 8.80 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1.;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 2.132869 * MEV;
 
   // Co56
   nuclides.push_back({.z = 27, .a = 56, .meanlife = 113.7 * DAY});
   nuclides.back().endecay_positron = 0.63 * MEV;
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.19;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1 - 0.19;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = 4.566645 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 4.566645 * MEV;
 
   // Cr48
   nuclides.push_back({.z = 24, .a = 48, .meanlife = 1.29602 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1.;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 1.656692 * MEV;
 
   // V48
   nuclides.push_back({.z = 23, .a = 48, .meanlife = 23.0442 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_BETAPLUS] = 0.499;
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1. - 0.499;
   nuclides.back().endecay_positron = 0.290 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_BETAPLUS] = 4.014947 * MEV;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 4.014947 * MEV;
 
   // Co57
   nuclides.push_back({.z = 27, .a = 57, .meanlife = 392.03 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1.;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 0.836359 * MEV;
 
   // Fe52
   nuclides.push_back({.z = 26, .a = 52, .meanlife = 0.497429 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1.;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 2.001543 * MEV;
 
   // Mn52
   nuclides.push_back({.z = 25, .a = 52, .meanlife = 0.0211395 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1.;
+  nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 5.085870 * MEV;
 
   const auto standard_nuclides = nuclides;
 

--- a/tests/classicmode_1d_3dgrid_inputfiles/results_md5_final.txt
+++ b/tests/classicmode_1d_3dgrid_inputfiles/results_md5_final.txt
@@ -1,7 +1,7 @@
 720460f61e4679a3742b610a39cc96e5  absorption.out
 0167803b4d8071d4e822a0637b314d16  absorptionpol.out
 c0604236aa7df99cda43e5c7bbe7b6f4  bflist.out
-ee99d46171a66314cfe33512b78c0a9c  deposition.out
+9ba547b399c3f88706e45c51fc8c2007  deposition.out
 dc4a9539fedc191c3f5733d0fc8b84ad  emission.out
 718af39f55b4b48707804e544a6fe693  emissionpol.out
 033a9a9dad7b136c70bfc9b7ad0e62a7  emissiontrue.out

--- a/tests/classicmode_1d_3dgrid_inputfiles/results_md5_final.txt
+++ b/tests/classicmode_1d_3dgrid_inputfiles/results_md5_final.txt
@@ -1,7 +1,7 @@
 720460f61e4679a3742b610a39cc96e5  absorption.out
 0167803b4d8071d4e822a0637b314d16  absorptionpol.out
 c0604236aa7df99cda43e5c7bbe7b6f4  bflist.out
-20488327baabbfb3a84f01aa702a656d  deposition.out
+ee99d46171a66314cfe33512b78c0a9c  deposition.out
 dc4a9539fedc191c3f5733d0fc8b84ad  emission.out
 718af39f55b4b48707804e544a6fe693  emissionpol.out
 033a9a9dad7b136c70bfc9b7ad0e62a7  emissiontrue.out

--- a/tests/classicmode_1d_3dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/classicmode_1d_3dgrid_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 50b9f7d56a9043dc93401ade3394c615  absorption.out
 c0604236aa7df99cda43e5c7bbe7b6f4  bflist.out
-ab9f6432e846af40bf63fbe2cb4c5052  deposition.out
+7f4ec4424a9424fedb981ae343328fbb  deposition.out
 a1207970e0eb48483f0292427183e7f0  emission.out
 7e898fe3ad5b42313e6c3c77355372a5  emissiontrue.out
 e823ffee05a72430b7b18ea7d0c2fcde  gamma_light_curve.out

--- a/tests/classicmode_1d_3dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/classicmode_1d_3dgrid_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 50b9f7d56a9043dc93401ade3394c615  absorption.out
 c0604236aa7df99cda43e5c7bbe7b6f4  bflist.out
-7f4ec4424a9424fedb981ae343328fbb  deposition.out
+024a27ff6c7dd17f6ea13217449dd4a2  deposition.out
 a1207970e0eb48483f0292427183e7f0  emission.out
 7e898fe3ad5b42313e6c3c77355372a5  emissiontrue.out
 e823ffee05a72430b7b18ea7d0c2fcde  gamma_light_curve.out

--- a/tests/classicmode_3d_inputfiles/results_md5_final.txt
+++ b/tests/classicmode_3d_inputfiles/results_md5_final.txt
@@ -1,7 +1,7 @@
 c2cb0af299e98805434994a22dc82e28  absorption.out
 26cad4454f136c5d313e85dad544bba9  absorptionpol.out
 9cbb3a257dd95b6b3dd92d1d7d913e6c  bflist.out
-2e6675f73d4426594d756f184a40d589  deposition.out
+9e0a08fe673d5453874864c45dbf9a25  deposition.out
 fb1fb642f4b4b54ae0cda4a5990ed5ec  emission.out
 039c09bd1bb9ab818870fb32053f3407  emissionpol.out
 da69071f99dfe2dae04161311799521a  emissiontrue.out

--- a/tests/classicmode_3d_inputfiles/results_md5_final.txt
+++ b/tests/classicmode_3d_inputfiles/results_md5_final.txt
@@ -1,7 +1,7 @@
 c2cb0af299e98805434994a22dc82e28  absorption.out
 26cad4454f136c5d313e85dad544bba9  absorptionpol.out
 9cbb3a257dd95b6b3dd92d1d7d913e6c  bflist.out
-9e0a08fe673d5453874864c45dbf9a25  deposition.out
+cf58e4e3888f80358968e7392774ec6a  deposition.out
 fb1fb642f4b4b54ae0cda4a5990ed5ec  emission.out
 039c09bd1bb9ab818870fb32053f3407  emissionpol.out
 da69071f99dfe2dae04161311799521a  emissiontrue.out

--- a/tests/classicmode_3d_inputfiles/results_md5_job0.txt
+++ b/tests/classicmode_3d_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 5f1161041ac8efecc19b48f53d17ad80  absorption.out
 9cbb3a257dd95b6b3dd92d1d7d913e6c  bflist.out
-998f77fb33d5d3738a72525d1e993d05  deposition.out
+811992c006dc364822494104588122f6  deposition.out
 164b6b997ca7776ea343b3d412a8e9cf  emission.out
 be5a03bf2fd379fc73ec03b89a0c196c  emissiontrue.out
 0276e19a222ca8d8c343ecc16f983dc5  gamma_light_curve.out

--- a/tests/classicmode_3d_inputfiles/results_md5_job0.txt
+++ b/tests/classicmode_3d_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 5f1161041ac8efecc19b48f53d17ad80  absorption.out
 9cbb3a257dd95b6b3dd92d1d7d913e6c  bflist.out
-811992c006dc364822494104588122f6  deposition.out
+018d0d85f4f046828f8efc08adbc06ea  deposition.out
 164b6b997ca7776ea343b3d412a8e9cf  emission.out
 be5a03bf2fd379fc73ec03b89a0c196c  emissiontrue.out
 0276e19a222ca8d8c343ecc16f983dc5  gamma_light_curve.out

--- a/tests/kilonova_1d_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_1d_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 360b1d4cb1291cb793cbba3911461198  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-f8c4c796a275174f471c96b70ad657e1  deposition.out
+c54233aeb25341644d8be743cfebe585  deposition.out
 bc2a166881d9c9ae2c37dbfd185287b6  emission.out
 e488892a663f4601000d0fdd00dd7d70  emissiontrue.out
 ffb4284fc746264a43ce59c7a9cbba9e  gamma_light_curve.out

--- a/tests/kilonova_1d_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_1d_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 360b1d4cb1291cb793cbba3911461198  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-06219edb248acf467236c946bbea5cfb  deposition.out
+f8c4c796a275174f471c96b70ad657e1  deposition.out
 bc2a166881d9c9ae2c37dbfd185287b6  emission.out
 e488892a663f4601000d0fdd00dd7d70  emissiontrue.out
 ffb4284fc746264a43ce59c7a9cbba9e  gamma_light_curve.out

--- a/tests/kilonova_1d_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_1d_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 056a69b7aa3d53a4ad316890c57e5575  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-34fd0470d6a4a0197eef0be4ccc9a830  deposition.out
+b91590c489703fa199683bb2745edf93  deposition.out
 5053a3325e5890036bae64fd4066ebb3  emission.out
 ceab4edbda13da21e96d7231ea4bb391  emissiontrue.out
 72d54cb832603187ac91c06859a50570  gamma_light_curve.out

--- a/tests/kilonova_1d_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_1d_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 056a69b7aa3d53a4ad316890c57e5575  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-b91590c489703fa199683bb2745edf93  deposition.out
+d713e7004f9ede3e1aa3000d3f79ab09  deposition.out
 5053a3325e5890036bae64fd4066ebb3  emission.out
 ceab4edbda13da21e96d7231ea4bb391  emissiontrue.out
 72d54cb832603187ac91c06859a50570  gamma_light_curve.out

--- a/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 a4d7582a62cf48ed97733d81916f5134  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-fd1f762a1f1826ed579eb01769a2e6de  deposition.out
+cb57dbcab7ac545abf11d522fe8fa842  deposition.out
 155e1cda3fe0d5725d8c788b997242c5  emission.out
 00f40bf7928ed71a92a6d6d11975fc78  emissiontrue.out
 93ba28a1d281bb48999cc80be47356e7  gamma_light_curve.out

--- a/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 a4d7582a62cf48ed97733d81916f5134  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-d71a34c5663a8ca04c43a10000c2bc91  deposition.out
+fd1f762a1f1826ed579eb01769a2e6de  deposition.out
 155e1cda3fe0d5725d8c788b997242c5  emission.out
 00f40bf7928ed71a92a6d6d11975fc78  emissiontrue.out
 93ba28a1d281bb48999cc80be47356e7  gamma_light_curve.out

--- a/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_job0.txt
@@ -1,5 +1,5 @@
 897316929176464ebc9ad085f31e7284  bflist.out
-4b78dd82d701a942955cd2837ea4e563  deposition.out
+da86d45d121e95d449d5d6b052925b10  deposition.out
 e8184231da559af4b3126c81608654fc  gamma_light_curve.out
 3f5bfe0a49e6832660967ad0090c8789  gammalinelist.out
 29ac1cb06f3139df7cbca0bbdb426e1c  grid.out

--- a/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_job0.txt
@@ -1,5 +1,5 @@
 897316929176464ebc9ad085f31e7284  bflist.out
-457b30e31a5b6a9cfce4eb62e2994819  deposition.out
+4b78dd82d701a942955cd2837ea4e563  deposition.out
 e8184231da559af4b3126c81608654fc  gamma_light_curve.out
 3f5bfe0a49e6832660967ad0090c8789  gammalinelist.out
 29ac1cb06f3139df7cbca0bbdb426e1c  grid.out

--- a/tests/kilonova_2d_expansionopac_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_expansionopac_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 c3c0d55a0472ab5d62a76c24ef614918  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-a4992177c05f9f3b36db98d4b7bb9db6  deposition.out
+22921a4965fd97c02bb0ac5febe327ce  deposition.out
 20462b75566609b422ac8dcf60458bb2  emission.out
 321ece2a7759b37a7da621cd7a4eee90  emissiontrue.out
 e11a3881ed4b24a495a54669edba6a0c  gamma_light_curve.out

--- a/tests/kilonova_2d_expansionopac_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_expansionopac_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 c3c0d55a0472ab5d62a76c24ef614918  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-8c2f68d587fb3c12121d85b3f444f5bd  deposition.out
+a4992177c05f9f3b36db98d4b7bb9db6  deposition.out
 20462b75566609b422ac8dcf60458bb2  emission.out
 321ece2a7759b37a7da621cd7a4eee90  emissiontrue.out
 e11a3881ed4b24a495a54669edba6a0c  gamma_light_curve.out

--- a/tests/kilonova_2d_expansionopac_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_expansionopac_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 0fe358e0cec80c0ab1852d2e5a9147a1  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-280dd1e44a8f2548325e22c31b2e2939  deposition.out
+1210d3e90a0ecdb646092eb4fe248ba5  deposition.out
 fe621c0177ac652fe49fb4fcfa584407  emission.out
 f5902ae8e529c0e852df6b3614fd1597  emissiontrue.out
 c9f5f6beb93b1de3feca20bb084509a1  gamma_light_curve.out

--- a/tests/kilonova_2d_expansionopac_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_expansionopac_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 0fe358e0cec80c0ab1852d2e5a9147a1  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-1210d3e90a0ecdb646092eb4fe248ba5  deposition.out
+33ae8fbc912e8724dd86e22d60cd2c10  deposition.out
 fe621c0177ac652fe49fb4fcfa584407  emission.out
 f5902ae8e529c0e852df6b3614fd1597  emissiontrue.out
 c9f5f6beb93b1de3feca20bb084509a1  gamma_light_curve.out

--- a/tests/kilonova_2d_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 03fe75f2cdd1fa2e3707c3cc2973446a  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-ba7815af46ae985211e5bee889ecc57f  deposition.out
+4dadbbf62e41b6616216d45d71608abe  deposition.out
 b7c8656992d024f11e6e688b1cf48be1  emission.out
 52190a7969f9539ccf3778ee610ae32d  emissiontrue.out
 14cfc2703bcd8c1f20de03c05df92e5c  gamma_light_curve.out

--- a/tests/kilonova_2d_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 03fe75f2cdd1fa2e3707c3cc2973446a  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-4dadbbf62e41b6616216d45d71608abe  deposition.out
+0ab0a507c917417df9e26c0bd1354127  deposition.out
 b7c8656992d024f11e6e688b1cf48be1  emission.out
 52190a7969f9539ccf3778ee610ae32d  emissiontrue.out
 14cfc2703bcd8c1f20de03c05df92e5c  gamma_light_curve.out

--- a/tests/kilonova_2d_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_inputfiles/results_md5_job0.txt
@@ -1,5 +1,5 @@
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-900dcd856d11ecf5fef7a71d94519f7f  deposition.out
+4588e8fa2308728dabe47e37b6e6f7ef  deposition.out
 0fa4abe523979ab8d7bf264eeb326638  gamma_light_curve.out
 3f5bfe0a49e6832660967ad0090c8789  gammalinelist.out
 29ac1cb06f3139df7cbca0bbdb426e1c  grid.out

--- a/tests/kilonova_2d_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_inputfiles/results_md5_job0.txt
@@ -1,5 +1,5 @@
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-8b9f415b5fbdab13412e5fc9522378aa  deposition.out
+900dcd856d11ecf5fef7a71d94519f7f  deposition.out
 0fa4abe523979ab8d7bf264eeb326638  gamma_light_curve.out
 3f5bfe0a49e6832660967ad0090c8789  gammalinelist.out
 29ac1cb06f3139df7cbca0bbdb426e1c  grid.out

--- a/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 793ebff120a80bdd74c6f445c026a019  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-6c4d6c5fb20dec55787267301a3d289c  deposition.out
+88abf61beea0ca1fa29e89f5a729634f  deposition.out
 7535223a225e73201e353c2d0b2e850b  emission.out
 64a6f03f6eb860497fd37a6966721cae  emissiontrue.out
 331c456b0765a1da1a2f424d56e177bb  gamma_light_curve.out

--- a/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 793ebff120a80bdd74c6f445c026a019  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-169ad96771aeef26763f14abe115aac5  deposition.out
+6c4d6c5fb20dec55787267301a3d289c  deposition.out
 7535223a225e73201e353c2d0b2e850b  emission.out
 64a6f03f6eb860497fd37a6966721cae  emissiontrue.out
 331c456b0765a1da1a2f424d56e177bb  gamma_light_curve.out

--- a/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 86c1e58d71e892a904a0003a4e1231d7  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-3648302b47612d7661d572f6badae671  deposition.out
+82a4684925da6d6f6a91828a9e054fb3  deposition.out
 90064f820495cb6a3ebac2073f408abf  emission.out
 a128486eada880753f6c23d52445d3ab  emissiontrue.out
 e209cc2811b0f4f4c32554ed5d2a647d  gamma_light_curve.out

--- a/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 86c1e58d71e892a904a0003a4e1231d7  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-82a4684925da6d6f6a91828a9e054fb3  deposition.out
+99f41f00b247ddc32544e0cf1343b949  deposition.out
 90064f820495cb6a3ebac2073f408abf  emission.out
 a128486eada880753f6c23d52445d3ab  emissiontrue.out
 e209cc2811b0f4f4c32554ed5d2a647d  gamma_light_curve.out

--- a/tests/nebular_1d_3dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 b063b3ef77fa5fbd8785691357d643cb  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-dfdeb73f4f6ec889bb1829c095edfb0a  deposition.out
+497735c110b3002aba0cdac0c5bc2ee9  deposition.out
 8b55b95db5d185b0ee22ad175908d3d9  emission.out
 1bd636277e92b605d255fffce646dfd0  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 b063b3ef77fa5fbd8785691357d643cb  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-497735c110b3002aba0cdac0c5bc2ee9  deposition.out
+2dd6ddaaef350f9b7859b6e954b4a3fb  deposition.out
 8b55b95db5d185b0ee22ad175908d3d9  emission.out
 1bd636277e92b605d255fffce646dfd0  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 f0ae020ee730f8b1f2b40e4126a82b1e  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-d24dca8f4fa4d77c9b08fb4d3524d3e9  deposition.out
+567c963f3d98dc844e227b017b8bd3a9  deposition.out
 20d93a306d1e5ff290918d5e1dd48fdc  emission.out
 a8eed00cb8fb6a779997259f79bdc11c  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 f0ae020ee730f8b1f2b40e4126a82b1e  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-567c963f3d98dc844e227b017b8bd3a9  deposition.out
+4a4545a0f4a6c14b6cb917dd074ed18e  deposition.out
 20d93a306d1e5ff290918d5e1dd48fdc  emission.out
 a8eed00cb8fb6a779997259f79bdc11c  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_final.txt
+++ b/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 f3dbb4063d5e87cb8cadc86cafdc0e62  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-bbd852338bca08ca92fa49a05417c9cd  deposition.out
+8070cee9ff60b6216895e07f02a94378  deposition.out
 3fbc31b3fe4519b2b12fc96df33c67cc  emission.out
 7fce731f61acd345271b0dcdccfa33d2  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_final.txt
+++ b/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 f3dbb4063d5e87cb8cadc86cafdc0e62  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-cea2096ac852cbd6c7dd1434d77c6b6a  deposition.out
+bbd852338bca08ca92fa49a05417c9cd  deposition.out
 3fbc31b3fe4519b2b12fc96df33c67cc  emission.out
 7fce731f61acd345271b0dcdccfa33d2  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_job0.txt
+++ b/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 49f5619d555bcc13b625cfb1b5dfa7b8  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-aaed686ce3e74240c1bc4e14ae43ed5b  deposition.out
+9f0a50685b9c84c0a74fd98981c7a8c5  deposition.out
 dde9d0c7a64bde094fd5f0eed8adac4d  emission.out
 47f2ada2a0fcd442583c76aad76c3133  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_job0.txt
+++ b/tests/nebular_1d_3dgrid_limitbfest_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 49f5619d555bcc13b625cfb1b5dfa7b8  absorption.out
 aff44ecad68d986f04fcd6110331ba8b  bflist.out
-98104543818076206920665b601967b2  deposition.out
+aaed686ce3e74240c1bc4e14ae43ed5b  deposition.out
 dde9d0c7a64bde094fd5f0eed8adac4d  emission.out
 47f2ada2a0fcd442583c76aad76c3133  emissiontrue.out
 20dadbc26e8f98511b3a587798c9e190  gammalinelist.out

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 ddb5021168575ac79ab0857a4d611f37  absorption.out
 c19a7bda729842c067cc2b27d0caab91  bflist.out
-1e7ec24c135fbbb97f9390fa83b39da6  deposition.out
+73f025b0571e69c0132c470ae3e1b4b4  deposition.out
 ff524844b4b87b33db9e8340a895f7f2  emission.out
 ff524844b4b87b33db9e8340a895f7f2  emissiontrue.out
 8f79eb586838373f605460f614fe600d  gamma_light_curve.out

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 ddb5021168575ac79ab0857a4d611f37  absorption.out
 c19a7bda729842c067cc2b27d0caab91  bflist.out
-d35b97f2fc6bec8f0c0a1d0f0d391f0b  deposition.out
+1e7ec24c135fbbb97f9390fa83b39da6  deposition.out
 ff524844b4b87b33db9e8340a895f7f2  emission.out
 ff524844b4b87b33db9e8340a895f7f2  emissiontrue.out
 8f79eb586838373f605460f614fe600d  gamma_light_curve.out

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 af6da5dbd7183d8357f8c79f7f59accd  absorption.out
 c19a7bda729842c067cc2b27d0caab91  bflist.out
-da9720e20f169b0070820392c2ba723b  deposition.out
+78de89706761737c3083499431246b73  deposition.out
 910e6e4c779a2ffe2647e09a60bf39fd  emission.out
 910e6e4c779a2ffe2647e09a60bf39fd  emissiontrue.out
 ea93edba8172bf36d66c474d0332a828  gamma_light_curve.out

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 af6da5dbd7183d8357f8c79f7f59accd  absorption.out
 c19a7bda729842c067cc2b27d0caab91  bflist.out
-99ab7d8f1b9b8d3f4fdbf59f928ab513  deposition.out
+da9720e20f169b0070820392c2ba723b  deposition.out
 910e6e4c779a2ffe2647e09a60bf39fd  emission.out
 910e6e4c779a2ffe2647e09a60bf39fd  emissiontrue.out
 ea93edba8172bf36d66c474d0332a828  gamma_light_curve.out


### PR DESCRIPTION
Populate `endecay_q` for the built-in Ni57, Ni56, Co56, Cr48, V48, Co57, Fe52, and Mn52 entries in `init_nuclides`. This aligns beta-plus/electron-capture branch data with explicit total decay Q-values so downstream decay-energy calculations can use complete per-channel inputs.