### PR TITLE
Refactor repeated code and merge emission spectrum writers

### DIFF
--- a/atomic.h
+++ b/atomic.h
@@ -38,6 +38,12 @@ inline const std::array phixsdata_filenames{"IGNORE", "phixsdata.txt", "phixsdat
   return static_cast<int>(globals::elements.size());
 }
 
+// Bounds check (active only in TESTMODE builds) for an elementindex
+DEVICE_FUNC inline void assert_valid_element([[maybe_unused]] const int element) {
+  assert_testmodeonly(element >= 0);
+  assert_testmodeonly(element < get_nelements());
+}
+
 // total density of nuclei
 [[gnu::pure]] DEVICE_FUNC inline auto get_nnion_tot(int nonemptymgi) -> double {
   double nntot = 0.;
@@ -50,41 +56,47 @@ inline const std::array phixsdata_filenames{"IGNORE", "phixsdata.txt", "phixsdat
 
 // Return the number of ions associated with a specific element given by its elementindex.
 [[gnu::pure]] inline auto get_nions(const int element) -> int {
-  assert_testmodeonly(element < get_nelements());
+  assert_valid_element(element);
   return static_cast<int>(globals::elements[element].ions.size());
+}
+
+// Bounds check (active only in TESTMODE builds) for an elementindex and ionindex
+DEVICE_FUNC inline void assert_valid_ion([[maybe_unused]] const int element, [[maybe_unused]] const int ion) {
+  assert_valid_element(element);
+  assert_testmodeonly(ion >= 0);
+  assert_testmodeonly(ion < get_nions(element));
 }
 
 // Return the number of levels associated with a specific ion given its elementindex and ionindex.
 [[gnu::pure]] DEVICE_FUNC inline auto get_nlevels(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels;
+}
+
+// Bounds check (active only in TESTMODE builds) for elementindex, ionindex, and levelindex
+DEVICE_FUNC inline void assert_valid_level([[maybe_unused]] const int element, [[maybe_unused]] const int ion,
+                                           [[maybe_unused]] const int level) {
+  assert_valid_ion(element, ion);
+  assert_testmodeonly(level >= 0);
+  assert_testmodeonly(level < get_nlevels(element, ion));
 }
 
 // get the uniquelevelindex of the lowest level of an ion (excited levels are offset from this)
 [[nodiscard]] DEVICE_FUNC inline auto get_ionuniquelevelindexstart(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].uniquelevelindexstart;
 }
 
 // get the index into the nltepops_allcells array of the lowest NLTE level of an ion
 // higher levels are consecutive offsets from this
 [[nodiscard]] DEVICE_FUNC inline auto get_allnltelevelsindexstart(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].allnltelevelsindexstart;
 }
 
 // Get an index for level of an ionstage of an element that is unique across every ion of every element
 [[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   const auto uniquelevelindex = get_ionuniquelevelindexstart(element, ion) + level;
   assert_testmodeonly(uniquelevelindex < get_includedlevels());
 
@@ -93,33 +105,25 @@ inline const std::array phixsdata_filenames{"IGNORE", "phixsdata.txt", "phixsdat
 
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
 [[nodiscard]] DEVICE_FUNC inline auto get_ionstage(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].lowest_ionstage + ion;
 }
 
 // Return the ionisation potential of an ion in erg.
 [[nodiscard]] DEVICE_FUNC inline auto get_ionpot(const int element, const int ion) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].ionpot;
 }
 
 // Return the index in the groundcont array for the ground state photoion continuum of an ion.
 [[nodiscard]] DEVICE_FUNC inline auto get_groundcontindex(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].groundcontindex;
 }
 
 // Return the number of levels associated with an ion that have energies below the ionisation threshold.
 [[nodiscard]] DEVICE_FUNC inline auto get_nlevels_ionising(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_ionising;
 }
 
@@ -130,9 +134,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int uniquelevelindex) -> int {
 
 // Returns the number of target states for photoionisation of (element,ion,level).
 DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion >= 0);
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   const auto nphixstargets = get_nphixstargets(get_uniquelevelindex(element, ion, level));
   assert_testmodeonly(nphixstargets == 0 ||
                       ((ion < (get_nions(element) - 1)) && (level < get_nlevels_ionising(element, ion))));
@@ -170,17 +172,14 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_phixsprobability(const int element, const int ion,
                                                                          const int level, const int phixstargetindex)
     -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
 
   return get_phixsprobability(get_uniquelevelindex(element, ion, level), phixstargetindex);
 }
 
 // Return the level index of the highest level with a non-zero recombination rate for ion ion of element element.
 [[gnu::pure]] [[nodiscard]] inline auto get_maxrecombininglevel(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].maxrecombininglevel;
 }
 
@@ -276,9 +275,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 // Return the statistical weight of (element,ion,level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto stat_weight(const int element, const int ion, const int level)
     -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   return stat_weight(get_uniquelevelindex(element, ion, level));
 }
 
@@ -294,8 +291,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 
 // Returns the atomic number associated with a given elementindex.
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_atomicnumber(const int element) -> int {
-  assert_testmodeonly(element >= 0);
-  assert_testmodeonly(element < get_nelements());
+  assert_valid_element(element);
   return globals::elements[element].anumber;
 }
 
@@ -303,9 +299,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 // (note this function returns true for the ground state,
 //  although it is stored separately from the excited NLTE states)
 [[gnu::pure]] [[nodiscard]] inline auto is_nlte(const int element, const int ion, const int level) -> bool {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   return level <= ION_NLEVELS_EXCITED_NLTE(get_atomicnumber(element), get_ionstage(element, ion));
 }
 
