### PR TITLE
Fix MPI reduction, file-write and index-guard defects

### DIFF
--- a/atomic.h
+++ b/atomic.h
@@ -303,9 +303,8 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
   return level <= ION_NLEVELS_EXCITED_NLTE(get_atomicnumber(element), get_ionstage(element, ion));
 }
 
-// Return the elementindex associated with a given atomic number.
-// If there is no element with the given atomic number in the atomic data,
-// then return a negative value
+// Return the elementindex associated with a given atomic number, or -1 if there is no element with the
+// given atomic number in the atomic data.
 [[gnu::pure]] [[nodiscard]] inline auto get_elementindex(const int Z) -> int {
   const auto elem =
       std::ranges::find_if(globals::elements, [Z](const Element& element) { return element.anumber == Z; });
@@ -313,7 +312,7 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
     return static_cast<int>(elem - globals::elements.begin());
   }
 
-  return -100;
+  return -1;
 }
 
 inline void update_includedionslevels_maxnions() {

--- a/decay.cc
+++ b/decay.cc
@@ -1353,6 +1353,9 @@ void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptym
     // use uniform decay time distribution and scale the packet energies instead.
     // keeping the pellet decay rate constant will give better statistics at late times
     // when very little energy and few packets are released
+    // NB: the interpolation endpoints are deliberately (tmax, tdecaymin) rather than the other way round.
+    // The draw is uniform over [tdecaymin, tmax] either way; swapping them would change which decay time
+    // each random number maps to, and hence every result.
     pkt.tdecay = std::lerp(globals::tmax, tdecaymin, rng_uniform(get_rngstate(pkt)));
 
     // we need to scale the packet energy up or down according to decay rate at the randomly selected time.

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -48,14 +48,23 @@ struct GammaLine {
 
 std::vector<std::vector<GammaLine>> gamma_spectra;
 
-struct el_photoion_data {
+struct ElementPhotoionData {
   double energy;  // energy in MeV
   double sigma_xcom;  // cross section in barns/atom
 };
 
-constexpr int numb_xcom_elements = USE_XCOM_GAMMAPHOTOION ? 100 : 0;
+// the XCOM table covers Z = 1..xcom_max_atomic_number (indexed by Z - 1)
+constexpr int xcom_max_atomic_number = USE_XCOM_GAMMAPHOTOION ? 100 : 0;
 
-std::array<std::vector<el_photoion_data>, numb_xcom_elements> photoion_data;
+std::array<std::vector<ElementPhotoionData>, xcom_max_atomic_number> photoion_data;
+
+// Gamma-ray energies expressed as frequencies [Hz]. NB: these are very slightly inconsistent with MEV / H
+// from constants.h (which gives 2.41805e+20 for 1 MeV); the historical values are kept here so that
+// results are unchanged.
+constexpr double nu_100kev = 2.41326e+19;
+constexpr double nu_1mev = 2.41326e+20;
+constexpr double nu_1p022mev = 2.46636e+20;  // electron-positron pair rest mass energy (pair production threshold)
+constexpr double nu_1p5mev = 3.61990e+20;
 
 void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   // read the gamma ray lines and store the average energy in gamma rays per nuclear decay
@@ -212,7 +221,7 @@ void init_gamma_linelist() {
 
 void init_xcom_photoion_data() {
   printlnlog("reading XCOM photoionisation data...");
-  for (int Z = 0; Z < numb_xcom_elements; Z++) {
+  for (int Z = 0; Z < xcom_max_atomic_number; Z++) {
     photoion_data[Z].reserve(100);
   }
 
@@ -224,7 +233,7 @@ void init_xcom_photoion_data() {
     double sigma = 0;
     std::stringstream(line_str) >> Z >> E >> sigma;
     assert_always(Z > 0);
-    assert_always(Z <= numb_xcom_elements);
+    assert_always(Z <= xcom_max_atomic_number);
     // convert XCOM data to cgs units already here
     photoion_data[Z - 1].push_back({.energy = E, .sigma_xcom = sigma * 1e-24});
   }
@@ -440,32 +449,31 @@ void compton_scatter(Packet& pkt) {
   if constexpr (!USE_XCOM_GAMMAPHOTOION) {
     // Cross sections from Equation 2 of Ambwani & Sutherland (1988), attributed to Veigele (1973)
 
-    // 2.41326e19 Hz = 100 keV / H
-    const double hnu_over_100kev = nu_cmf / 2.41326e+19;
+    const double hnu_over_100kev = nu_cmf / nu_100kev;
 
     const double sigma_cmf_si = 1.16e-24 * pow(hnu_over_100kev, -3.13);
 
     const double sigma_cmf_fe = 25.7e-24 * pow(hnu_over_100kev, -3.0);
 
-    // Now need to multiply by the particle number density.
+    // Now need to multiply by the particle number density. The composition is approximated as a mix of just
+    // two species: an iron-group one with mass fraction ffegrp, and silicon for the remainder. The nuclide
+    // number densities therefore use A = 56 for the iron group and A = 28 for silicon.
 
     const double chi_cmf_si = sigma_cmf_si * (rho / MH / 28);
-    // Assumes Z = 14. So mass = 28.
 
     const double chi_cmf_fe = sigma_cmf_fe * (rho / MH / 56);
-    // Assumes Z = 28. So mass = 56.
 
     return (chi_cmf_fe * ffegrp) + (chi_cmf_si * (1. - ffegrp));
   }
 
-  const double hnu_over_1MeV = nu_cmf / 2.41326e+20;
+  const double hnu_over_1MeV = nu_cmf / nu_1mev;
   const double log10_hnu_over_1MeV = log10(hnu_over_1MeV);
   double chi_cmf{0.};
   for (int i = 0; i < get_nelements(); i++) {
     // determine charge number:
     const int Z = get_atomicnumber(i);
-    if (Z > numb_xcom_elements) {
-      continue;  // no XCOM photoionisation data available (table only covers Z = 1..numb_xcom_elements)
+    if (Z > xcom_max_atomic_number) {
+      continue;  // no XCOM photoionisation data available (table only covers Z = 1..xcom_max_atomic_number)
     }
     const auto numb_energies = std::ssize(photoion_data[Z - 1]);
     if (numb_energies == 0) {
@@ -476,37 +484,37 @@ void compton_scatter(Packet& pkt) {
       continue;
     }
     // get indices of lower and upper boundary
-    int E_gtr_idx = -1;
+    int idx_above = -1;
 
     for (int j = 0; j < numb_energies; j++) {
       if (photoion_data[Z - 1][j].energy > hnu_over_1MeV) {
-        E_gtr_idx = j;
+        idx_above = j;
         break;
       }
     }
-    if (E_gtr_idx == 0) {  // packet energy smaller than all tabulated values
+    if (idx_above == 0) {  // packet energy smaller than all tabulated values
       chi_cmf += photoion_data[Z - 1][0].sigma_xcom * n_i;
       continue;
     }
-    if (E_gtr_idx == -1) {  // packet energy greater than all tabulated values
+    if (idx_above == -1) {  // packet energy greater than all tabulated values
       chi_cmf += photoion_data[Z - 1][numb_energies - 1].sigma_xcom * n_i;
       continue;
     }
-    assert_always(E_gtr_idx > 0);
-    assert_always(E_gtr_idx < numb_energies);
-    const int E_smaller_idx = E_gtr_idx - 1;
-    assert_always(E_smaller_idx >= 0);
+    assert_always(idx_above > 0);
+    assert_always(idx_above < numb_energies);
+    const int idx_below = idx_above - 1;
+    assert_always(idx_below >= 0);
     const double log10_E = log10_hnu_over_1MeV;
-    const double log10_E_gtr = log10(photoion_data[Z - 1][E_gtr_idx].energy);
-    const double log10_E_smaller = log10(photoion_data[Z - 1][E_smaller_idx].energy);
-    const double log10_sigma_lower = log10(photoion_data[Z - 1][E_smaller_idx].sigma_xcom);
-    const double log10_sigma_gtr = log10(photoion_data[Z - 1][E_gtr_idx].sigma_xcom);
+    const double log10_E_above = log10(photoion_data[Z - 1][idx_above].energy);
+    const double log10_E_below = log10(photoion_data[Z - 1][idx_below].energy);
+    const double log10_sigma_below = log10(photoion_data[Z - 1][idx_below].sigma_xcom);
+    const double log10_sigma_above = log10(photoion_data[Z - 1][idx_above].sigma_xcom);
     // interpolate or extrapolate, both linear in log10-log10 space
-    const double log10_intpol = log10_sigma_lower + ((log10_sigma_gtr - log10_sigma_lower) /
-                                                     (log10_E_gtr - log10_E_smaller) * (log10_E - log10_E_smaller));
-    const double sigma_intpol = pow(10., log10_intpol);
-    const double chi_cmf_contrib = sigma_intpol * n_i;
-    assert_always(sigma_intpol >= 0.);
+    const double log10_sigma_interp = log10_sigma_below + ((log10_sigma_above - log10_sigma_below) /
+                                                           (log10_E_above - log10_E_below) * (log10_E - log10_E_below));
+    const double sigma_interp = pow(10., log10_sigma_interp);
+    const double chi_cmf_contrib = sigma_interp * n_i;
+    assert_always(sigma_interp >= 0.);
     chi_cmf += chi_cmf_contrib;
   }
   return chi_cmf;
@@ -519,8 +527,8 @@ void compton_scatter(Packet& pkt) {
   }
   const double rho = grid::get_rho(nonemptymgi);
 
-  // 2.46636e+20 Hz = 1022 keV / H
-  if (nu_cmf <= 2.46636e+20) {
+  // below the pair production threshold there is no pair production
+  if (nu_cmf <= nu_1p022mev) {
     return 0.;
   }
 
@@ -529,9 +537,8 @@ void compton_scatter(Packet& pkt) {
 
   // Cross sections from Equation 2 of Ambwani & Sutherland (1988), attributed to Hubbell (1969)
 
-  // 3.61990e+20 = 1500 keV in frequency / H
-  const double hnu_over_mev = nu_cmf / 2.41326e+20;
-  if (nu_cmf > 3.61990e+20) {
+  const double hnu_over_mev = nu_cmf / nu_1mev;
+  if (nu_cmf > nu_1p5mev) {
     sigma_cmf_si = (0.0481 + (0.301 * (hnu_over_mev - 1.5))) * 196.e-27;
 
     sigma_cmf_fe = (0.0481 + (0.301 * (hnu_over_mev - 1.5))) * 784.e-27;
@@ -541,13 +548,12 @@ void compton_scatter(Packet& pkt) {
     sigma_cmf_fe = 1.0063 * (hnu_over_mev - 1.022) * 784.e-27;
   }
 
-  // multiply by the particle number density.
+  // multiply by the particle number density. As in get_chi_photo_electric_cmf(), the composition is
+  // approximated as an iron-group species (A = 56) with mass fraction ffegrp plus silicon (A = 28).
 
   const double chi_cmf_si = sigma_cmf_si * (rho / MH / 28);
-  // Assumes Z = 14. So mass = 28.
 
   const double chi_cmf_fe = sigma_cmf_fe * (rho / MH / 56);
-  // Assumes Z = 28. So mass = 56.
 
   const double chi_cmf = (chi_cmf_fe * ffegrp) + (chi_cmf_si * (1. - ffegrp));
 
@@ -580,7 +586,7 @@ constexpr auto meanf_sigma(const double x) -> double {
   const auto chi_pair_prod_cmf = get_chi_pair_prod_cmf(nonemptymgi, ffegrp, nu_cmf);
 
   return ((meanf_sigma(xx) * grid::get_nnetot(nonemptymgi)) + chi_photo_electric_cmf +
-          (chi_pair_prod_cmf * (1. - (2.46636e+20 / nu_cmf))));
+          (chi_pair_prod_cmf * (1. - (nu_1p022mev / nu_cmf))));
 }
 
 // update the energy deposition estimator for gamma ray path increment
@@ -778,7 +784,9 @@ void absorb_or_escape_gamma(Packet& pkt, const double f_gamma) {
   assert_always(f_gamma <= 1.);
 
   if (rng_uniform(get_rngstate(pkt)) < f_gamma) {
-    // packet is absorbed and contributes to the heating as a k-packet
+    // packet is absorbed and contributes to the heating as a k-packet.
+    // These parameterised thermalisation schemes don't resolve which process absorbed the gamma ray, so the
+    // absorption is recorded under the photoelectric type (the dominant absorber at the relevant energies).
     pkt.type = TYPE_NTLEPTON_DEPOSITED;
     pkt.absorptiontype = ABSTYPE_GAMMA_PHOTOELECTRIC;
   } else {
@@ -803,7 +811,9 @@ void barnes_thermalisation(Packet& pkt)
   const double E_kin = grid::get_ejecta_kinetic_energy();
   const double v_ej = sqrt(E_kin * 2 / grid::mtot_input);
 
-  // t_ineff = sqrt(rho_0 * R_0 * t_0^2 * mean_gamma_opac), expressed via the paper's scaling relation:
+  // t_ineff = sqrt(rho_0 * R_0 * t_0^2 * mean_gamma_opac), expressed via the paper's scaling relation.
+  // The 29979200000 literal is the speed of light in cm/s (it differs from CLIGHT in the 7th digit, and is
+  // left as-is here so that results are unchanged), so 0.2 * it is the paper's reference velocity of 0.2c.
   const double t_ineff = 1.4 * 86400. * sqrt(grid::mtot_input / (5.e-3 * 1.989 * 1.e33)) * ((0.2 * 29979200000) / v_ej);
   const double tau = pow2(t_ineff / pkt.prop_time);
   const double f_gamma = 1. - exp(-tau);

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -952,8 +952,10 @@ DEVICE_FUNC void do_gamma(Packet& pkt, const int nts, const double t2) {
     if constexpr (GAMMA_THERMALISATION_SCHEME != GammaThermalisationScheme::FREQUENCYDEPENDENT) {
       // no transport, so the path-based gamma deposition estimator won't get updated unless we do it here
       const int mgi = grid::get_propcell_modelgridindex(pkt.cellindex);
-      const int nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
-      atomicadd(globals::dep_estimator_gamma[nonemptymgi], pkt.e_cmf);
+      if (mgi >= 0) {  // empty cells have no deposition estimator
+        const int nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
+        atomicadd(globals::dep_estimator_gamma[nonemptymgi], pkt.e_cmf);
+      }
     }
   }
 }

--- a/globals.h
+++ b/globals.h
@@ -97,7 +97,11 @@ struct TimeStep {
   double eps_alpha_ana_power{0.};  // cmf alpha KE energy generation rate analytical [erg/s]
   ALIGNAS_AVOID_FALSE_SHARING double spfission_dep_discrete{
       0.,
-  };  // cmf spontaneous fission energy deposition from absorption events [erg]
+  };  // cmf spontaneous fission energy deposition from absorption events [erg].
+      // Unlike the other *_dep_discrete counters, this is accumulated at pellet decay in update_pellet()
+      // rather than at a separate deposition event, because a spontaneous fission pellet converts straight
+      // to TYPE_NTALPHA_FISPROD_DEPOSITED. Emission and deposition therefore coincide, which is why
+      // write_deposition_file() uses this same member in both the total deposition and the total emission sums.
   double eps_spfission_ana_power{0.};  // cmf spontaneous fission energy generation rate analytical [erg/s]
   ALIGNAS_AVOID_FALSE_SHARING double gamma_emission{0.};  // gamma decay energy generation in this timestep [erg]
   double qdot_betaminus{0.};  // energy generation from beta-minus decays (including neutrinos) [erg/s/g]

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -56,7 +56,8 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
   const auto T_e = grid::get_Te(nonemptymgi);
 
   double C_ion = 0.;
-  [[maybe_unused]] int i = 0;  // NOLINT(misc-const-correctness)
+  // cursor into this ion's slice of the cooling list, only advanced when we are filling the cellcache
+  [[maybe_unused]] int coolinglistindex = 0;  // NOLINT(misc-const-correctness)
 
   const int nionisinglevels = get_nlevels_ionising(element, ion);
   const double nncurrention = get_nnion(nonemptymgi, element, ion);
@@ -68,11 +69,12 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     C_ion += C_ff_ion;
 
     if constexpr (update_cellcache_contribs) {
-      ion_contribs[i] = C_ion;
+      ion_contribs[coolinglistindex] = C_ion;
 
-      assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + i] == CoolingType::FREEFREE);
+      assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + coolinglistindex] ==
+                          CoolingType::FREEFREE);
 
-      i++;
+      coolinglistindex++;
     } else {
       *C_ff += C_ff_ion;
     }
@@ -106,11 +108,12 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
     }
     if constexpr (update_cellcache_contribs) {
       if (nuptrans > 0) {
-        ion_contribs[i] = C_ion;
+        ion_contribs[coolinglistindex] = C_ion;
 
-        assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + i] == CoolingType::COLLEXC);
+        assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + coolinglistindex] ==
+                            CoolingType::COLLEXC);
 
-        i++;
+        coolinglistindex++;
       }
     }
   }
@@ -135,13 +138,14 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
 
         C_ion += C;
         if constexpr (update_cellcache_contribs) {
-          ion_contribs[i] = C_ion;
+          ion_contribs[coolinglistindex] = C_ion;
 
-          assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + i] == CoolingType::COLLION);
-          assert_testmodeonly(coolinglist_level[get_coolinglistoffset(element, ion) + i] == level);
-          assert_testmodeonly(coolinglist_upperlevel[get_coolinglistoffset(element, ion) + i] == upper);
+          assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + coolinglistindex] ==
+                              CoolingType::COLLION);
+          assert_testmodeonly(coolinglist_level[get_coolinglistoffset(element, ion) + coolinglistindex] == level);
+          assert_testmodeonly(coolinglist_upperlevel[get_coolinglistoffset(element, ion) + coolinglistindex] == upper);
 
-          i++;
+          coolinglistindex++;
         } else {
           *C_ionisation += C;
         }
@@ -165,14 +169,15 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
         C_ion += C;
 
         if constexpr (update_cellcache_contribs) {
-          ion_contribs[i] = C_ion;
+          ion_contribs[coolinglistindex] = C_ion;
 
-          assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + i] == CoolingType::FREEBOUND);
-          assert_testmodeonly(coolinglist_level[get_coolinglistoffset(element, ion) + i] == level);
-          assert_testmodeonly(coolinglist_upperlevel[get_coolinglistoffset(element, ion) + i] ==
+          assert_testmodeonly(coolinglist_type[get_coolinglistoffset(element, ion) + coolinglistindex] ==
+                              CoolingType::FREEBOUND);
+          assert_testmodeonly(coolinglist_level[get_coolinglistoffset(element, ion) + coolinglistindex] == level);
+          assert_testmodeonly(coolinglist_upperlevel[get_coolinglistoffset(element, ion) + coolinglistindex] ==
                               get_phixsupperlevel(uniquelevelindex, phixstargetindex));
 
-          i++;
+          coolinglistindex++;
         } else {
           *C_fb += C;
         }
