### PR TITLE
Trigger status checks after checksum updates

### DIFF
--- a/.github/workflows/updatechecksums.yml
+++ b/.github/workflows/updatechecksums.yml
@@ -1,8 +1,8 @@
 ---
 name: Update checksums
 permissions:
-    contents: write
-    actions: write
+    contents: read
+    actions: read
 on:
     workflow_dispatch:
 
@@ -10,7 +10,20 @@ jobs:
     updatechecksums:
         runs-on: ubuntu-latest
         steps:
+            - name: Check checksum update token
+              env:
+                  CHECKSUM_UPDATE_TOKEN: ${{ secrets.CHECKSUM_UPDATE_TOKEN }}
+              run: |
+                  if [ -z "$CHECKSUM_UPDATE_TOKEN" ]; then
+                      echo "::error::Configure the CHECKSUM_UPDATE_TOKEN repository secret with Contents read/write access."
+                      exit 1
+                  fi
+
             - uses: actions/checkout@v7
+              with:
+                  # A push authenticated with github.token does not trigger workflows.
+                  # Use a separate token so the checksum commit gets normal push checks.
+                  token: ${{ secrets.CHECKSUM_UPDATE_TOKEN }}
 
             - name: Find latest CI checksums artifact for this branch
               id: findartifact
@@ -41,12 +54,10 @@ jobs:
                   rm -rf checksums_artifact
 
             - name: Commit and push updated checksums
-              id: commitpush
               run: |
                   git add tests/*_inputfiles/results_md5*.txt
                   if git diff --cached --quiet; then
                       echo "Expected checksums already match the latest CI results. Nothing to commit."
-                      echo "pushed=false" >> $GITHUB_OUTPUT
                       exit 0
                   fi
                   git diff --cached --stat
@@ -55,13 +66,3 @@ jobs:
                   git commit -m "Update expected checksums from CI run of ${{ steps.findartifact.outputs.head_sha }}" \
                       -m "Source: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.findartifact.outputs.run_id }}"
                   git push origin HEAD:${{ github.ref_name }}
-                  echo "pushed=true" >> $GITHUB_OUTPUT
-
-            - name: Trigger CI on the updated branch
-              if: steps.commitpush.outputs.pushed == 'true'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  gh workflow run ci.yml --ref ${{ github.ref_name }}
-                  gh workflow run ci-checks.yml --ref ${{ github.ref_name }}
-                  gh workflow run cislowtestmode.yml --ref ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- push checksum update commits with a dedicated repository token
- let the existing `push` triggers start all status-check workflows on the new commit
- remove the manually maintained workflow-dispatch list
- reduce the built-in `GITHUB_TOKEN` permissions to read-only
- fail with a clear message when `CHECKSUM_UPDATE_TOKEN` is not configured

## Root cause

Commits pushed by a workflow using `GITHUB_TOKEN` do not emit downstream `push` workflow runs. The existing manual dispatch workaround started CI on the new SHA, but those check runs were not associated with the pull request, so they did not refresh the PR status checks.

Using a separate token for checkout and push creates a normal push event. This also automatically covers future workflows that listen for pushes without requiring updates to `updatechecksums.yml`.

## Repository setup

Configure the `CHECKSUM_UPDATE_TOKEN` repository secret with Contents read/write access before running the workflow.

## Validation

- repository pre-commit hooks
- YAML validation
- Makefile validation hook
- `git diff --check`