### PR TITLE
Keep sampled free-bound emission frequency within the cross-section table

### DIFF
--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -551,11 +551,24 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
     }
   }
 
-  const double nuoffset =
-      (alpha_sp != alpha_sp_old) ? ((total_alpha_sp * zrand) - alpha_sp_old) / (alpha_sp - alpha_sp_old) * deltanu : 0.;
+  double nuoffset = 0.;
+  if (i < npieces) {
+    // the loop found the piece containing the target value, so interpolate between the remaining
+    // integrals at the piece boundaries
+    nuoffset = (alpha_sp != alpha_sp_old)
+                   ? ((total_alpha_sp * zrand) - alpha_sp_old) / (alpha_sp - alpha_sp_old) * deltanu
+                   : 0.;
+  } else if (alpha_sp > 0.) {
+    // the loop completed without a break, so the target lies in the topmost piece, where the
+    // remaining integral falls from alpha_sp at the piece's lower boundary to zero at nu_max_phixs.
+    // Interpolating with the previous piece's values here would extrapolate to nu_lower > nu_max_phixs.
+    nuoffset = (alpha_sp - (total_alpha_sp * zrand)) / alpha_sp * deltanu;
+  }
   const double nu_lower = nu_threshold + ((i - 1) * deltanu) + nuoffset;
 
   assert_testmodeonly(std::isfinite(nu_lower));
+  assert_testmodeonly(nu_lower >= nu_threshold);
+  assert_testmodeonly(nu_lower <= nu_max_phixs);
 
   return nu_lower;
 }


### PR DESCRIPTION
`select_continuum_nu()` samples the frequency of a free-bound emission packet by locating the piece of the frequency grid containing the target value of the remaining energy-weighted recombination integral, then interpolating linearly within it. When the target lay in the topmost piece (the loop completed without a break), the interpolation used the remaining-integral values of the piece *below*, linearly extrapolating to `nu_lower > nu_max_phixs` — beyond the end of the photoionisation cross-section table, even though `total_alpha_sp` only integrates up to `nu_max_phixs`.

Interpolate the topmost piece against its true upper-boundary value instead (the remaining integral is zero at `nu_max_phixs`), and assert in TESTMODE that the sampled frequency stays within `[nu_threshold, nu_max_phixs]`.

This is the last remaining item from the review that produced #458 and #459.

Note for CI: this changes the sampled frequency whenever a free-bound emission lands in the topmost piece (a small but nonzero probability per fb emission, largest for low-energy edges where the Boltzmann tail is least suppressed), so checksums are expected to need regeneration with the update workflow.

Generated with [Claude Code](https://claude.com/claude-code)