@@ -362,22 +356,19 @@ inline void update_includedionslevels_maxnions() {
 // Return the number of NLTE levels associated with with a specific ion given
 // its elementindex and ionindex. Does not include the ground state or superlevel
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_excited_nlte(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_excited_nlte;
 }
 
 // Returns the number of autoionising levels for an ion
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_autoion(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_autoion;
 }
 
 // get the number of levels that are not autoionising
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_nonautoion(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return get_nlevels(element, ion) - get_nlevels_autoion(element, ion);
 }
 
@@ -388,9 +379,7 @@ inline void update_includedionslevels_maxnions() {
 
 [[gnu::pure]] [[nodiscard]] inline auto get_nautoiondowntrans(const int element, const int ion, const int level)
     -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   return get_nautoiondowntrans(get_uniquelevelindex(element, ion, level));
 }
 
@@ -411,20 +400,30 @@ inline void update_includedionslevels_maxnions() {
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_groundterm(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_groundterm;
 }
 
 // Get an index for an ionstage of an element that is unique for every ion of every element
 [[gnu::pure]] [[nodiscard]] inline auto get_uniqueionindex(const int element, const int ion) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
 
   const auto uniqueionindex = globals::elements[element].uniqueionindexstart + ion;
   assert_testmodeonly(uniqueionindex < get_includedions());
 
   return uniqueionindex;
+}
+
+// Index into the flattened per-cell-per-ion arrays (e.g. grid::ion_partfuncts_allcells) for an ion
+// of a non-empty model grid cell.
+[[gnu::pure]] [[nodiscard]] inline auto get_cellionindex(const ptrdiff_t nonemptymgi, const int uniqueionindex)
+    -> ptrdiff_t {
+  return (nonemptymgi * get_includedions()) + uniqueionindex;
+}
+
+[[gnu::pure]] [[nodiscard]] inline auto get_cellionindex(const ptrdiff_t nonemptymgi, const int element, const int ion)
+    -> ptrdiff_t {
+  return get_cellionindex(nonemptymgi, get_uniqueionindex(element, ion));
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto get_ionfromuniqueionindex(const int uniqueionindex) -> std::tuple<int, int> {
@@ -445,8 +444,7 @@ inline void update_includedionslevels_maxnions() {
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto ion_has_superlevel(const int element, const int ion) -> bool {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   return (get_nlevels(element, ion) > (get_nlevels_excited_nlte(element, ion) + get_nlevels_autoion(element, ion) + 1));
 }
 
@@ -457,9 +455,7 @@ inline void update_includedionslevels_maxnions() {
 
 // the number of downward bound-bound transitions from the specified level
 [[gnu::pure]] [[nodiscard]] inline auto get_ndowntrans(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   return get_ndowntrans(get_uniquelevelindex(element, ion, level));
 }
 
@@ -485,9 +481,7 @@ inline void update_includedionslevels_maxnions() {
 
 // the number of upward bound-bound transitions from the specified level
 [[gnu::pure]] [[nodiscard]] inline auto get_nuptrans(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   return get_nuptrans(get_uniquelevelindex(element, ion, level));
 }
 
@@ -497,25 +491,19 @@ inline void update_includedionslevels_maxnions() {
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto get_nautoionuptrans(const int element, const int ion, const int level) -> int {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   return globals::alllevels.nautoionuptrans[get_uniquelevelindex(element, ion, level)];
 }
 
 // the number of autoion transitions from the specified level
 inline void set_nautoiondowntrans(const int element, const int ion, const int level, const int nautoiondowntrans) {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   globals::alllevels.nautoiondowntrans[get_uniquelevelindex(element, ion, level)] = nautoiondowntrans;
 }
 
 // the number of autoion transitions from the specified level
 inline void set_nautoionuptrans(const int element, const int ion, const int level, const int nautoionuptrans) {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   globals::alllevels.nautoionuptrans[get_uniquelevelindex(element, ion, level)] = nautoionuptrans;
 }
 
@@ -547,9 +535,7 @@ inline void set_nautoionuptrans(const int element, const int ion, const int leve
 // Return the photionisation threshold energy [erg]
 [[gnu::pure]] [[nodiscard]] inline auto get_phixs_threshold(const int element, const int ion, const int level,
                                                             const int phixstargetindex) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   const int uniquelevelindex = get_uniquelevelindex(element, ion, level);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
   const int upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex);

--- a/atomic.h
+++ b/atomic.h
@@ -39,7 +39,7 @@ inline const std::array phixsdata_filenames{"IGNORE", "phixsdata.txt", "phixsdat
 }
 
 // Bounds check (active only in TESTMODE builds) for an elementindex
-DEVICE_FUNC inline void assert_valid_element([[maybe_unused]] const int element) {
+DEVICE_FUNC inline void testmodeassert_valid_element([[maybe_unused]] const int element) {
   assert_testmodeonly(element >= 0);
   assert_testmodeonly(element < get_nelements());
 }
@@ -56,47 +56,47 @@ DEVICE_FUNC inline void assert_valid_element([[maybe_unused]] const int element)
 
 // Return the number of ions associated with a specific element given by its elementindex.
 [[gnu::pure]] inline auto get_nions(const int element) -> int {
-  assert_valid_element(element);
+  testmodeassert_valid_element(element);
   return static_cast<int>(globals::elements[element].ions.size());
 }
 
 // Bounds check (active only in TESTMODE builds) for an elementindex and ionindex
-DEVICE_FUNC inline void assert_valid_ion([[maybe_unused]] const int element, [[maybe_unused]] const int ion) {
-  assert_valid_element(element);
+DEVICE_FUNC inline void testmodeassert_valid_ion([[maybe_unused]] const int element, [[maybe_unused]] const int ion) {
+  testmodeassert_valid_element(element);
   assert_testmodeonly(ion >= 0);
   assert_testmodeonly(ion < get_nions(element));
 }
 
 // Return the number of levels associated with a specific ion given its elementindex and ionindex.
 [[gnu::pure]] DEVICE_FUNC inline auto get_nlevels(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels;
 }
 
 // Bounds check (active only in TESTMODE builds) for elementindex, ionindex, and levelindex
-DEVICE_FUNC inline void assert_valid_level([[maybe_unused]] const int element, [[maybe_unused]] const int ion,
-                                           [[maybe_unused]] const int level) {
-  assert_valid_ion(element, ion);
+DEVICE_FUNC inline void testmodeassert_valid_level([[maybe_unused]] const int element, [[maybe_unused]] const int ion,
+                                                   [[maybe_unused]] const int level) {
+  testmodeassert_valid_ion(element, ion);
   assert_testmodeonly(level >= 0);
   assert_testmodeonly(level < get_nlevels(element, ion));
 }
 
 // get the uniquelevelindex of the lowest level of an ion (excited levels are offset from this)
 [[nodiscard]] DEVICE_FUNC inline auto get_ionuniquelevelindexstart(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].uniquelevelindexstart;
 }
 
 // get the index into the nltepops_allcells array of the lowest NLTE level of an ion
 // higher levels are consecutive offsets from this
 [[nodiscard]] DEVICE_FUNC inline auto get_allnltelevelsindexstart(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].allnltelevelsindexstart;
 }
 
 // Get an index for level of an ionstage of an element that is unique across every ion of every element
 [[nodiscard]] inline auto get_uniquelevelindex(const int element, const int ion, const int level) -> int {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   const auto uniquelevelindex = get_ionuniquelevelindexstart(element, ion) + level;
   assert_testmodeonly(uniquelevelindex < get_includedlevels());
 
@@ -105,25 +105,25 @@ DEVICE_FUNC inline void assert_valid_level([[maybe_unused]] const int element, [
 
 // Return the ionisation stage of an ion specified by its elementindex and ionindex.
 [[nodiscard]] DEVICE_FUNC inline auto get_ionstage(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].lowest_ionstage + ion;
 }
 
 // Return the ionisation potential of an ion in erg.
 [[nodiscard]] DEVICE_FUNC inline auto get_ionpot(const int element, const int ion) -> double {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].ionpot;
 }
 
 // Return the index in the groundcont array for the ground state photoion continuum of an ion.
 [[nodiscard]] DEVICE_FUNC inline auto get_groundcontindex(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].groundcontindex;
 }
 
 // Return the number of levels associated with an ion that have energies below the ionisation threshold.
 [[nodiscard]] DEVICE_FUNC inline auto get_nlevels_ionising(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_ionising;
 }
 
@@ -134,7 +134,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int uniquelevelindex) -> int {
 
 // Returns the number of target states for photoionisation of (element,ion,level).
 DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, const int level) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   const auto nphixstargets = get_nphixstargets(get_uniquelevelindex(element, ion, level));
   assert_testmodeonly(nphixstargets == 0 ||
                       ((ion < (get_nions(element) - 1)) && (level < get_nlevels_ionising(element, ion))));
@@ -172,14 +172,14 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_phixsprobability(const int element, const int ion,
                                                                          const int level, const int phixstargetindex)
     -> double {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
 
   return get_phixsprobability(get_uniquelevelindex(element, ion, level), phixstargetindex);
 }
 
 // Return the level index of the highest level with a non-zero recombination rate for ion ion of element element.
 [[gnu::pure]] [[nodiscard]] inline auto get_maxrecombininglevel(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].maxrecombininglevel;
 }
 
@@ -275,7 +275,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 // Return the statistical weight of (element,ion,level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto stat_weight(const int element, const int ion, const int level)
     -> double {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   return stat_weight(get_uniquelevelindex(element, ion, level));
 }
 
@@ -291,7 +291,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 
 // Returns the atomic number associated with a given elementindex.
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_atomicnumber(const int element) -> int {
-  assert_valid_element(element);
+  testmodeassert_valid_element(element);
   return globals::elements[element].anumber;
 }
 
@@ -299,7 +299,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 // (note this function returns true for the ground state,
 //  although it is stored separately from the excited NLTE states)
 [[gnu::pure]] [[nodiscard]] inline auto is_nlte(const int element, const int ion, const int level) -> bool {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   return level <= ION_NLEVELS_EXCITED_NLTE(get_atomicnumber(element), get_ionstage(element, ion));
 }
 
@@ -356,19 +356,19 @@ inline void update_includedionslevels_maxnions() {
 // Return the number of NLTE levels associated with with a specific ion given
 // its elementindex and ionindex. Does not include the ground state or superlevel
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_excited_nlte(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_excited_nlte;
 }
 
 // Returns the number of autoionising levels for an ion
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_autoion(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_autoion;
 }
 
 // get the number of levels that are not autoionising
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_nonautoion(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return get_nlevels(element, ion) - get_nlevels_autoion(element, ion);
 }
 
@@ -379,7 +379,7 @@ inline void update_includedionslevels_maxnions() {
 
 [[gnu::pure]] [[nodiscard]] inline auto get_nautoiondowntrans(const int element, const int ion, const int level)
     -> int {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   return get_nautoiondowntrans(get_uniquelevelindex(element, ion, level));
 }
 
@@ -400,13 +400,13 @@ inline void update_includedionslevels_maxnions() {
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto get_nlevels_groundterm(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return globals::elements[element].ions[ion].nlevels_groundterm;
 }
 
 // Get an index for an ionstage of an element that is unique for every ion of every element
 [[gnu::pure]] [[nodiscard]] inline auto get_uniqueionindex(const int element, const int ion) -> int {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
 
   const auto uniqueionindex = globals::elements[element].uniqueionindexstart + ion;
   assert_testmodeonly(uniqueionindex < get_includedions());
@@ -444,7 +444,7 @@ inline void update_includedionslevels_maxnions() {
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto ion_has_superlevel(const int element, const int ion) -> bool {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   return (get_nlevels(element, ion) > (get_nlevels_excited_nlte(element, ion) + get_nlevels_autoion(element, ion) + 1));
 }
 
@@ -455,7 +455,7 @@ inline void update_includedionslevels_maxnions() {
 
 // the number of downward bound-bound transitions from the specified level
 [[gnu::pure]] [[nodiscard]] inline auto get_ndowntrans(const int element, const int ion, const int level) -> int {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   return get_ndowntrans(get_uniquelevelindex(element, ion, level));
 }
 
@@ -481,7 +481,7 @@ inline void update_includedionslevels_maxnions() {
 
 // the number of upward bound-bound transitions from the specified level
 [[gnu::pure]] [[nodiscard]] inline auto get_nuptrans(const int element, const int ion, const int level) -> int {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   return get_nuptrans(get_uniquelevelindex(element, ion, level));
 }
 
@@ -491,19 +491,19 @@ inline void update_includedionslevels_maxnions() {
 }
 
 [[gnu::pure]] [[nodiscard]] inline auto get_nautoionuptrans(const int element, const int ion, const int level) -> int {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   return globals::alllevels.nautoionuptrans[get_uniquelevelindex(element, ion, level)];
 }
 
 // the number of autoion transitions from the specified level
 inline void set_nautoiondowntrans(const int element, const int ion, const int level, const int nautoiondowntrans) {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   globals::alllevels.nautoiondowntrans[get_uniquelevelindex(element, ion, level)] = nautoiondowntrans;
 }
 
 // the number of autoion transitions from the specified level
 inline void set_nautoionuptrans(const int element, const int ion, const int level, const int nautoionuptrans) {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   globals::alllevels.nautoionuptrans[get_uniquelevelindex(element, ion, level)] = nautoionuptrans;
 }
 
@@ -535,7 +535,7 @@ inline void set_nautoionuptrans(const int element, const int ion, const int leve
 // Return the photionisation threshold energy [erg]
 [[gnu::pure]] [[nodiscard]] inline auto get_phixs_threshold(const int element, const int ion, const int level,
                                                             const int phixstargetindex) -> double {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   const int uniquelevelindex = get_uniquelevelindex(element, ion, level);
   assert_testmodeonly(phixstargetindex < get_nphixstargets(uniquelevelindex));
   const int upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex);

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -408,9 +408,7 @@ void compton_scatter(Packet& pkt) {
 
     // It now has a rest frame direction and a co-moving frequency.
     //  Just need to set the rest frame energy.
-    const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
-    pkt.nu_rf = pkt.nu_cmf / dopplerfactor;
-    pkt.e_rf = pkt.e_cmf / dopplerfactor;
+    set_pkt_restframe_from_cmf(pkt);
   } else {
     // energy loss of the gamma becomes energy of the electron (needed to calculate time-dependent thermalisation rate)
     if constexpr (PARTICLE_THERMALISATION_SCHEME == ParticleThermalisationScheme::TIMEDEPENDENTWITHGAMMAPRODUCTS) {
@@ -631,9 +629,7 @@ DEVICE_FUNC void emit_gamma_isotropic(Packet& pkt) {
 
   pkt.dir = angle_ab(dir_cmf, vel_vec);
 
-  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
-  pkt.nu_rf = pkt.nu_cmf / dopplerfactor;
-  pkt.e_rf = pkt.e_cmf / dopplerfactor;
+  set_pkt_restframe_from_cmf(pkt);
 
   pkt.type = TYPE_GAMMA;
 }

--- a/globals.h
+++ b/globals.h
@@ -330,6 +330,15 @@ inline bool lte_iteration{false};
 
 }  // namespace globals
 
+// DO_TITER mode: average an estimator with its saved value from the previous timestep iteration
+// (if one exists) and store the result as the new saved value.
+inline void titer_average(double& value, double& saved) {
+  if (saved >= 0) {
+    value = (value + saved) / 2;
+  }
+  saved = value;
+}
+
 [[nodiscard]] inline auto get_max_threads() -> int {
 #ifdef _OPENMP
   return omp_get_max_threads();

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -28,11 +28,8 @@ namespace {
 
 // use Saha equation for LTE ionisation balance
 [[gnu::pure]] [[nodiscard]] auto phi_saha(const int element, const int ion, const int nonemptymgi) -> double {
-  const int uniqueionindex = get_uniqueionindex(element, ion);
-  const auto partfunc_ion =
-      grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex];
-  const auto partfunc_upperion =
-      grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex + 1];
+  const auto partfunc_ion = get_ion_partfunct(nonemptymgi, element, ion);
+  const auto partfunc_upperion = get_ion_partfunct(nonemptymgi, element, ion + 1);
 
   const auto T_e = grid::get_Te(nonemptymgi);
   const double ionpot = epsilon(element, ion + 1, 0) - epsilon(element, ion, 0);
@@ -45,8 +42,7 @@ namespace {
 // should have units of [cm^3] so that when multiplied by nne it gives the population ratio of two consecutive
 // ionisation stages
 [[gnu::pure]] [[nodiscard]] auto phi_rate_balance(const int element, const int ion, const int nonemptymgi) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
 
   assert_testmodeonly(!globals::lte_iteration);
   assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);  // should use use phi_lte instead
@@ -54,8 +50,7 @@ namespace {
   assert_testmodeonly(!elem_has_nlte_levels(element));  // don't use this function if the NLTE solver is active
 
   const int uniqueionindex = get_uniqueionindex(element, ion);
-  const auto partfunc_ion =
-      grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex];
+  const auto partfunc_ion = get_ion_partfunct(nonemptymgi, element, ion);
 
   const auto T_e = grid::get_Te(nonemptymgi);
 
@@ -137,9 +132,7 @@ auto nne_solution_f(const double nne_assumed, const int nonemptymgi, const bool 
 // return population and whether the population came from the nlte solver
 auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level)
     -> std::tuple<double, bool> {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
 
   if (level == 0) {
     return {get_groundlevelpop(nonemptymgi, element, ion), false};
@@ -170,11 +163,8 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
 
 // Calculate the partition function for ion=ion of element=element in a cell modelgridindex
 auto calculate_partfunct(const int element, const int ion, const int nonemptymgi) -> float {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
   double pop_store{NAN};
-
-  const int uniqueionindex = get_uniqueionindex(element, ion);
 
   bool initial = false;
   if (get_groundlevelpop(nonemptymgi, element, ion) < MINPOP) {
@@ -183,8 +173,7 @@ auto calculate_partfunct(const int element, const int ion, const int nonemptymgi
     // of groundlevelpop for this calculation doesn't matter, so long as it's not zero!
     pop_store = get_groundlevelpop(nonemptymgi, element, ion);
     initial = true;
-    grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex] =
-        1.;
+    set_groundlevelpop(nonemptymgi, element, ion, 1.);
   }
 
   double U = 1.;
@@ -201,8 +190,7 @@ auto calculate_partfunct(const int element, const int ion, const int nonemptymgi
 
   if (initial) {
     // put back the zero, just in case it matters for something
-    grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) + uniqueionindex] =
-        static_cast<float>(pop_store);
+    set_groundlevelpop(nonemptymgi, element, ion, static_cast<float>(pop_store));
   }
 
   return U_float;
@@ -227,7 +215,6 @@ void set_groundlevelpops_neutral(const ptrdiff_t nonemptymgi) {
     const int nions = get_nions(element);
     // Assign the species population to the neutral ion and set higher ions to MINPOP
     for (int ion = 0; ion < nions; ion++) {
-      const int uniqueionindex = get_uniqueionindex(element, ion);
       double nnion{NAN};
       if (ion == 0) {
         nnion = nnelement;
@@ -237,10 +224,9 @@ void set_groundlevelpops_neutral(const ptrdiff_t nonemptymgi) {
         nnion = 0.;
       }
       const auto groundpop =
-          static_cast<float>(nnion * stat_weight(element, ion, 0) /
-                             grid::ion_partfuncts_allcells[(nonemptymgi * get_includedions()) + uniqueionindex]);
+          static_cast<float>(nnion * stat_weight(element, ion, 0) / get_ion_partfunct(nonemptymgi, element, ion));
 
-      grid::ion_groundlevelpops_allcells[(nonemptymgi * get_includedions()) + uniqueionindex] = groundpop;
+      set_groundlevelpop(nonemptymgi, element, ion, groundpop);
     }
   }
 }
@@ -357,9 +343,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 // Calculate occupation population of a level assuming LTE excitation
 [[gnu::pure]] [[nodiscard]] auto calculate_levelpop_boltzmann(const int nonemptymgi, const int element, const int ion,
                                                               const int level) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
-  assert_testmodeonly(level < get_nlevels(element, ion));
+  assert_valid_level(element, ion, level);
   const auto nnground = get_groundlevelpop(nonemptymgi, element, ion);
   if (level == 0) {
     return nnground;
@@ -393,8 +377,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 void calculate_cellpartfuncts(const int nonemptymgi, const int element) {
   const int nions = get_nions(element);
   for (int ion = 0; ion < nions; ion++) {
-    grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                  get_uniqueionindex(element, ion)] = calculate_partfunct(element, ion, nonemptymgi);
+    set_ion_partfunct(nonemptymgi, element, ion, calculate_partfunct(element, ion, nonemptymgi));
   }
 }
 

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -42,7 +42,7 @@ namespace {
 // should have units of [cm^3] so that when multiplied by nne it gives the population ratio of two consecutive
 // ionisation stages
 [[gnu::pure]] [[nodiscard]] auto phi_rate_balance(const int element, const int ion, const int nonemptymgi) -> double {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
 
   assert_testmodeonly(!globals::lte_iteration);
   assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);  // should use use phi_lte instead
@@ -132,7 +132,7 @@ auto nne_solution_f(const double nne_assumed, const int nonemptymgi, const bool 
 // return population and whether the population came from the nlte solver
 auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level)
     -> std::tuple<double, bool> {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
 
   if (level == 0) {
     return {get_groundlevelpop(nonemptymgi, element, ion), false};
@@ -163,7 +163,7 @@ auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const
 
 // Calculate the partition function for ion=ion of element=element in a cell modelgridindex
 auto calculate_partfunct(const int element, const int ion, const int nonemptymgi) -> float {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
   double pop_store{NAN};
 
   bool initial = false;
@@ -343,7 +343,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 // Calculate occupation population of a level assuming LTE excitation
 [[gnu::pure]] [[nodiscard]] auto calculate_levelpop_boltzmann(const int nonemptymgi, const int element, const int ion,
                                                               const int level) -> double {
-  assert_valid_level(element, ion, level);
+  testmodeassert_valid_level(element, ion, level);
   const auto nnground = get_groundlevelpop(nonemptymgi, element, ion);
   if (level == 0) {
     return nnground;

--- a/ltepop.h
+++ b/ltepop.h
@@ -44,11 +44,9 @@ void set_groundlevelpops(int nonemptymgi, int element, float nne, bool force_sah
 // during update_grid and stored to the grid.
 [[gnu::pure]] [[nodiscard]] inline DEVICE_FUNC auto get_groundlevelpop(const int nonemptymgi, const int element,
                                                                        const int ion) -> double {
-  assert_testmodeonly(element < get_nelements());
-  assert_testmodeonly(ion < get_nions(element));
+  assert_valid_ion(element, ion);
 
-  const double nn = grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                                       get_uniqueionindex(element, ion)];
+  const double nn = grid::ion_groundlevelpops_allcells[get_cellionindex(nonemptymgi, element, ion)];
   if (nn < MINPOP) {
     if (grid::get_elem_massfrac(nonemptymgi, element) > 0) {
       return MINPOP;
@@ -58,11 +56,25 @@ void set_groundlevelpops(int nonemptymgi, int element, float nne, bool force_sah
   return nn;
 }
 
+// Store an ion's ground level population for a cell (usually calculated during update_grid).
+inline void set_groundlevelpop(const int nonemptymgi, const int element, const int ion, const float groundlevelpop) {
+  grid::ion_groundlevelpops_allcells[get_cellionindex(nonemptymgi, element, ion)] = groundlevelpop;
+}
+
+// Return an ion's partition function for a cell, which was precalculated during update_grid.
+[[gnu::pure]] [[nodiscard]] inline auto get_ion_partfunct(const int nonemptymgi, const int element, const int ion)
+    -> float {
+  return grid::ion_partfuncts_allcells[get_cellionindex(nonemptymgi, element, ion)];
+}
+
+// Store an ion's partition function for a cell.
+inline void set_ion_partfunct(const int nonemptymgi, const int element, const int ion, const float partfunct) {
+  grid::ion_partfuncts_allcells[get_cellionindex(nonemptymgi, element, ion)] = partfunct;
+}
+
 // Use the ground level population and partition function to get an ion population
 [[gnu::pure]] [[nodiscard]] inline auto get_nnion(const int nonemptymgi, const int element, const int ion) -> double {
-  const auto nnion = get_groundlevelpop(nonemptymgi, element, ion) *
-                     grid::ion_partfuncts_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                                   get_uniqueionindex(element, ion)] /
+  const auto nnion = get_groundlevelpop(nonemptymgi, element, ion) * get_ion_partfunct(nonemptymgi, element, ion) /
                      stat_weight(element, ion, 0);
   assert_testmodeonly(nnion >= 0.);
   assert_testmodeonly(std::isfinite(nnion));

--- a/ltepop.h
+++ b/ltepop.h
@@ -44,7 +44,7 @@ void set_groundlevelpops(int nonemptymgi, int element, float nne, bool force_sah
 // during update_grid and stored to the grid.
 [[gnu::pure]] [[nodiscard]] inline DEVICE_FUNC auto get_groundlevelpop(const int nonemptymgi, const int element,
                                                                        const int ion) -> double {
-  assert_valid_ion(element, ion);
+  testmodeassert_valid_ion(element, ion);
 
   const double nn = grid::ion_groundlevelpops_allcells[get_cellionindex(nonemptymgi, element, ion)];
   if (nn < MINPOP) {
@@ -57,12 +57,13 @@ void set_groundlevelpops(int nonemptymgi, int element, float nne, bool force_sah
 }
 
 // Store an ion's ground level population for a cell (usually calculated during update_grid).
-inline void set_groundlevelpop(const int nonemptymgi, const int element, const int ion, const float groundlevelpop) {
+inline void set_groundlevelpop(const ptrdiff_t nonemptymgi, const int element, const int ion,
+                               const float groundlevelpop) {
   grid::ion_groundlevelpops_allcells[get_cellionindex(nonemptymgi, element, ion)] = groundlevelpop;
 }
 
 // Return an ion's partition function for a cell, which was precalculated during update_grid.
-[[gnu::pure]] [[nodiscard]] inline auto get_ion_partfunct(const int nonemptymgi, const int element, const int ion)
+[[gnu::pure]] [[nodiscard]] inline auto get_ion_partfunct(const ptrdiff_t nonemptymgi, const int element, const int ion)
     -> float {
   return grid::ion_partfuncts_allcells[get_cellionindex(nonemptymgi, element, ion)];
 }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -355,7 +355,7 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
     // originating levels population cancels out in the macroatom transition probabilities
     // which are based on detailed balance.
 
-    assert_valid_ion(element, ion);
+    testmodeassert_valid_ion(element, ion);
     const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
     const int uniquelevelindex = ionuniquelevelindexstart + level;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -355,8 +355,7 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
     // originating levels population cancels out in the macroatom transition probabilities
     // which are based on detailed balance.
 
-    assert_testmodeonly(ion >= 0);
-    assert_testmodeonly(ion < get_nions(element));
+    assert_valid_ion(element, ion);
     const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
     const int uniquelevelindex = ionuniquelevelindexstart + level;
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1360,8 +1360,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
         printlnlog("  WARNING: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to zero ",
                    get_atomicnumber(element), get_ionstage(element, ion));
 
-        grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                           get_uniqueionindex(element, ion)] = 0.;
+        set_groundlevelpop(nonemptymgi, element, ion, 0.);
 
         for (int level = 1; level <= nlevels_excited_nlte; level++) {
           set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level, 0.);
@@ -1371,8 +1370,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
           set_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion, 0.);
         }
       } else {
-        grid::ion_groundlevelpops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * get_includedions()) +
-                                           get_uniqueionindex(element, ion)] = static_cast<float>(popvec[index_gs]);
+        set_groundlevelpop(nonemptymgi, element, ion, static_cast<float>(popvec[index_gs]));
 
         for (int level = 1; level <= nlevels_excited_nlte; level++) {
           const int index = get_nlte_vector_index(element, ion, level, first_ion_used);

--- a/radfield.cc
+++ b/radfield.cc
@@ -894,19 +894,9 @@ auto get_T_J_from_J(const int nonemptymgi) -> float {
 }
 
 #ifdef DO_TITER
-void titer_J(const int nonemptymgi) {
-  if (J_reduced_save[nonemptymgi] >= 0) {
-    J[nonemptymgi] = (J[nonemptymgi] + J_reduced_save[nonemptymgi]) / 2;
-  }
-  J_reduced_save[nonemptymgi] = J[nonemptymgi];
-}
+void titer_J(const int nonemptymgi) { titer_average(J[nonemptymgi], J_reduced_save[nonemptymgi]); }
 
-void titer_nuJ(const int nonemptymgi) {
-  if (nuJ_reduced_save[nonemptymgi] >= 0) {
-    nuJ[nonemptymgi] = (nuJ[nonemptymgi] + nuJ_reduced_save[nonemptymgi]) / 2;
-  }
-  nuJ_reduced_save[nonemptymgi] = nuJ[nonemptymgi];
-}
+void titer_nuJ(const int nonemptymgi) { titer_average(nuJ[nonemptymgi], nuJ_reduced_save[nonemptymgi]); }
 #endif
 
 // reduce and broadcast (allreduce) the estimators for J and nuJ in all bins

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -369,9 +369,7 @@ void electron_scatter_rpkt(Packet& pkt) {
   // Finally we want to put in the rest frame energy and frequency.
   // And record that it's now a r-pkt.
 
-  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
-  pkt.nu_rf = pkt.nu_cmf / dopplerfactor;
-  pkt.e_rf = pkt.e_cmf / dopplerfactor;
+  set_pkt_restframe_from_cmf(pkt);
 }
 
 void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
@@ -868,9 +866,7 @@ DEVICE_FUNC void emit_rpkt(Packet& pkt) {
   // Finally we want to put in the rest frame energy and frequency. And record
   // that it's now a r-pkt.
 
-  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
-  pkt.nu_rf = pkt.nu_cmf / dopplerfactor;
-  pkt.e_rf = pkt.e_cmf / dopplerfactor;
+  set_pkt_restframe_from_cmf(pkt);
 
   if constexpr (POL_ON) {
     // Reset to unpolarised

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -343,8 +343,7 @@ void write_deposition_file() {
 }
 
 void write_timestep_file() {
-  auto timestepfile = std::fstream("timesteps.out", std::ofstream::out | std::ofstream::trunc);
-  assert_always(timestepfile.is_open());
+  auto timestepfile = fstream_required("timesteps.out", std::ofstream::out | std::ofstream::trunc);
   std::print(timestepfile, "#timestep tstart_days tmid_days twidth_days\n");
   for (int n = 0; n < globals::ntimesteps; n++) {
     std::println(timestepfile, "{} {:g} {:g} {:g}", n, globals::timesteps[n].start / DAY,

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -321,8 +321,10 @@ void write_spectrum_file(const std::string& spec_filename, const Spectra& spectr
   }
 }
 
-void write_emission_spectrum_file(const std::string& emission_filename, const Spectra& spectra,
-                                  const int numtimesteps) {
+// Write an emission-type spectrum (emission or true emission) with a line for each frequency bin of
+// each timestep, holding one column per emission process (see get_proccount).
+void write_emission_spectrum_file(const std::string& emission_filename,
+                                  const std::span<const double> emission_alltimesteps, const int numtimesteps) {
   assert_always(numtimesteps <= globals::ntimesteps);
   assert_always(!emission_filename.empty());
   auto emission_file = fstream_required(emission_filename, std::ios::out | std::ios::trunc);
@@ -332,27 +334,9 @@ void write_emission_spectrum_file(const std::string& emission_filename, const Sp
     for (auto nts = 0Z; nts < numtimesteps; nts++) {
       const auto emindex_nts_nubin = (nubin * ntimesteps_all * proccount) + (nts * proccount);
       for (int nproc = 0; nproc < proccount; nproc++) {
-        std::print(emission_file, "{:g} ", spectra.emissionalltimesteps[emindex_nts_nubin + nproc]);
+        std::print(emission_file, "{:g} ", emission_alltimesteps[emindex_nts_nubin + nproc]);
       }
       std::println(emission_file, "");
-    }
-  }
-}
-
-void write_trueemission_spectrum_file(const std::string& trueemission_filename, const Spectra& spectra,
-                                      const int numtimesteps) {
-  assert_always(numtimesteps <= globals::ntimesteps);
-  assert_always(!trueemission_filename.empty());
-  auto trueemission_file = fstream_required(trueemission_filename, std::ios::out | std::ios::trunc);
-  const auto ntimesteps_all = static_cast<ptrdiff_t>(globals::ntimesteps);
-  const auto proccount = static_cast<ptrdiff_t>(get_proccount());
-  for (auto nubin = 0Z; nubin < MNUBINS; nubin++) {
-    for (auto nts = 0Z; nts < numtimesteps; nts++) {
-      const auto emindex_nts_nubin = (nubin * ntimesteps_all * proccount) + (nts * proccount);
-      for (int truenproc = 0; truenproc < proccount; truenproc++) {
-        std::print(trueemission_file, "{:g} ", spectra.trueemissionalltimesteps[emindex_nts_nubin + truenproc]);
-      }
-      std::println(trueemission_file, "");
     }
   }
 }
@@ -397,11 +381,11 @@ void write_spectra(const std::string& spec_filename, const std::string& emission
 
   if (spectra.do_emission_absorption) {
     if (this_rank_writes_file(2)) {
-      write_emission_spectrum_file(emission_filename, spectra, numtimesteps);
+      write_emission_spectrum_file(emission_filename, spectra.emissionalltimesteps.span(), numtimesteps);
     }
 
     if (this_rank_writes_file(3)) {
-      write_trueemission_spectrum_file(trueemission_filename, spectra, numtimesteps);
+      write_emission_spectrum_file(trueemission_filename, spectra.trueemissionalltimesteps.span(), numtimesteps);
     }
 
     if (this_rank_writes_file(4)) {

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -290,11 +290,7 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
 
         globals::gammaestimator[ionestimindex] *= estimator_normfactor / H;
 #ifdef DO_TITER
-        if (globals::gammaestimator_save[ionestimindex] >= 0) {
-          globals::gammaestimator[ionestimindex] =
-              (globals::gammaestimator[ionestimindex] + globals::gammaestimator_save[ionestimindex]) / 2;
-        }
-        globals::gammaestimator_save[ionestimindex] = globals::gammaestimator[ionestimindex];
+        titer_average(globals::gammaestimator[ionestimindex], globals::gammaestimator_save[ionestimindex]);
 #endif
 
         globals::corrphotoionrenorm[ionestimindex] =
@@ -330,11 +326,7 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
       if constexpr (USE_ION_BFHEATING_ESTIMATORS) {
         globals::bfheatingestimator[ionestimindex] *= estimator_normfactor;
 #ifdef DO_TITER
-        if (globals::bfheatingestimator_save[ionestimindex] >= 0) {
-          globals::bfheatingestimator[ionestimindex] =
-              (globals::bfheatingestimator[ionestimindex] + globals::bfheatingestimator_save[ionestimindex]) / 2;
-        }
-        globals::bfheatingestimator_save[ionestimindex] = globals::bfheatingestimator[ionestimindex];
+        titer_average(globals::bfheatingestimator[ionestimindex], globals::bfheatingestimator_save[ionestimindex]);
 #endif
         // Now convert bfheatingestimator into the bfheating renormalisation coefficient used in
         // for the remaining part of update_grid. At the start of the next update_packets, it will be reset
@@ -350,17 +342,9 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
 
 #ifdef DO_TITER
 static void titer_average_estimators(const int nonemptymgi) {
-  if (globals::ffheatingestimator_save[nonemptymgi] >= 0) {
-    globals::ffheatingestimator[nonemptymgi] =
-        (globals::ffheatingestimator[nonemptymgi] + globals::ffheatingestimator_save[nonemptymgi]) / 2;
-  }
-  globals::ffheatingestimator_save[nonemptymgi] = globals::ffheatingestimator[nonemptymgi];
+  titer_average(globals::ffheatingestimator[nonemptymgi], globals::ffheatingestimator_save[nonemptymgi]);
   if constexpr (!DIRECT_COL_HEAT) {
-    if (globals::colheatingestimator_save[nonemptymgi] >= 0) {
-      globals::colheatingestimator[nonemptymgi] =
-          (globals::colheatingestimator[nonemptymgi] + globals::colheatingestimator_save[nonemptymgi]) / 2;
-    }
-    globals::colheatingestimator_save.at(nonemptymgi) = globals::colheatingestimator.at(nonemptymgi);
+    titer_average(globals::colheatingestimator[nonemptymgi], globals::colheatingestimator_save[nonemptymgi]);
   }
 }
 #endif

--- a/vectors.h
+++ b/vectors.h
@@ -128,6 +128,14 @@ constexpr void move_pkt_withtime(Packet& pkt, const double distance) {
   move_pkt_withtime(pkt.pos, pkt.dir, pkt.prop_time, pkt.nu_rf, pkt.nu_cmf, pkt.e_rf, pkt.e_cmf, distance);
 }
 
+// Set the packet's rest-frame frequency and energy from its co-moving frame values using the
+// Doppler factor for its current position, direction, and propagation time.
+DEVICE_FUNC constexpr void set_pkt_restframe_from_cmf(Packet& pkt) {
+  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
+  pkt.nu_rf = pkt.nu_cmf / dopplerfactor;
+  pkt.e_rf = pkt.e_cmf / dopplerfactor;
+}
+
 [[gnu::pure]] [[nodiscard]] constexpr auto get_escapedirectionbin(const Vec3d& dir_in) -> int {
   constexpr auto xhat = Vec3d{1.0, 0.0, 0.0};
 


### PR DESCRIPTION
This pull request improves the safety and clarity of atomic data access by introducing centralized bounds-checking helper functions and updating all relevant functions to use them. It also introduces new utility functions for working with per-cell per-ion arrays and simplifies partition function access in LTE population calculations.

**Safety and Validation Improvements:**

* Introduced helper functions `testmodeassert_valid_element`, `testmodeassert_valid_ion`, and `testmodeassert_valid_level` for bounds checking of element, ion, and level indices, replacing scattered assertions throughout `atomic.h`. All relevant functions now use these helpers for consistency and maintainability.

**Utility Function Additions:**

* Added `get_cellionindex` overloads to compute the flattened index for per-cell-per-ion arrays, improving code clarity and reuse.

**Partition Function Access Simplification:**

* Replaced manual indexing into `grid::ion_partfuncts_allcells` with a new `get_ion_partfunct` helper in `ltepop.cc`, making partition function access more robust and readable.

**Code Reuse and Consistency:**

* Updated all functions that require rest-frame packet properties in `gammapkt.cc` to use the new `set_pkt_restframe_from_cmf(pkt)` helper, reducing code duplication and potential errors.

**Miscellaneous Utility:**

* Added a `titer_average` helper function for averaging estimators in DO_TITER mode.