### PR TITLE
Prevent zero-weight outcomes from being sampled

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -907,7 +907,8 @@ void init_gamma_data() {
   double runtot = 0.;
   for (auto n = 0Z; n < std::ssize(gamma_spectra[nucindex]); n++) {
     runtot += gamma_spectra[nucindex][n].probability * gamma_spectra[nucindex][n].energy / E_gamma;
-    if (zrand <= runtot) {
+    // Strict comparison ensures that zrand == 0 does not select a leading zero-probability line.
+    if (zrand < runtot) {
       return gamma_spectra[nucindex][n].energy / H;
     }
   }

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -520,13 +520,14 @@ DEVICE_FUNC void do_kpkt(Packet& pkt, const double t2, const int nts) {
           col_excitation_ratecoeff(T_e, clumpednne, upper_statweight, alltransindex, epsilon_trans, statweight) *
           epsilon_trans;
       contrib += C;
-      if (contrib >= rndcool_ion_process) {
+      // Strict comparison ensures that a zero target skips leading transitions with zero contribution.
+      if (contrib > rndcool_ion_process) {
         upper = tmpupper;
         break;
       }
     }
 
-    assert_always(contrib >= rndcool_ion_process);
+    assert_always(contrib > rndcool_ion_process);
 
     stats::increment(stats::Counter::MA_STAT_ACTIVATION_COLLEXC);
     stats::increment(stats::Counter::K_STAT_TO_MA_COLLEXC);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1457,7 +1457,8 @@ auto select_nt_ionisation(const int nonemptymgi, rngstate_type& rngstate) -> std
     const int nions = get_nions(ielement);
     for (int ilowerion = 0; ilowerion < nions - 1; ilowerion++) {
       ratesum += ion_ntion_energyrate(nonemptymgi, ielement, ilowerion);
-      if (ratesum >= zrand * ratetotal) {
+      // Strict comparison ensures that zrand == 0 skips leading ions with zero rate.
+      if (ratesum > zrand * ratetotal) {
         return {ielement, ilowerion};
       }
     }
@@ -2249,7 +2250,8 @@ DEVICE_FUNC auto nt_random_upperion(const int nonemptymgi, const int element, co
     for (int upperion = lowerion + 1; upperion <= nt_ionisation_maxupperion(element, lowerion); upperion++) {
       prob_sum += nt_ionisation_upperion_probability(nonemptymgi, element, lowerion, upperion, energyweighted);
 
-      if (zrand <= prob_sum) {
+      // Strict comparison ensures that zrand == 0 skips leading zero-probability outcomes.
+      if (zrand < prob_sum) {
         return upperion;
       }
     }


### PR DESCRIPTION
## Summary

- use strict cumulative-distribution boundaries when selecting gamma-ray lines, non-thermal ionisation targets, and Auger outcomes
- apply the same zero-target handling to collisional-excitation transition selection
- document why a zero random target must skip leading entries with zero contribution

## Root cause

Several cumulative samplers accepted equality at the selection boundary. Because the uniform random generator can return zero, a leading entry with zero weight could satisfy the selection condition and be returned even though its probability was zero.

Using strict comparisons makes each sampler select the first entry whose cumulative weight is strictly greater than the target.

## Impact

Zero-probability lines, ions, Auger outcomes, and collisional transitions can no longer be selected when the random variate is exactly zero.

## Validation

- `clang-format --dry-run --Werror gammapkt.cc nonthermal.cc kpkt.cc`
- `clang-tidy -p . -quiet -extra-arg=-isystem/opt/homebrew/Cellar/open-mpi/5.0.9/include gammapkt.cc nonthermal.cc kpkt.cc`
- `cppcheck --enable=warning,performance,portability --std=c++23 --inline-suppr --suppress=missingIncludeSystem gammapkt.cc nonthermal.cc kpkt.cc`
- `make -j2 TESTMODE=ON OPTIMIZE=OFF`
- `git diff --check`