### PR TITLE
Define enum values for negative absorptiontype numbers

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -419,7 +419,7 @@ void compton_scatter(Packet& pkt) {
     } else {
       pkt.type = TYPE_NTLEPTON_DEPOSITED;
     }
-    pkt.absorptiontype = -3;
+    pkt.absorptiontype = ABSTYPE_GAMMA_COMPTON;
     stats::increment(stats::Counter::NT_STAT_FROM_GAMMA);
   }
 }
@@ -664,7 +664,7 @@ void pair_production(Packet& pkt) {
       pkt.type = TYPE_NTLEPTON_DEPOSITED;
     }
 
-    pkt.absorptiontype = -5;
+    pkt.absorptiontype = ABSTYPE_GAMMA_PAIRPRODUCTION;
     stats::increment(stats::Counter::NT_STAT_FROM_GAMMA);
   } else {
     // The energy goes into emission at 511 keV.
@@ -765,7 +765,7 @@ void transport_gamma(Packet& pkt, const double t2) {
         pkt.type = TYPE_NTLEPTON_DEPOSITED;
       }
 
-      pkt.absorptiontype = -4;
+      pkt.absorptiontype = ABSTYPE_GAMMA_PHOTOELECTRIC;
       stats::increment(stats::Counter::NT_STAT_FROM_GAMMA);
     } else {
       // It's a pair production
@@ -785,7 +785,7 @@ void absorb_or_escape_gamma(Packet& pkt, const double f_gamma) {
   if (rng_uniform(get_rngstate(pkt)) < f_gamma) {
     // packet is absorbed and contributes to the heating as a k-packet
     pkt.type = TYPE_NTLEPTON_DEPOSITED;
-    pkt.absorptiontype = -4;
+    pkt.absorptiontype = ABSTYPE_GAMMA_PHOTOELECTRIC;
   } else {
     // let packet escape, i.e. make it inactive. change_cell_or_escape() records pkt.escape_type = pkt.type
     // before setting the type to TYPE_ESCAPE, so leave pkt.type as TYPE_GAMMA here so the escaped gamma is
@@ -926,7 +926,7 @@ DEVICE_FUNC void pellet_gamma_decay(Packet& pkt) {
   // if no gamma spectra is known, then convert straight to kpkts (e.g., Fe52, Mn52)
   if (pkt.nu_cmf < 0) {
     pkt.type = TYPE_KPKT;
-    pkt.absorptiontype = -6;
+    pkt.absorptiontype = ABSTYPE_PELLET_NOGAMMASPEC;
     return;
   }
 

--- a/packet.h
+++ b/packet.h
@@ -27,6 +27,18 @@ enum packet_type : int {
 constexpr int EMTYPE_NOTSET{-9999000};
 constexpr int EMTYPE_FREEFREE{-9999999};
 
+// negative absorptiontype values; non-negative values are linelist indices of bound-bound absorption
+enum absorption_type : int {
+  ABSTYPE_FREEFREE = -1,
+  ABSTYPE_BOUNDFREE = -2,
+  ABSTYPE_GAMMA_COMPTON = -3,
+  ABSTYPE_GAMMA_PHOTOELECTRIC = -4,
+  ABSTYPE_GAMMA_PAIRPRODUCTION = -5,
+  ABSTYPE_PELLET_NOGAMMASPEC = -6,  // pellet decay with no known gamma spectrum (e.g. 52Fe chain)
+  ABSTYPE_PELLET_BEFORESIMSTART = -7,  // pellet decayed before the onset of the simulation
+  ABSTYPE_PELLET_PARTICLEDECAY = -10,  // pellet decay to non-thermal particle (e.g. positron)
+};
+
 struct MacroAtomState {
   int element;  // macro atom of type element (this is an element index)
   int ion;  // in ionstage ion (this is an ion index)
@@ -55,12 +67,8 @@ struct Packet {
   int emissiontype{EMTYPE_NOTSET};  // records how the packet was emitted if it is a r-pkt
   Vec3d em_pos{NAN};  // Position of the last emission (x,y,z).
   float em_time{-1.};
-  int absorptiontype{0};  // records linelistindex of the last absorption
-                          // negative values give ff-abs (-1), bf-abs (-2), compton scattering of gammas (-3),
-                          // photoelectric effect of gammas (-4), pair production of gammas (-5)
-                          // decaying pellets of the 52Fe chain (-6) and pellets which decayed before the
-                          // onset of the simulation (-7)
-                          // decay of a positron pellet (-10)
+  int absorptiontype{0};  // records linelistindex of the last absorption,
+                          // or a negative absorption_type enum value
   double absorptionfreq{};  // records nu_rf of packet at last absorption
   double stokes_q{0.};  // normalised Stokes q = Q/I
   double stokes_u{0.};  // normalised Stokes u = U/I

--- a/packet.h
+++ b/packet.h
@@ -36,7 +36,7 @@ enum absorption_type : int {
   ABSTYPE_GAMMA_PAIRPRODUCTION = -5,
   ABSTYPE_PELLET_NOGAMMASPEC = -6,  // pellet decay with no known gamma spectrum (e.g. 52Fe chain)
   ABSTYPE_PELLET_BEFORESIMSTART = -7,  // pellet decayed before the onset of the simulation
-  ABSTYPE_PELLET_PARTICLEDECAY = -10,  // pellet decay to non-thermal particle (e.g. positron)
+  ABSTYPE_PELLET_PARTICLEDECAY = -10,  // pellet decay to non-thermal particle (beta+/-, alpha, fission fragment)
 };
 
 struct MacroAtomState {
@@ -67,7 +67,7 @@ struct Packet {
   int emissiontype{EMTYPE_NOTSET};  // records how the packet was emitted if it is a r-pkt
   Vec3d em_pos{NAN};  // Position of the last emission (x,y,z).
   float em_time{-1.};
-  int absorptiontype{0};  // records linelistindex of the last absorption,
+  int absorptiontype{0};  // records linelistindex of the last absorption
                           // or a negative absorption_type enum value
   double absorptionfreq{};  // records nu_rf of packet at last absorption
   double stokes_q{0.};  // normalised Stokes q = Q/I

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -410,13 +410,13 @@ void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
     // ff: transform to k-pkt
     stats::increment(stats::Counter::K_STAT_FROM_FF);
     pkt.type = TYPE_KPKT;
-    pkt.absorptiontype = -1;
+    pkt.absorptiontype = ABSTYPE_FREEFREE;
   } else if (chi_rnd < chi_escatter + chi_ff + chi_bf) {
     // bf: transform to k-pkt or activate macroatom corresponding to probabilities
 
     const auto& phixslist = chi_rpkt_cont.phixslist;
 
-    pkt.absorptiontype = -2;
+    pkt.absorptiontype = ABSTYPE_BOUNDFREE;
 
     const double chi_bf_inrest = chi_rpkt_cont.chi_boundfree;
     assert_testmodeonly(phixslist.chi_bf_sum[phixslist.allcontend - 1] == chi_bf_inrest);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -207,7 +207,7 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
         __builtin_unreachable();
       }
       pkt.em_time = static_cast<float>(pkt.prop_time);
-      pkt.absorptiontype = -10;
+      pkt.absorptiontype = ABSTYPE_PELLET_PARTICLEDECAY;
     } else {
       // decay to gamma-ray packet
       atomicadd(globals::timesteps[nts].gamma_emission, pkt.e_cmf);
@@ -222,7 +222,7 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
 
     pkt.e_cmf *= tdecay / globals::tmin;
     pkt.type = TYPE_PRE_KPKT;
-    pkt.absorptiontype = -7;
+    pkt.absorptiontype = ABSTYPE_PELLET_BEFORESIMSTART;
     stats::increment(stats::Counter::K_STAT_FROM_EARLIERDECAY);
 
     pkt.prop_time = globals::tmin;


### PR DESCRIPTION
## What changed

Adds a named `absorption_type` enum in `packet.h` for the negative values stored in `Packet::absorptiontype`, and replaces the magic numbers at all nine assignment sites in `rpkt.cc`, `gammapkt.cc`, and `update_packets.cc`:

- `ABSTYPE_FREEFREE = -1`, `ABSTYPE_BOUNDFREE = -2` — r-packet continuum absorption
- `ABSTYPE_GAMMA_COMPTON = -3`, `ABSTYPE_GAMMA_PHOTOELECTRIC = -4`, `ABSTYPE_GAMMA_PAIRPRODUCTION = -5` — gamma-ray interactions
- `ABSTYPE_PELLET_NOGAMMASPEC = -6` — pellet decay with no known gamma spectrum (e.g. 52Fe chain)
- `ABSTYPE_PELLET_BEFORESIMSTART = -7` — pellets that decayed before the simulation onset
- `ABSTYPE_PELLET_PARTICLEDECAY = -10` — pellet decay to a non-thermal particle

## Why

The meanings of the negative values were only documented in a comment on the struct field; the assignment sites used bare numbers. Named values make the sites self-documenting and grep-able.

## Notes for reviewers

- The enum is unscoped with an `int` base (matching the existing `packet_type` enum style) because non-negative `absorptiontype` values are linelist indices, so the field must stay a plain `int`.
- Numeric values are unchanged, so packet files on disk remain compatible.
- The old comment called -10 "decay of a positron pellet", but the code sets it for all particle decays (beta+, beta-, alpha, spontaneous fission), hence the name `ABSTYPE_PELLET_PARTICLEDECAY`.