### PR TITLE
Fix three robustness defects found in a core physics audit

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -562,6 +562,23 @@ void compton_scatter(Packet& pkt) {
 
 // Compute the mean energy converted to non-thermal electrons times the Klein-Nishina cross section.
 constexpr auto meanf_sigma(const double x) -> double {
+  if (x < THOMSON_LIMIT) {
+    // The closed form below sums five terms of order 1/x^2 that have to cancel down to O(x), so it
+    // loses about 8 decimal digits per decade in x: the relative error is 2e-9 at x = 1e-2, 2e-6 at
+    // 1e-3, 25% at 1e-4, and the result turns negative below ~1e-6. Use the exact Taylor series of
+    // the same expression instead, which is accurate to 6e-11 at the x = THOMSON_LIMIT crossover
+    // and better below it. The leading term is the Thomson-limit mean fractional energy transfer x.
+    constexpr std::array taylor_coeffs{
+        1., -21. / 5., 147. / 10., -1616. / 35., 940. / 7., -2584. / 7., 14588. / 15., -409088. / 165.,
+    };
+    // Horner evaluation, starting from the highest-order coefficient
+    double series = taylor_coeffs.back();
+    for (int i = static_cast<int>(taylor_coeffs.size()) - 2; i >= 0; i--) {
+      series = taylor_coeffs[i] + (x * series);
+    }
+    return SIGMA_T * x * series;
+  }
+
   const double f = 1 + (2 * x);
 
   const double term0 = 2 / x;

--- a/grid.cc
+++ b/grid.cc
@@ -2487,7 +2487,10 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
 
     const double r_outer = cellcoordmax[0] * tstart / globals::tmin;
     const double d_coordmaxboundary =
-        expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, speed, r_outer, tstart);
+        is_boundary_overshoot_within_tolerance<BoundaryType::UPPER>(pktposgridcoord[0], pktvelgridcoord[0],
+                                                                    cellcoordmax[0], tstart)
+            ? 0.
+            : expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, speed, r_outer, tstart);
 
     // upper d coordinate of the current cell
     if ((d_coordmaxboundary >= 0.) && (d_coordmaxboundary < distance)) {
@@ -2498,7 +2501,10 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
     const double r_inner = cellcoordmin[0] * tstart / globals::tmin;
     if (r_inner > 0.) {
       const double d_coordminboundary =
-          expanding_shell_intersection<BoundaryType::LOWER>(pos, dir, speed, r_inner, tstart);
+          is_boundary_overshoot_within_tolerance<BoundaryType::LOWER>(pktposgridcoord[0], pktvelgridcoord[0],
+                                                                      cellcoordmin[0], tstart)
+              ? 0.
+              : expanding_shell_intersection<BoundaryType::LOWER>(pos, dir, speed, r_inner, tstart);
       // lower d coordinate of the current cell
       if ((d_coordminboundary >= 0.) && (d_coordminboundary < distance)) {
         distance = d_coordminboundary;

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -306,6 +306,19 @@ void read_recombrate_file() {
 
         const int nlevels = get_nlevels_ionising(element, ion - 1);
 
+        // scale_level_phixs() writes node-shared memory (allphixs and the derived rate coefficient
+        // tables) from rank_in_node == 0 only, while every rank on the node is reading those same
+        // arrays in calculate_ionrecombcoeff(). Bracket the writes with node barriers so that no
+        // rank can read a partially rescaled table.
+        const auto scale_levels = [element, ion, nlevels](const int firstlevel, const double multiplier) {
+          assert_always(std::isfinite(multiplier) && multiplier >= 0.);
+          MPI_Barrier_node();
+          for (int level = firstlevel; level < nlevels; level++) {
+            scale_level_phixs(element, ion - 1, level, multiplier);
+          }
+          MPI_Barrier_node();
+        };
+
         const double x = (log_Te_estimate - T_highestbelow.log_Te) / (T_lowestabove.log_Te - T_highestbelow.log_Te);
         const double input_rrc_low_n = std::lerp(T_highestbelow.rrc_low_n, T_lowestabove.rrc_low_n, x);
         const double input_rrc_total = std::lerp(T_highestbelow.rrc_total, T_lowestabove.rrc_total, x);
@@ -318,19 +331,25 @@ void read_recombrate_file() {
                                               false, per_groundmultipletpop);
         printlnlog("              rrc: {:10.3e}", rrc);
 
+        if (!(rrc > 0.)) {
+          // no recombination into this ion from the atomic data (e.g. the ion below has no
+          // photoionisation targets), so there is nothing to calibrate and the multipliers below
+          // would all be a division by zero
+          printlnlog("    rrc is not positive, so skipping the recombination rate calibration for this ion");
+          continue;
+        }
+
         if (input_rrc_low_n >= 0)  // if it's < 0, ignore it
         {
           printlnlog("  input_rrc_low_n: {:10.3e}", input_rrc_low_n);
 
           const double phixs_multiplier = input_rrc_low_n / rrc;
-          if (phixs_multiplier < 0.05 || phixs_multiplier >= 2.0) {
+          if (!(phixs_multiplier >= 0.05) || phixs_multiplier >= 2.0) {
             printlnlog("    Not scaling phixs of all levels by {:.3f} (because < 0.05 or >= 2.0)", phixs_multiplier);
           } else {
             printlnlog("    scaling phixs of all levels by {:.3f}", phixs_multiplier);
 
-            for (int level = 0; level < nlevels; level++) {
-              scale_level_phixs(element, ion - 1, level, phixs_multiplier);
-            }
+            scale_levels(0, phixs_multiplier);
 
             rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
                                            per_groundmultipletpop);
@@ -343,7 +362,10 @@ void read_recombrate_file() {
 
         printlnlog("  input_rrc_total: {:10.3e}", input_rrc_total);
 
-        if (rrc < input_rrc_total) {
+        if (input_rrc_total < 0) {
+          // negative means no tabulated total, in the same way that a negative rrc_low_n is ignored above
+          printlnlog("    input_rrc_total is negative, so not scaling to the total recombination rate");
+        } else if (rrc < input_rrc_total) {
           const double rrc_superlevel = calculate_ionrecombcoeff(
               -1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, true, per_groundmultipletpop);
           printlnlog("  rrc(superlevel): {:10.3e}", rrc_superlevel);
@@ -351,31 +373,22 @@ void read_recombrate_file() {
           if (rrc_superlevel > 0) {
             const double phixs_multiplier_superlevel = 1.0 + ((input_rrc_total - rrc) / rrc_superlevel);
             printlnlog("    scaling phixs of levels in the superlevel by {:.3f}", phixs_multiplier_superlevel);
-            assert_always(phixs_multiplier_superlevel >= 0);
 
             const int first_superlevel_level = get_nlevels_excited_nlte(element, ion - 1) + 1;
-            for (int level = first_superlevel_level; level < nlevels; level++) {
-              scale_level_phixs(element, ion - 1, level, phixs_multiplier_superlevel);
-            }
+            scale_levels(first_superlevel_level, phixs_multiplier_superlevel);
           } else {
             printlnlog("There is no superlevel recombination, so multiplying all levels instead");
             const double phixs_multiplier = input_rrc_total / rrc;
             printlnlog("    scaling phixs of all levels by {:.3f}", phixs_multiplier);
-            assert_always(phixs_multiplier >= 0);
 
-            for (int level = 0; level < nlevels; level++) {
-              scale_level_phixs(element, ion - 1, level, phixs_multiplier);
-            }
+            scale_levels(0, phixs_multiplier);
           }
         } else {
           printlnlog("rrc >= input_rrc_total!");
           const double phixs_multiplier = input_rrc_total / rrc;
           printlnlog("    scaling phixs of all levels by {:.3f}", phixs_multiplier);
-          assert_always(phixs_multiplier >= 0);
 
-          for (int level = 0; level < nlevels; level++) {
-            scale_level_phixs(element, ion - 1, level, phixs_multiplier);
-          }
+          scale_levels(0, phixs_multiplier);
         }
 
         rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,


### PR DESCRIPTION
Three defects found while auditing the RT core. None of them changes results for a well-formed run: they remove an abort path, a numerical-precision cliff, and a data race.

## 1. `boundary_distance()` had no boundary-overshoot handling for SPHERICAL1D

`CARTESIAN3D` and `CYLINDRICAL2D` both call `is_boundary_overshoot_within_tolerance<>()` to force a zero-distance crossing when floating-point rounding has left a packet marginally past a boundary it is outrunning. The `SPHERICAL1D` branch did not, and `snap_pos_to_cell()` returns early for non-Cartesian grids, so a 1D packet in that state had no way to be pulled back inside its shell.

For a packet at `r` a hair above `r_outer` moving outward, the `UPPER` quadratic has `a > 0`, `c > 0` and `b > 0`, so both roots are negative and `expanding_shell_intersection()` returns `-1`; the `LOWER` shell likewise returns `-1`. `next_cellindex` is then left at its initialiser `-1` and

```cpp
assert_always((next_cellindex == -99) || ((next_cellindex >= 0) && (next_cellindex < ngrid)));
```

aborts the run. `assert_always` is active in every build, so this is a hard abort rather than silent corruption. Same class of error as the existing `[ERROR] packet outside coord` check that the 3D path already guards.

## 2. `meanf_sigma()` lost all precision at low photon energy

The closed form sums five terms of order `1/x²` that have to cancel down to `O(x)`. Measured against a 60-digit evaluation of the same expression:

| `x = hν/mₑc²` | double | exact | rel. error |
|---|---|---|---|
| 1e-2 | 9.59425134e-3 | 9.59425135e-3 | 2e-9 |
| 1e-3 | 9.95812840e-4 | 9.95814654e-4 | 2e-6 |
| 1e-4 | 1.24766974e-4 | 9.99580147e-5 | **25 %** |
| 1e-5 | 1.02408434e-1 | 9.99958001e-6 | 1e4 |
| 1e-6 | **−6.47e+1** | 1.00e-6 | 6e7 |

`get_chi_compton_cmf()` and `compton_scatter()` both switch to the Thomson limit below `THOMSON_LIMIT`; `get_chi_cmf_loss_weighted()` did not, so it was the one place evaluating the unstable expression in the regime it breaks down in. A negative value there would trip `assert_testmodeonly(heating_cont >= 0.)` or silently subtract from `dep_estimator_gamma`. It is largely masked today (once `x < THOMSON_LIMIT`, `compton_scatter()` sets `f = 1` and stops degrading `nu_cmf`), but nothing enforces a floor — the Doppler redshift accumulated in `move_pkt_withtime()` lowers `nu_cmf` independently of scattering.

Replaced below `THOMSON_LIMIT` with the exact Taylor series of the same expression (σ_T factored out):

```
x − (21/5)x² + (147/10)x³ − (1616/35)x⁴ + (940/7)x⁵ − (2584/7)x⁶ + (14588/15)x⁷ − (409088/165)x⁸ + …
```

Truncated after `x⁸` this is accurate to 6e-11 at the crossover and better below, i.e. more accurate than the closed form is anywhere in that range. The leading term `x` is the expected Thomson-limit mean fractional energy transfer. `x = 0` now returns `0` instead of `NaN`.

## 3. `read_recombrate_file()` raced on node-shared memory and divided by an unchecked `rrc`

`ratecoefficients_init()` is called by every rank, so every rank runs `read_recombrate_file()`. Inside it, `scale_level_phixs()` writes `globals::allphixs`, `spontrecombcoeffs`, `corrphotoioncoeffs` and `bfcooling_coeffs` — all node-shared — under `if (rank_in_node == 0)`, while every other rank on the node is concurrently inside `calculate_ionrecombcoeff()` reading those same arrays via `get_spontrecombcoeff()` and `get_phixs_table()`. There was no `MPI_Barrier_node()` anywhere in the function, unlike `precalculate_rate_coefficient_integrals()` which brackets its shared-memory writes with barriers. The stored data was still deterministic (only rank 0 writes), but non-zero ranks read half-rescaled tables, which is a genuine data race and makes their `rrc:` log lines meaningless.

The scaling loops are now factored into a `scale_levels()` lambda that brackets the writes with node barriers. With the race gone, every rank computes the same `rrc` and so takes the same branches, which keeps the barriers collective.

Also guarded the divisions. `calculate_ionrecombcoeff()` returns exactly `0.` whenever the lower ion has no photoionisation targets (`maxrecombininglevel` defaults to `-1`, so the recombining-level loop body never runs), which made `input_rrc / rrc` an unchecked division by zero whose `+inf` passed `assert_always(phixs_multiplier >= 0)` unchallenged. A negative `rrc_total` column is now ignored the same way a negative `rrc_low_n` already was, rather than aborting on that assertion.

## Verification

- Builds clean with `-Werror` in both the default configuration and `REPRODUCIBLE=ON TESTMODE=ON MAX_NODE_SIZE=2 FASTMATH=OFF`.
- `clang-format` clean; `clang-tidy` (repo `.clang-tidy`) reports zero diagnostics on the changed lines; `cppcheck` with the CI flags is clean on all three files.
- The two `meanf_sigma()` branches were compiled standalone and compared across the crossover: they agree to 1.8e-9 (which is the closed form's own error there) and the function stays smooth and monotonic.

Not run here: a baseline-vs-changed checksum comparison. The `meanf_sigma` change only moves values where the old formula already had ≥1e-9 relative error, i.e. gamma packets that have redshifted below ~5 keV. If the test models reach that regime the checksums will need regenerating; otherwise results are bit-identical.

## Follow-ups found in the same audit, deliberately not in this PR

- **`vpkt.cc trace_vpkt_direction()` mixes three time conventions in one loop.** The continuum optical depth scales density by `pow3(t_start / t_future)`, the Sobolev line term uses `t_line` with unevolved populations, and the expansion-opacity term is not scaled at all. Since `τ_sob ∝ t⁻³·t = t⁻²`, the line term is too large by `(t_line/t_start)³` — ≈1.3× at `v_max = 0.1c` and ≈2.2× at `0.3c` for rays leaving the far side of the ejecta. It is wrong under both possible intents (a frozen-ejecta trace would use `t_start`). This is a real physics bug but it changes vpkt spectra, so it needs its own PR with regenerated checksums.
- **Estimator Doppler convention.** `update_gamma_dep()` uses `chi_cmf · e_rf · doppler² · dist`, the exact comoving-frame volume estimator (`ds_cmf = D · ds_rf`, and `V_cmf·Δt_cmf = V_rf·Δt_rf`), made deliberate in #433. `J`, `nuJ`, `gammaestimator`, `bfheatingestimator`, `ffheatingestimator` and the detailed bf-rate estimator all use `e_cmf · ds_rf`, one factor of `D` fewer. They are mutually self-consistent, so this is a single global O(v/c) convention rather than a local slip — worth a comment so that one side does not get "fixed" into inconsistency with the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