@@ -181,7 +186,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
   }
 
   if constexpr (update_cellcache_contribs) {
-    assert_always(i == std::ssize(ion_contribs));
+    assert_always(coolinglistindex == std::ssize(ion_contribs));
   }
 
   return C_ion;

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -290,14 +290,15 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
     }
   }
 
-  double factor = 1.;
-  int ion = 0;
-  for (ion = 0; ion < uppermost_ion; ion++) {
+  // running product of nne * phi over the ions below, i.e. the population ratio of the ground ion to ion+1.
+  // Once it overflows to infinity the higher ions are utterly negligible, so the list is truncated there.
+  double pop_ratio_ground_to_upper = 1.;
+  for (int ion = 0; ion < uppermost_ion; ion++) {
     const auto phifactor =
         use_phi_saha ? phi_saha(element, ion, nonemptymgi) : phi_rate_balance(element, ion, nonemptymgi);
-    factor *= nne_hi * phifactor;
+    pop_ratio_ground_to_upper *= nne_hi * phifactor;
 
-    if (!std::isfinite(factor)) {
+    if (!std::isfinite(pop_ratio_ground_to_upper)) {
       printlnlog(
           "[info] calculate_ion_balance_nne: uppermost_ion limited by phi factors for element Z={}, ionstage {} in "
           "cell {}",

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -213,7 +213,10 @@ struct NonThermalCellSolution {
 
 MPI_shared_array<NonThermalCellSolution> nt_solution;
 
-MPI_shared_array<double> deposition_rate_density_all_cells;
+// Deposition rate density [erg/s/cm3] available to the non-thermal lepton (Spencer-Fano) treatment:
+// gamma-ray, positron and electron deposition only. Alpha particles and spontaneous fission fragments
+// deposit as pure heating and are accounted for separately in HeatingCoolingRates (see thermalbalance.cc).
+MPI_shared_array<double> ntlepton_deposition_rate_density_all_cells;
 
 constexpr auto uppertriangular(const int i, const int j) -> int {
   assert_testmodeonly(i >= 0);
@@ -1146,7 +1149,7 @@ auto calculate_nt_frac_ionisation_shell(const int nonemptymgi, const int element
 
 // non-thermal ionisation rate coefficient (multiply by population to get rate)
 auto nt_ionisation_ratecoeff_wfapprox(const int nonemptymgi, const int element, const int ion) -> double {
-  const double deposition_rate_density = get_deposition_rate_density(nonemptymgi);
+  const double deposition_rate_density = get_ntlepton_deposition_rate_density(nonemptymgi);
   // to get the non-thermal ionisation rate we need to divide the energy deposited
   // per unit volume per unit time in the grid cell (sum of terms above)
   // by the total ion number density and the "work per ion pair"
@@ -1195,7 +1198,7 @@ auto calculate_nt_ionisation_ratecoeff(const int nonemptymgi, const int element,
   const double y_xs_de =
       std::inner_product(yfunc.begin(), yfunc.end(), cross_section_vec_allshells.begin(), 0.0) * DELTA_E;
 
-  const double deposition_rate_density_ev = get_deposition_rate_density(nonemptymgi) / EV;
+  const double deposition_rate_density_ev = get_ntlepton_deposition_rate_density(nonemptymgi) / EV;
   const double yscalefactor = deposition_rate_density_ev / E_init_ev;
 
   return yscalefactor * y_xs_de;
@@ -1314,7 +1317,7 @@ auto get_eff_ionpot(const int nonemptymgi, const int element, const int ion) {
 // Kozma & Fransson 1992 equation 13
 // returns the rate coefficient in s^-1
 auto nt_ionisation_ratecoeff_sf(const int nonemptymgi, const int element, const int ion) -> double {
-  const double deposition_rate_density = get_deposition_rate_density(nonemptymgi);
+  const double deposition_rate_density = get_ntlepton_deposition_rate_density(nonemptymgi);
   if (deposition_rate_density > 0.) {
     return deposition_rate_density / get_nnion_tot(nonemptymgi) / get_eff_ionpot(nonemptymgi, element, ion);
   }
@@ -1681,7 +1684,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
                                      &NonThermalExcitation::frac_deposition);
 
     // the excitation list is now sorted by frac_deposition descending
-    const double deposition_rate_density = get_deposition_rate_density(nonemptymgi);
+    const double deposition_rate_density = get_ntlepton_deposition_rate_density(nonemptymgi);
 
     if (std::ssize(tmp_excitation_list) > nt_excitations_stored) {
       // truncate the sorted list to save memory
@@ -1749,14 +1752,15 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
   }  // NT_EXCITATION_ON
 
   // calculate number density of non-thermal electrons
-  const double deposition_rate_density_ev = get_deposition_rate_density(nonemptymgi) / EV;
+  const double deposition_rate_density_ev = get_ntlepton_deposition_rate_density(nonemptymgi) / EV;
   const double yscalefactor = deposition_rate_density_ev / E_init_ev;
 
   double nne_nt_max = 0.;
   for (int i = 0; i < SFPTS; i++) {
     const double endash = engrid(i);
     const double delta_endash = DELTA_E;
-    const double oneovervelocity = std::sqrt(9.10938e-31 / 2 / endash / 1.60218e-19) / 100;  // in sec/cm
+    // 1 / v for a non-relativistic electron of kinetic energy endash [eV], in sec/cm
+    const double oneovervelocity = std::sqrt(ME / (2 * endash * EV));
     nne_nt_max += yscalefactor * yfunc[i] * oneovervelocity * delta_endash;
   }
 
@@ -2049,10 +2053,10 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
 void init() {
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
 
-  deposition_rate_density_all_cells = MPI_shared_array<double>(nonempty_npts_model);
+  ntlepton_deposition_rate_density_all_cells = MPI_shared_array<double>(nonempty_npts_model);
 
   if (globals::rank_in_node == 0) {
-    std::ranges::fill(deposition_rate_density_all_cells, -1.);
+    std::ranges::fill(ntlepton_deposition_rate_density_all_cells, -1.);
   }
 
   if (!NT_ON) {
@@ -2159,14 +2163,15 @@ void calculate_deposition_rate_density(const int nonemptymgi, const int timestep
   // spontaneous fission contribution is always treated as instant deposition
   heatingcoolingrates.dep_spfission = heatingcoolingrates.eps_spfission_ana;
 
-  deposition_rate_density_all_cells[nonemptymgi] =
+  ntlepton_deposition_rate_density_all_cells[nonemptymgi] =
       (heatingcoolingrates.dep_gamma + heatingcoolingrates.dep_positron + heatingcoolingrates.dep_electron);
 }
 
-// get non-thermal deposition rate density in erg / s / cm^3 previously stored by calculate_deposition_rate_density()
-DEVICE_FUNC auto get_deposition_rate_density(const int nonemptymgi) -> double {
-  assert_always(deposition_rate_density_all_cells[nonemptymgi] >= 0);
-  return deposition_rate_density_all_cells[nonemptymgi];
+// get the non-thermal lepton deposition rate density (gamma + positron + electron, excluding alpha and
+// spontaneous fission) in erg / s / cm^3, previously stored by calculate_deposition_rate_density()
+DEVICE_FUNC auto get_ntlepton_deposition_rate_density(const int nonemptymgi) -> double {
+  assert_always(ntlepton_deposition_rate_density_all_cells[nonemptymgi] >= 0);
+  return ntlepton_deposition_rate_density_all_cells[nonemptymgi];
 }
 
 auto get_nt_frac_heating(const int nonemptymgi) -> float {
@@ -2291,7 +2296,7 @@ DEVICE_FUNC auto nt_excitation_ratecoeff(const int nonemptymgi, const int lowerl
     return 0.;
   }
 
-  const double deposition_rate_density = get_deposition_rate_density(nonemptymgi);
+  const double deposition_rate_density = get_ntlepton_deposition_rate_density(nonemptymgi);
   const double ratecoeffperdeposition = ntexcitation->ratecoeffperdeposition;
 
   return ratecoeffperdeposition * deposition_rate_density;
@@ -2403,11 +2408,11 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
   if (timestep < globals::num_lte_timesteps + 1) {
     printlnlog("Skipping Spencer-Fano solution for first NLTE timestep");
     skip_solution = true;
-  } else if (get_deposition_rate_density(nonemptymgi) / EV < MINDEPRATE) {
+  } else if (get_ntlepton_deposition_rate_density(nonemptymgi) / EV < MINDEPRATE) {
     printlnlog(
         "Non-thermal deposition rate of {:g} eV/cm/s/cm^3 below  MINDEPRATE {:g} in cell {} at timestep {}. Skipping "
         "Spencer-Fano solution.",
-        get_deposition_rate_density(nonemptymgi) / EV, MINDEPRATE, modelgridindex, timestep);
+        get_ntlepton_deposition_rate_density(nonemptymgi) / EV, MINDEPRATE, modelgridindex, timestep);
 
     skip_solution = true;
   }
@@ -2516,7 +2521,7 @@ void write_restart_data(FILE* gridsave_file) {
   fprintf(gridsave_file, "%d %la %la\n", SFPTS, SF_EMIN, SF_EMAX);
 
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
-    fprintf(gridsave_file, "%d %la ", nonemptymgi, deposition_rate_density_all_cells[nonemptymgi]);
+    fprintf(gridsave_file, "%d %la ", nonemptymgi, ntlepton_deposition_rate_density_all_cells[nonemptymgi]);
 
     if (NT_ON && NT_SOLVE_SPENCERFANO) {
       check_auger_probabilities(nonemptymgi);
@@ -2568,8 +2573,8 @@ void read_restart_data(FILE* gridsave_file) {
 
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     int nonemptymgi_in = 0;
-    assert_always(fscanf(gridsave_file, "%d %la ", &nonemptymgi_in, &deposition_rate_density_all_cells[nonemptymgi]) ==
-                  2);
+    assert_always(fscanf(gridsave_file, "%d %la ", &nonemptymgi_in,
+                         &ntlepton_deposition_rate_density_all_cells[nonemptymgi]) == 2);
     assert_always(nonemptymgi_in == nonemptymgi);
 
     if (NT_ON && NT_SOLVE_SPENCERFANO) {
@@ -2609,7 +2614,7 @@ void read_restart_data(FILE* gridsave_file) {
 }
 
 void nt_MPI_Bcast(const ptrdiff_t nonemptymgi, const int root_node_id) {
-  MPI_Bcast_safe(deposition_rate_density_all_cells[nonemptymgi], root_node_id, globals::mpi_comm_internode);
+  MPI_Bcast_safe(ntlepton_deposition_rate_density_all_cells[nonemptymgi], root_node_id, globals::mpi_comm_internode);
 
   if (NT_ON && NT_SOLVE_SPENCERFANO) {
     if (globals::rank_in_node == 0) {

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -25,7 +25,9 @@ void solve_spencerfano(int nonemptymgi, int timestep, int iteration);
 [[nodiscard]] DEVICE_FUNC auto nt_random_upperion(int nonemptymgi, int element, int lowerion, bool energyweighted,
                                                   rngstate_type& rngstate) -> int;
 void calculate_deposition_rate_density(int nonemptymgi, int timestep, HeatingCoolingRates& heatingcoolingrates);
-[[nodiscard]] DEVICE_FUNC auto get_deposition_rate_density(int nonemptymgi) -> double;
+// deposition rate density [erg/s/cm3] of the non-thermal leptons handled by the Spencer-Fano solver, i.e.
+// gamma + positron + electron. Alpha and spontaneous fission deposition are tracked separately.
+[[nodiscard]] DEVICE_FUNC auto get_ntlepton_deposition_rate_density(int nonemptymgi) -> double;
 [[nodiscard]] auto get_nt_frac_heating(int nonemptymgi) -> float;
 
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto nt_excitation_ratecoeff(int nonemptymgi, int lowerlevel, int upperlevel,

--- a/radfield.cc
+++ b/radfield.cc
@@ -216,11 +216,14 @@ void update_bfestimators(const ptrdiff_t nonemptymgi, const double distance_e_cm
                             std::ranges::upper_bound(globals::bfestim_nu_edge.first(phixslist.bfestimend), nu_cmf));
   assert_testmodeonly(bfestimend <= bfestimcount);
   assert_testmodeonly(phixslist.bfestimbegin >= 0);
+  // bfestimend was recalculated from the current (lower) nu_cmf, so it can fall below the bfestimbegin that
+  // was stored for the higher nu_cmf. Clamp so that the subspan count below can never go negative (which
+  // would wrap to a huge size_t), which just leaves an empty range with no contributions to make.
+  const auto bfestimbegin_stored = std::min<ptrdiff_t>(phixslist.bfestimbegin, bfestimend);
   const auto bfestimbegin = std::ranges::distance(
       globals::bfestim_nu_edge.begin(),
-      std::ranges::lower_bound(
-          globals::bfestim_nu_edge.subspan(phixslist.bfestimbegin, bfestimend - phixslist.bfestimbegin),
-          nu_cmf / last_phixs_nuovernuedge));
+      std::ranges::lower_bound(globals::bfestim_nu_edge.subspan(bfestimbegin_stored, bfestimend - bfestimbegin_stored),
+                               nu_cmf / last_phixs_nuovernuedge));
 
   for (auto bfestimindex = bfestimbegin; bfestimindex < bfestimend; bfestimindex++) {
     atomicadd(bfrate_raw[(nonemptymgi * bfestimcount) + bfestimindex],

--- a/radfield.cc
+++ b/radfield.cc
@@ -446,7 +446,7 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
   }
 }
 
-auto get_bfcontindex(const int element, const int lowerion, const int lower, const int phixstargetindex) -> int {
+auto get_allcontindex(const int element, const int lowerion, const int lower, const int phixstargetindex) -> int {
   // simple linear search seems to be faster than the binary search
   // possibly because lower frequency transitions near start of list are more likely to be called?
   int bfcontindex = 0;
@@ -891,7 +891,7 @@ void normalise_bf_estimators(const int nts, const int nts_prev, const int titer,
                                                                   const int lower, const int phixstargetindex,
                                                                   const int nonemptymgi) -> double {
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {
-    const int allcontindex = get_bfcontindex(element, lowerion, lower, phixstargetindex);
+    const int allcontindex = get_allcontindex(element, lowerion, lower, phixstargetindex);
     if (allcontindex >= 0) {
       const auto bfestimindex = globals::allcont.bfestimindex[allcontindex];
       if (bfestimindex >= 0) {

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -535,34 +535,38 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
   const double deltanu = nu_range / npieces;
   double error{NAN};
 
-  const auto total_alpha_sp = integrator<31>(
+  // integral of the energy-weighted emissivity over the whole continuum, i.e. the normalisation of the
+  // distribution that we are sampling a frequency from
+  const auto emissivity_integral_total = integrator<31>(
       [&](const double nu_minus_nu_edge) {
         return alpha_sp_E_integrand(nu_minus_nu_edge, nu_threshold, T_e, photoion_xs);
       },
       0., nu_range, RATECOEFF_INTEGRAL_ACCURACY, &error);
 
-  assert_testmodeonly(std::isfinite(total_alpha_sp));
-  assert_testmodeonly(total_alpha_sp > 0.);
-  if (!(total_alpha_sp > 0.) || !std::isfinite(total_alpha_sp)) {
+  assert_testmodeonly(std::isfinite(emissivity_integral_total));
+  assert_testmodeonly(emissivity_integral_total > 0.);
+  if (!(emissivity_integral_total > 0.) || !std::isfinite(emissivity_integral_total)) {
     return nu_threshold;
   }
 
-  double alpha_sp_old = total_alpha_sp;
-  double alpha_sp = total_alpha_sp;
+  // emissivity_tailintegral is the part of the integral above the current piece's lower boundary, so it
+  // decreases from emissivity_integral_total to zero as we step up in frequency. _prev is its value at the
+  // previous piece boundary.
+  double emissivity_tailintegral_prev = emissivity_integral_total;
+  double emissivity_tailintegral = emissivity_integral_total;
 
   int i = 1;
   for (; i < npieces; i++) {
-    alpha_sp_old = alpha_sp;
+    emissivity_tailintegral_prev = emissivity_tailintegral;
     const double nu_minus_nu_edge_low = i * deltanu;
 
-    // Spontaneous recombination and bf-cooling coefficient don't depend on the radiation field
-    alpha_sp = integrator<31>(
+    emissivity_tailintegral = integrator<31>(
         [&](const double nu_minus_nu_edge) {
           return alpha_sp_E_integrand(nu_minus_nu_edge, nu_threshold, T_e, photoion_xs);
         },
         nu_minus_nu_edge_low, nu_range, RATECOEFF_INTEGRAL_ACCURACY, &error);
 
-    if (zrand >= alpha_sp / total_alpha_sp) {
+    if (zrand >= emissivity_tailintegral / emissivity_integral_total) {
       break;
     }
   }
@@ -571,22 +575,23 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
   if (i < npieces) {
     // the loop found the piece containing the target value, so interpolate between the remaining
     // integrals at the piece boundaries
-    nuoffset = (alpha_sp != alpha_sp_old)
-                   ? ((total_alpha_sp * zrand) - alpha_sp_old) / (alpha_sp - alpha_sp_old) * deltanu
+    nuoffset = (emissivity_tailintegral != emissivity_tailintegral_prev)
+                   ? ((emissivity_integral_total * zrand) - emissivity_tailintegral_prev) /
+                         (emissivity_tailintegral - emissivity_tailintegral_prev) * deltanu
                    : 0.;
-  } else if (alpha_sp > 0.) {
-    // the loop completed without a break, so the target lies in the topmost piece, where the
-    // remaining integral falls from alpha_sp at the piece's lower boundary to zero at nu_max_phixs.
-    // Interpolating with the previous piece's values here would extrapolate to nu_lower > nu_max_phixs.
-    nuoffset = (alpha_sp - (total_alpha_sp * zrand)) / alpha_sp * deltanu;
+  } else if (emissivity_tailintegral > 0.) {
+    // the loop completed without a break, so the target lies in the topmost piece, where the remaining
+    // integral falls from emissivity_tailintegral at the piece's lower boundary to zero at nu_max_phixs.
+    // Interpolating with the previous piece's values here would extrapolate beyond nu_max_phixs.
+    nuoffset = (emissivity_tailintegral - (emissivity_integral_total * zrand)) / emissivity_tailintegral * deltanu;
   }
-  const double nu_lower = nu_threshold + ((i - 1) * deltanu) + nuoffset;
+  const double nu_sampled = nu_threshold + ((i - 1) * deltanu) + nuoffset;
 
-  assert_testmodeonly(std::isfinite(nu_lower));
-  assert_testmodeonly(nu_lower >= nu_threshold);
-  assert_testmodeonly(nu_lower <= nu_max_phixs);
+  assert_testmodeonly(std::isfinite(nu_sampled));
+  assert_testmodeonly(nu_sampled >= nu_threshold);
+  assert_testmodeonly(nu_sampled <= nu_max_phixs);
 
-  return nu_lower;
+  return nu_sampled;
 }
 
 // Get an ion's rate coefficient for spontaneous recombination in LTE

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -45,8 +45,10 @@ namespace {
 // kappa times Planck function for each bin of each non-empty cell
 MPI_shared_array<double> expansionopacity_planck_cumulative{};
 
-// get the frequency change per distance travelled assuming linear change to the abort distance
-// this is done is two parts to get identical results to do_rpkt_step()
+// get the comoving-frame frequency that the packet will have redshifted to at the abort distance (the cell
+// boundary or the end of the timestep, whichever is nearer). The caller turns this into a frequency change
+// per unit distance for the linear interpolation along the path.
+// The move is done in two halves to give bit-identical results to the two half-steps in do_rpkt_step().
 auto get_nu_cmf_abort(const Vec3d& pos, const Vec3d& dir, const double prop_time, const double nu_rf,
                       const double abort_dist) -> double {
   const auto half_abort_dist = abort_dist / 2.;

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -372,7 +372,8 @@ void mpi_communicate_grid_properties() {
     }
     const ptrdiff_t root_nstart_nonempty = grid::get_nstart_nonempty(root);
     assert_always(root_nstart_nonempty >= 0);
-    assert_always((root_nstart_nonempty + root_ndo_nonempty - 1) <= grid::get_nonempty_npts_model());
+    // the highest index accessed below is (nstart + ndo - 1), which must be a valid index
+    assert_always((root_nstart_nonempty + root_ndo_nonempty - 1) < grid::get_nonempty_npts_model());
 
     if (USE_LUT_PHOTOION && globals::nbfcontinua_ground > 0) {
       MPI_Bcast_safe(std::span{globals::gammaestimator}.subspan(root_nstart_nonempty * globals::nbfcontinua_ground,
@@ -542,6 +543,9 @@ void mpi_reduce_estimators(const int nts) {
 
   MPI_Allreduce_safe(globals::timesteps[nts].alpha_emission, MPI_SUM, MPI_COMM_WORLD);
   globals::timesteps[nts].alpha_emission /= globals::nprocs;
+
+  MPI_Allreduce_safe(globals::timesteps[nts].spfission_dep_discrete, MPI_SUM, MPI_COMM_WORLD);
+  globals::timesteps[nts].spfission_dep_discrete /= globals::nprocs;
 
   MPI_Allreduce_safe(globals::timesteps[nts].gamma_emission, MPI_SUM, MPI_COMM_WORLD);
   globals::timesteps[nts].gamma_emission /= globals::nprocs;
@@ -916,10 +920,12 @@ auto main(int argc, char* argv[]) -> int {
 
   MPI_Barrier_allranks();
 
-  // Record the chosen syn_dir
-  auto syn_file = fstream_required("syn_dir.txt", std::ios::out | std::ios::trunc);
-  std::print(syn_file, "{} {} {}", syn_dir[0], syn_dir[1], syn_dir[2]);
-  syn_file.close();
+  // Record the chosen syn_dir (only one rank writes it, since every rank would write the same file)
+  if (globals::my_rank == 0) {
+    auto syn_file = fstream_required("syn_dir.txt", std::ios::out | std::ios::trunc);
+    std::print(syn_file, "{} {} {}", syn_dir[0], syn_dir[1], syn_dir[2]);
+    syn_file.close();
+  }
 
   bool terminate_early = false;
 

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -50,7 +50,7 @@ constexpr double traceemissabs_nuupper = (1.e8 * CLIGHT / traceemissabs_lambdami
 constexpr double traceemissabs_timemin = (320. * DAY);
 constexpr double traceemissabs_timemax = (340. * DAY);
 
-struct emissionabsorptioncontrib {
+struct EmissionAbsorptionContrib {
   double energyemitted;
   double emission_weightedvelocity_sum;
   double energyabsorbed;
@@ -58,7 +58,7 @@ struct emissionabsorptioncontrib {
   int lineindex;  // this will be important when the list gets sorted
 };
 
-std::vector<emissionabsorptioncontrib> traceemissionabsorption;
+std::vector<EmissionAbsorptionContrib> traceemissionabsorption;
 double traceemission_totalenergy = 0.;
 double traceabsorption_totalenergy = 0.;
 
@@ -88,7 +88,7 @@ void printout_tracemission_stats() {
           traceemission_totalenergy);
     } else {
       std::ranges::SORT_OR_STABLE_SORT(traceemissionabsorption, std::ranges::greater{},
-                                       &emissionabsorptioncontrib::energyabsorbed);
+                                       &EmissionAbsorptionContrib::energyabsorbed);
       printlnlog(
           "Top line absorption contributions in the range lambda [{:5.1f}, {:5.1f}] time [{:5.1f}d, {:5.1f}d] ({:g} "
           "erg)",
@@ -200,7 +200,7 @@ auto columnindex_from_emissiontype(const int et) -> int {
   return (get_nelements() * get_max_nions()) + (element * get_max_nions()) + ion;
 }
 
-[[nodiscard]] auto get_absindex(const ptrdiff_t nts, const ptrdiff_t nnu_abs) -> ptrdiff_t {
+[[nodiscard]] auto get_absorption_spectrum_index(const ptrdiff_t nts, const ptrdiff_t nnu_abs) -> ptrdiff_t {
   const ptrdiff_t nelements = get_nelements();
   const ptrdiff_t max_nions = get_max_nions();
   return (nnu_abs * globals::ntimesteps * nelements * max_nions) + (nts * nelements * max_nions);
@@ -354,7 +354,8 @@ void write_absorption_spectrum_file(const std::string& absorption_filename, cons
   for (auto nubin = 0Z; nubin < MNUBINS; nubin++) {
     for (auto nts = 0Z; nts < numtimesteps; nts++) {
       for (int i = 0; i < ioncount; i++) {
-        std::print(absorption_file, "{:g} ", spectra.absorptionalltimesteps[get_absindex(nts, nubin) + i]);
+        std::print(absorption_file, "{:g} ",
+                   spectra.absorptionalltimesteps[get_absorption_spectrum_index(nts, nubin) + i]);
       }
       std::println(absorption_file, "");
     }
@@ -455,7 +456,8 @@ void write_specpol(const std::string& specpol_filename, const std::string& emiss
             if (i > 0) {
               std::print(absorptionpol_file, " ");
             }
-            std::print(absorptionpol_file, "{:g}", spec->absorptionalltimesteps[get_absindex(nts, nnu) + i]);
+            std::print(absorptionpol_file, "{:g}",
+                       spec->absorptionalltimesteps[get_absorption_spectrum_index(nts, nnu) + i]);
           }
           std::println(absorptionpol_file, "");
         }
@@ -619,7 +621,7 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra_I, Sp
           // bb-absorption
           const int element = globals::linelist.elementindex[at];
           const int ion = globals::linelist.ionindex[at];
-          const auto absindex = get_absindex(nts, nnu_abs) + (element * get_max_nions()) + ion;
+          const auto absindex = get_absorption_spectrum_index(nts, nnu_abs) + (element * get_max_nions()) + ion;
           atomicadd_always(spectra_I.absorptionalltimesteps[absindex], deltaE_absorption);
 
           if (spectra_Q != nullptr && spectra_Q->do_emission_absorption) {

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -38,7 +38,10 @@
 
 namespace {
 
-bool TRACE_EMISSION_ABSORPTION_REGION_ON = false;
+// Set to true to print the strongest line emission/absorption contributions in a fixed wavelength and time
+// window (see the traceemissabs_* limits below). This only works in exspec, which is the only caller of
+// init_spectrum_trace(), i.e. the only place where the traceemissionabsorption list is allocated.
+constexpr bool TRACE_EMISSION_ABSORPTION_REGION_ON = false;
 
 constexpr double traceemissabs_lambdamin = 1000.;  // in Angstroms
 constexpr double traceemissabs_lambdamax = 25000.;
@@ -233,8 +236,6 @@ void write_partial_lightcurve_spectra_dirbin(const int nts, std::span<const Pack
     reserve_resize(gamma_light_curve_lumcmf, globals::ntimesteps);
     std::ranges::fill(gamma_light_curve_lumcmf, 0.);
   }
-
-  TRACE_EMISSION_ABSORPTION_REGION_ON = false;
 
   init_spectra(rpkt_spectra_I, NU_MIN_R, NU_MAX_R, do_emission_absorption);
 
@@ -594,7 +595,9 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra_I, Sp
         }
       }
 
-      if (TRACE_EMISSION_ABSORPTION_REGION_ON && (dirbin == -1)) {
+      // traceemissionabsorption is only allocated by init_spectrum_trace(), which sn3d never calls, so
+      // check that it has been set up before indexing into it
+      if (TRACE_EMISSION_ABSORPTION_REGION_ON && (dirbin == -1) && !traceemissionabsorption.empty()) {
         const int et = pkt.trueemissiontype;
         if ((et >= 0) && (t_arrive >= traceemissabs_timemin && t_arrive <= traceemissabs_timemax) &&
             (pkt.nu_rf >= traceemissabs_nulower && pkt.nu_rf <= traceemissabs_nuupper))
@@ -626,8 +629,8 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra_I, Sp
             atomicadd_always(spectra_U->absorptionalltimesteps[absindex], pkt.stokes_u * deltaE_absorption);
           }
 
-          if ((TRACE_EMISSION_ABSORPTION_REGION_ON && t_arrive >= traceemissabs_timemin &&
-               t_arrive <= traceemissabs_timemax) &&
+          if ((TRACE_EMISSION_ABSORPTION_REGION_ON && !traceemissionabsorption.empty() &&
+               t_arrive >= traceemissabs_timemin && t_arrive <= traceemissabs_timemax) &&
               ((dirbin == -1) && (pkt.nu_rf >= traceemissabs_nulower) && (pkt.nu_rf <= traceemissabs_nuupper))) {
             traceemissionabsorption[at].energyabsorbed += deltaE_absorption;
             const auto vel_vec = get_velocity(pkt.em_pos, pkt.em_time);

--- a/tests/kilonova_1d_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_1d_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 360b1d4cb1291cb793cbba3911461198  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-c54233aeb25341644d8be743cfebe585  deposition.out
+fb6b39e3993c2d931e04baddc4dbd581  deposition.out
 bc2a166881d9c9ae2c37dbfd185287b6  emission.out
 e488892a663f4601000d0fdd00dd7d70  emissiontrue.out
 ffb4284fc746264a43ce59c7a9cbba9e  gamma_light_curve.out

--- a/tests/kilonova_1d_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_1d_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 056a69b7aa3d53a4ad316890c57e5575  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-d713e7004f9ede3e1aa3000d3f79ab09  deposition.out
+f7556f8b69d90ec0183738616fe245cb  deposition.out
 5053a3325e5890036bae64fd4066ebb3  emission.out
 ceab4edbda13da21e96d7231ea4bb391  emissiontrue.out
 72d54cb832603187ac91c06859a50570  gamma_light_curve.out

--- a/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 a4d7582a62cf48ed97733d81916f5134  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-cb57dbcab7ac545abf11d522fe8fa842  deposition.out
+daa38fb7df4bf70834db746d7ca1c1a2  deposition.out
 155e1cda3fe0d5725d8c788b997242c5  emission.out
 00f40bf7928ed71a92a6d6d11975fc78  emissiontrue.out
 93ba28a1d281bb48999cc80be47356e7  gamma_light_curve.out

--- a/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_barnesthermalisation_inputfiles/results_md5_job0.txt
@@ -1,5 +1,5 @@
 897316929176464ebc9ad085f31e7284  bflist.out
-da86d45d121e95d449d5d6b052925b10  deposition.out
+00af2b1e6ddf906f0a81b4eec8ffc091  deposition.out
 e8184231da559af4b3126c81608654fc  gamma_light_curve.out
 3f5bfe0a49e6832660967ad0090c8789  gammalinelist.out
 29ac1cb06f3139df7cbca0bbdb426e1c  grid.out

--- a/tests/kilonova_2d_expansionopac_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_expansionopac_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 c3c0d55a0472ab5d62a76c24ef614918  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-22921a4965fd97c02bb0ac5febe327ce  deposition.out
+942a4ecc24732b08a59d1540c0a1b3e3  deposition.out
 20462b75566609b422ac8dcf60458bb2  emission.out
 321ece2a7759b37a7da621cd7a4eee90  emissiontrue.out
 e11a3881ed4b24a495a54669edba6a0c  gamma_light_curve.out

--- a/tests/kilonova_2d_expansionopac_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_expansionopac_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 0fe358e0cec80c0ab1852d2e5a9147a1  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-33ae8fbc912e8724dd86e22d60cd2c10  deposition.out
+75653fe4ac40fe92042750142df50d8c  deposition.out
 fe621c0177ac652fe49fb4fcfa584407  emission.out
 f5902ae8e529c0e852df6b3614fd1597  emissiontrue.out
 c9f5f6beb93b1de3feca20bb084509a1  gamma_light_curve.out

--- a/tests/kilonova_2d_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 03fe75f2cdd1fa2e3707c3cc2973446a  absorption.out
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-0ab0a507c917417df9e26c0bd1354127  deposition.out
+0810f0aff2a923b4aaabc3c8d698b0ca  deposition.out
 b7c8656992d024f11e6e688b1cf48be1  emission.out
 52190a7969f9539ccf3778ee610ae32d  emissiontrue.out
 14cfc2703bcd8c1f20de03c05df92e5c  gamma_light_curve.out

--- a/tests/kilonova_2d_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_inputfiles/results_md5_job0.txt
@@ -1,5 +1,5 @@
 f9bb214eb7f1ac22791a13c8025c4887  bflist.out
-4588e8fa2308728dabe47e37b6e6f7ef  deposition.out
+056430440c25ce36dfed3b70aec50830  deposition.out
 0fa4abe523979ab8d7bf264eeb326638  gamma_light_curve.out
 3f5bfe0a49e6832660967ad0090c8789  gammalinelist.out
 29ac1cb06f3139df7cbca0bbdb426e1c  grid.out

--- a/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_final.txt
+++ b/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_final.txt
@@ -1,6 +1,6 @@
 793ebff120a80bdd74c6f445c026a019  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-88abf61beea0ca1fa29e89f5a729634f  deposition.out
+88d213357588269b2c9864d656c0617b  deposition.out
 7535223a225e73201e353c2d0b2e850b  emission.out
 64a6f03f6eb860497fd37a6966721cae  emissiontrue.out
 331c456b0765a1da1a2f424d56e177bb  gamma_light_curve.out

--- a/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_job0.txt
+++ b/tests/kilonova_2d_xcomgammaphotoion_inputfiles/results_md5_job0.txt
@@ -1,6 +1,6 @@
 86c1e58d71e892a904a0003a4e1231d7  absorption.out
 897316929176464ebc9ad085f31e7284  bflist.out
-99f41f00b247ddc32544e0cf1343b949  deposition.out
+76dd9c515a750bd7913290bb6d43ee35  deposition.out
 90064f820495cb6a3ebac2073f408abf  emission.out
 a128486eada880753f6c23d52445d3ab  emissiontrue.out
 e209cc2811b0f4f4c32554ed5d2a647d  gamma_light_curve.out

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -155,7 +155,7 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const doub
   calculate_heating_rates(nonemptymgi, fT_e, clumpfactor * nne, heatingcoolingrates, bfheatingcoeffs);
 
   const auto ntlepton_frac_heating = nonthermal::get_nt_frac_heating(nonemptymgi);
-  const auto ntlepton_dep = nonthermal::get_deposition_rate_density(nonemptymgi);
+  const auto ntlepton_dep = nonthermal::get_ntlepton_deposition_rate_density(nonemptymgi);
   const auto ntalpha_dep = heatingcoolingrates.dep_alpha;
   // spontaneous fission fragments deposit as pure heating via k-packets (like alpha particles)
   const auto ntspfission_dep = heatingcoolingrates.dep_spfission;

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -570,7 +570,7 @@ void update_grid(std::ostream& estimators_file, const int nts, const int nts_pre
   printlnlog("timestep {}: time before update grid (tstartup + {:.1f} seconds) simtime ts_mid {:g} days", nts,
              startup_elapsed_seconds, globals::timesteps[nts].mid / DAY);
 
-  globals::lte_iteration = (globals::timestep < globals::num_lte_timesteps);
+  globals::lte_iteration = (nts < globals::num_lte_timesteps);
   printlnlog("lte_iteration {}", globals::lte_iteration ? 1 : 0);
   assert_always(globals::num_lte_timesteps > 0);  // The first time step must solve the ionisation balance in LTE
 

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -72,6 +72,8 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
     const double v_ej = std::sqrt(E_kin * 2 / grid::mtot_input);
 
     const double prefactor = (pkt.type == TYPE_NONTHERMAL_PREDEPOSIT_ALPHA) ? 7.74 : 7.4;
+    // the 29979200000 literal is the speed of light in cm/s (it differs from CLIGHT in the 7th digit, and is
+    // left as-is here so that results are unchanged), so 0.2 * it is the paper's reference velocity of 0.2c
     const double tau_ineff = prefactor * 86400 * std::sqrt(grid::mtot_input / (5.e-3 * 1.989 * 1.e33)) *
                              std::pow((0.2 * 29979200000) / v_ej, 3. / 2.);
     const double f_p = std::log1p(2. * ts * ts / tau_ineff / tau_ineff) / (2. * ts * ts / tau_ineff / tau_ineff);
@@ -309,8 +311,11 @@ constexpr auto packetprop_update_required(const Packet& pkt, const double ts_end
   return pkt.prop_time < ts_end;
 }
 
-// Return the nonemptymgi for the cell cache if required (non-empty, non-thick cell),
-// otherwise return an empty std::optional to indicate that no cell cache is used
+// Return the id of the cell cache group that this packet belongs to, or an empty std::optional if the
+// packet does not use the cell cache at all (pellet/gamma/predeposit types, empty cells, thick cells).
+// In single-slot mode the group id is the nonemptymgi, because packets of a given cell must be processed
+// together while that cell occupies the rank's one cache slot. In multi-slot mode every cell has its own
+// persistent slot, so no partitioning is needed and all cache-using packets share group 0.
 auto get_packet_cellcachegroupid(const Packet& pkt) -> std::optional<int> {
   constexpr auto nocache_packettypes = std::array{
       TYPE_RADIOACTIVE_PELLET,

--- a/vectors.h
+++ b/vectors.h
@@ -206,8 +206,8 @@ DEVICE_FUNC constexpr void set_pkt_restframe_from_cmf(Packet& pkt) {
   const double cos_stokes_rot_1 = std::clamp(dot(ref1_sc, ref1), -1., 1.);
   const double cos_stokes_rot_2 = dot(ref1_sc, ref2);
 
-  const double i = std::atan2(cos_stokes_rot_2, cos_stokes_rot_1);
-  return i < 0 ? i + (2 * PI) : i;
+  const double rot_angle = std::atan2(cos_stokes_rot_2, cos_stokes_rot_1);
+  return rot_angle < 0 ? rot_angle + (2 * PI) : rot_angle;
 }
 
 // Compute the meridian frame axes ref1 and ref2


### PR DESCRIPTION
sn3d: spfission_dep_discrete was the only per-timestep counter never
MPI-reduced. Every sibling (gamma/positron/electron/alpha _dep_discrete
and _emission) is Allreduced and divided by nprocs in
mpi_reduce_estimators(), so the total_dep_Lsun, eps_erg/s/g and
spfission_dep_discrete_Lsun columns of deposition.out were carrying rank
0's private tally instead of the all-rank mean: unbiased, but nprocs
times noisier, and inconsistent between ranks in memory. Reduce it
alongside the others.

NOTE FOR CI: this changes deposition.out for models that use spontaneous
fission (the r-process kilonova tests), which is covered by the
tests/*_inputfiles/results_md5_*.txt references. Those cannot be
regenerated here (they need the cached atomic data and a 4-rank run per
model), so the affected checksum files must be taken from the CI run's
regenerated results_md5_*.txt.

sn3d: syn_dir.txt was opened with trunc and written by every MPI rank
concurrently. Guard it with my_rank == 0, like the neighbouring
linestat.out and timesteps.out writers.

sn3d: the range assert in mpi_communicate_grid_properties() used <= where
the highest index actually touched is nstart + ndo - 1, so it permitted
one element past the end.

spectrum_lightcurve: TRACE_EMISSION_ABSORPTION_REGION_ON was a mutable
global that is never set true, and was additionally re-assigned false at
the top of write_partial_lightcurve_spectra_dirbin(). That assignment was
the only thing preventing an out-of-bounds write, because
traceemissionabsorption is sized by init_spectrum_trace(), which only
exspec calls - in sn3d the vector is empty. Make the flag constexpr so
the intent is visible and the dead code folds away, drop the redundant
assignment, and guard the two accumulation sites on the list being
allocated so enabling the flag is safe in both binaries.

radfield: update_bfestimators() recomputes bfestimend from the current
(lower) nu_cmf while bfestimbegin was stored for the higher nu_cmf, so
their difference can go negative and wrap to a huge size_t in the subspan
count. Clamp the stored begin to bfestimend, which just yields an empty
range.

update_grid: update_grid() set lte_iteration from globals::timestep
instead of its own nts parameter, which it threads carefully everywhere
else. Same value today because the only caller passes globals::timestep.

gammapkt: do_gamma() indexed dep_estimator_gamma via
get_nonemptymgi_of_mgi(mgi) without the mgi >= 0 guard that every other
mgi use in the file has.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XwekC6kiRouU8U5nnCUMXP