### PR TITLE
Split the largest functions into focused helpers and deduplicate model reading

### DIFF
--- a/decay.cc
+++ b/decay.cc
@@ -1059,6 +1059,8 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
 
   add_standard_nuclides();
 
+  // deliberately a copy, not a reference: the decay-data readers below add further nuclides
+  // cppcheck-suppress redundantCopyLocalConst
   const auto standard_nuclides = nuclides;
 
   read_betaminus_decaydata();

--- a/decay.cc
+++ b/decay.cc
@@ -785,10 +785,11 @@ auto get_nucstring_a(const std::string& strnuc) -> int {
   return a;
 }
 
-// add all nuclides and decays, and later trim any irrelevant ones (not connected to input-specified nuclei)
-void init_nuclides(const std::span<const int> custom_zlist, const std::span<const int> custom_alist) {
-  assert_always(custom_zlist.size() == custom_alist.size());
+namespace {
 
+// add the standard set of nuclides for the classical double-decay chains (56Ni, 57Ni, 48Cr,
+// and 52Fe parents) with hardcoded decay data
+void add_standard_nuclides() {
   // Ni57
   nuclides.push_back({.z = 28, .a = 57, .meanlife = 51.36 * HOUR});
   nuclides.back().endecay_positron = 0.354 * MEV;
@@ -840,9 +841,10 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   nuclides.push_back({.z = 25, .a = 52, .meanlife = 0.0211395 * DAY});
   nuclides.back().branchprobs[DECAYTYPE_ELECTRONCAPTURE] = 1.;
   nuclides.back().endecay_q[DECAYTYPE_ELECTRONCAPTURE] = 5.085870 * MEV;
+}
 
-  const auto standard_nuclides = nuclides;
-
+// add the nuclides with beta-minus decay data from betaminusdecays.txt
+void read_betaminus_decaydata() {
   auto fbetaminus = fstream_required("betaminusdecays.txt", std::ios::in);
   std::string line;
   while (get_noncommentline(fbetaminus, line)) {
@@ -867,8 +869,13 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
       assert_always(e_elec_mev >= 0.);
     }
   }
+}
 
+// add or update the nuclides with alpha decay data from alphadecays.txt (also ensures that He4
+// exists as a decay product)
+void read_alpha_decaydata() {
   auto falpha = fstream_required("alphadecays.txt", std::ios::in);
+  std::string line;
   if (!nuc_exists(2, 4)) {
     nuclides.push_back({.z = 2, .a = 4, .meanlife = -1});
   }
@@ -905,8 +912,12 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
       nuclides[alphanucindex].endecay_q[DECAYTYPE_ALPHA] = Q_alphadecay_mev * MEV;
     }
   }
+}
 
+// add the nuclides with spontaneous fission decay data from fissiondecays.txt
+void read_spontfission_decaydata() {
   auto ffission = fstream_required("fissiondecays.txt", std::ios::in);
+  std::string line;
   while (get_noncommentline(ffission, line)) {
     int z_in = -1;
     int a_in = -1;
@@ -929,8 +940,13 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
     printlnlog("  added spontaneous fission nuclide: (Z={}){}{} meanlife {:.1e} days", z_in, get_elname(z_in), a_in,
                tau_sec / DAY);
   }
+}
 
+// read the fission product tables from fissionproducts_GEF_100keV.txt for the spontaneous
+// fission nuclides that are in use
+void read_fissionproduct_data() {
   auto ffission_products = fstream_required("fissionproducts_GEF_100keV.txt", std::ios::in);
+  std::string line;
   while (get_noncommentline(ffission_products, line)) {
     int z_parent = -1;
     int a_parent = -1;
@@ -968,7 +984,12 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
       nuclides[nucindex].decay_daughters_probsum = daughter_prob_sum;
     }
   }
+}
 
+// make sure that the input-specified nuclides and all decay daughters exist in the nuclide
+// list, adding any missing ones as stable nuclides
+void add_custom_and_daughter_nuclides(const std::span<const int> custom_zlist,
+                                      const std::span<const int> custom_alist) {
   std::set<std::tuple<int, int>> nuclides_ensure_list{};
 
   // add any extra nuclides that were specified but not in the decay data files
@@ -992,7 +1013,11 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
       nuclides.push_back({.z = z, .a = a, .meanlife = -1});
     }
   }
+}
 
+// consistency checks on the nuclide list: no duplicate nuclides, branching probabilities that
+// sum to one for unstable nuclides, and decay energies present for every active decay type
+void check_nuclide_data() {
   std::set<std::tuple<int, int>> seen_z_a{};
   for (const auto& nuc : nuclides) {
     assert_always(!seen_z_a.contains({nuc.z, nuc.a}));  // duplicate nuclide detected
@@ -1024,6 +1049,26 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
     }
     assert_always(nuc.endecay_gamma >= 0.);
   }
+}
+
+}  // anonymous namespace
+
+// add all nuclides and decays, and later trim any irrelevant ones (not connected to input-specified nuclei)
+void init_nuclides(const std::span<const int> custom_zlist, const std::span<const int> custom_alist) {
+  assert_always(custom_zlist.size() == custom_alist.size());
+
+  add_standard_nuclides();
+
+  const auto standard_nuclides = nuclides;
+
+  read_betaminus_decaydata();
+  read_alpha_decaydata();
+  read_spontfission_decaydata();
+  read_fissionproduct_data();
+
+  add_custom_and_daughter_nuclides(custom_zlist, custom_alist);
+
+  check_nuclide_data();
 
   printlnlog("Number of nuclides before filtering: {}", std::ssize(nuclides));
   decaypaths = find_decaypaths(custom_zlist, custom_alist, standard_nuclides);

--- a/grid.cc
+++ b/grid.cc
@@ -1442,219 +1442,6 @@ template <BoundaryType boundarytype>
   return movingtowards && (overshoot >= 0.) && (overshoot <= cellbound_tolerance(boundarypos));
 }
 
-// read the cell lines of a 1D spherical model.txt. Each line has the cell number (integer), the
-// velocity at the outer boundary of the cell [km/s], log10 of the mass density [g/cm3], and the
-// radioabundance columns.
-void read_ejecta_model_spherical1d(std::istream& fmodel, const int npts_0) {
-  std::string line;
-  std::istringstream ssline;
-
-  ncoord_model[0] = npts_0;
-  ncoord_model[1] = 0;
-  ncoord_model[2] = 0;
-  vout_model.resize(get_npts_model(), NAN);
-
-  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
-
-  int mgi = 0;
-  while (std::getline(fmodel, line)) {
-    double vout_kmps{NAN};
-    double log_rho{NAN};
-    int cellnumberin = 0;
-    ssline.clear();
-    ssline.str(line);
-
-    if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
-      printlnlog("Unexpected number of values in model.txt");
-      printlnlog("line: {}", line);
-      assert_always(false);
-    }
-
-    if (mgi == 0) {
-      first_cellindex = cellnumberin;
-      printlnlog("first_cellindex {}", first_cellindex);
-    }
-    assert_always(cellnumberin == mgi + first_cellindex);
-
-    vout_model[mgi] = vout_kmps * 1.e5;
-
-    const auto rho_tmin = static_cast<float>(log_rho > -90 ? pow(10., log_rho) * pow3(t_model / globals::tmin) : 0.);
-    set_rho_tmin(mgi, rho_tmin);
-    const bool keepcell = (rho_tmin > 0);
-    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-    mgi += 1;
-    if (mgi == get_npts_model()) {
-      break;
-    }
-  }
-
-  if (mgi != get_npts_model()) {
-    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
-    std::abort();
-  }
-
-  globals::vmax = vout_model[get_npts_model() - 1];
-}
-
-// read the cell lines of a 2D cylindrical model.txt. Each cell starts with a line holding the
-// cell number, its r and z midpoints, and the mass density, followed by the radioabundance
-// columns.
-void read_ejecta_model_cylindrical2d(std::istream& fmodel, const int npts_0, const int npts_1) {
-  std::string line;
-  std::istringstream ssline;
-
-  ncoord_model[0] = npts_0;
-  ncoord_model[1] = npts_1;
-  ncoord_model[2] = 0;
-  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
-
-  int mgi = 0;
-  while (std::getline(fmodel, line)) {
-    int cellnumberin = 0;
-    float cell_r_in{NAN};
-    float cell_z_in{NAN};
-    double rho_tmodel{NAN};
-    ssline.clear();
-    ssline.str(line);
-    assert_always(ssline >> cellnumberin >> cell_r_in >> cell_z_in >> rho_tmodel);
-
-    if (mgi == 0) {
-      first_cellindex = cellnumberin;
-    }
-    assert_always(cellnumberin == mgi + first_cellindex);
-
-    const int n_rcyl = (mgi % ncoord_model[0]);
-    const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
-    assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
-    const int n_z = (mgi / ncoord_model[0]);
-    const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
-    assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
-
-    if (rho_tmodel < 0) {
-      printlnlog("negative input density {:g} {}", rho_tmodel, mgi);
-      std::abort();
-    }
-
-    const bool keepcell = (rho_tmodel > 0);
-    const auto rho_tmin = static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin));
-    set_rho_tmin(mgi, rho_tmin);
-
-    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-    mgi++;
-  }
-
-  if (mgi != get_npts_model()) {
-    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
-    std::abort();
-  }
-}
-
-// read the cell lines of a 3D Cartesian model.txt. Each cell starts with a line holding the
-// cell number, its x, y, and z midpoints, and the mass density, followed by the radioabundance
-// columns.
-void read_ejecta_model_cartesian3d(std::istream& fmodel) {
-  std::string line;
-  std::istringstream ssline;
-
-  ncoord_model[0] = static_cast<int>(round(std::cbrt(npts_model)));
-  ncoord_model[1] = ncoord_model[0];
-  ncoord_model[2] = ncoord_model[0];
-
-  assert_always(static_cast<ptrdiff_t>(ncoord_model[0]) * ncoord_model[1] * ncoord_model[2] == npts_model);
-  // for a 3D input model, the propagation cells will match the input cells exactly
-  ncoordgrid = ncoord_model;
-  ngrid = npts_model;
-
-  const double xmax_tmodel = globals::vmax * t_model;
-
-  // Now read in the lines of the model.
-  min_den = -1.;
-
-  // check if expected positions match in either xyz or zyx column order
-  // set false if a problem is detected
-  bool posmatch_xyz = true;
-  bool posmatch_zyx = true;
-
-  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
-
-  // mgi is the index to the model grid - empty cells are sent to special value get_npts_model(),
-  // otherwise each input cell is one modelgrid cell
-  int mgi = 0;  // corresponds to model.txt index column, but zero indexed! (model.txt might be 1-indexed)
-  while (std::getline(fmodel, line)) {
-    int cellnumberin = 0;
-    std::array<float, 3> cellpos_in{};
-    float rho_model{NAN};
-    ssline.clear();
-    ssline.str(line);
-
-    assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model);
-
-    if (mgi == 0) {
-      first_cellindex = cellnumberin;
-    }
-    assert_always(cellnumberin == mgi + first_cellindex);
-
-    if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
-      printlnlog("read up to cell mgi {}", mgi);
-    }
-
-    // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
-    // however, the cellindex always should increment X first, then Y, then Z
-
-    for (int axis = 0; axis < 3; axis++) {
-      const double cellwidth = 2 * xmax_tmodel / ncoordgrid[axis];
-      const double cellpos_expected = -xmax_tmodel + (cellwidth * get_cellcoordindex(mgi, axis));
-      if (fabs(cellpos_expected - cellpos_in[axis]) > 0.5 * cellwidth) {
-        posmatch_xyz = false;
-      }
-      if (fabs(cellpos_expected - cellpos_in[2 - axis]) > 0.5 * cellwidth) {
-        posmatch_zyx = false;
-      }
-    }
-
-    if (rho_model < 0) {
-      printlnlog("negative input density {:g} {}", rho_model, mgi);
-      std::abort();
-    }
-
-    // in 3D cartesian, cellindex and modelgridindex are interchangeable
-    const bool keepcell = (rho_model > 0);
-    const auto rho_tmin = static_cast<float>(rho_model * pow3(t_model / globals::tmin));
-    set_rho_tmin(mgi, rho_tmin);
-
-    if (min_den < 0. || min_den > rho_model) {
-      min_den = rho_model;
-    }
-
-    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-    mgi++;
-  }
-  if (mgi != npts_model) {
-    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, npts_model);
-    std::abort();
-  }
-
-  // posmatch_xyz and posmatch_zyx should be mutually exclusive: if both column orders matched, an
-  // infinity probably occurred in the calculated positions
-  if (posmatch_xyz) {
-    printlnlog("Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
-  }
-  if (posmatch_zyx) {
-    printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
-  }
-
-  if (!posmatch_xyz && !posmatch_zyx) {
-    printlnlog(
-        "WARNING: Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
-        "order.");
-  }
-
-  printlnlog("min_den {:g} [g/cm3]", min_den);
-}
-
 }  // anonymous namespace
 
 // for a uniform grid get the the extent along the x,y,z coordinate (x_2 - x_1, etc.) at time tmin
@@ -2125,12 +1912,138 @@ void read_ejecta_model() {
   modelgrid_numpropcells.resize(npts_model + 1, 0);
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);
 
+  // geometry-specific setup of the model coordinate counts
   if (get_modelgridtype() == GridType::SPHERICAL1D) {
-    read_ejecta_model_spherical1d(fmodel, npts_0);
+    ncoord_model[0] = npts_0;
+    ncoord_model[1] = 0;
+    ncoord_model[2] = 0;
+    vout_model.resize(get_npts_model(), NAN);
   } else if (get_modelgridtype() == GridType::CYLINDRICAL2D) {
-    read_ejecta_model_cylindrical2d(fmodel, npts_0, npts_1);
+    ncoord_model[0] = npts_0;
+    ncoord_model[1] = npts_1;
+    ncoord_model[2] = 0;
+  } else {
+    ncoord_model[0] = static_cast<int>(round(std::cbrt(npts_model)));
+    ncoord_model[1] = ncoord_model[0];
+    ncoord_model[2] = ncoord_model[0];
+    assert_always(static_cast<ptrdiff_t>(ncoord_model[0]) * ncoord_model[1] * ncoord_model[2] == npts_model);
+    // for a 3D input model, the propagation cells will match the input cells exactly
+    ncoordgrid = ncoord_model;
+    ngrid = npts_model;
+    min_den = -1.;
+  }
+
+  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
+
+  // 3D only: whether the input cell positions match the expected values in x-y-z or z-y-x
+  // column order (set false when a mismatch is detected)
+  bool posmatch_xyz = true;
+  bool posmatch_zyx = true;
+
+  int mgi = 0;
+  while (mgi < get_npts_model() && std::getline(fmodel, line)) {
+    ssline.clear();
+    ssline.str(line);
+    int cellnumberin = 0;
+    double rho_tmodel{NAN};  // the cell density [g/cm3] at the model snapshot time t_model
+
+    // parse the geometry-specific part of the cell line to get the density (and for 1D, the
+    // outer velocity), and check that any cell midpoint coordinates match the expected values
+    if (get_modelgridtype() == GridType::SPHERICAL1D) {
+      // columns: cell number, outer velocity [km/s], log10 of the density
+      double vout_kmps{NAN};
+      double log_rho{NAN};
+      if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
+        printlnlog("Unexpected number of values in model.txt");
+        printlnlog("line: {}", line);
+        assert_always(false);
+      }
+      vout_model[mgi] = vout_kmps * 1.e5;
+      rho_tmodel = (log_rho > -90) ? pow(10., log_rho) : 0.;
+    } else if (get_modelgridtype() == GridType::CYLINDRICAL2D) {
+      // columns: cell number, r midpoint, z midpoint, density
+      float cell_r_in{NAN};
+      float cell_z_in{NAN};
+      assert_always(ssline >> cellnumberin >> cell_r_in >> cell_z_in >> rho_tmodel);
+
+      const int n_rcyl = (mgi % ncoord_model[0]);
+      const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
+      assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
+      const int n_z = (mgi / ncoord_model[0]);
+      const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
+      assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
+    } else {
+      // columns: cell number, x midpoint, y midpoint, z midpoint, density
+      std::array<float, 3> cellpos_in{};
+      float rho_model_in{NAN};
+      assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model_in);
+      rho_tmodel = rho_model_in;
+
+      if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
+        printlnlog("read up to cell mgi {}", mgi);
+      }
+
+      // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
+      // however, the cellindex always should increment X first, then Y, then Z
+      const double xmax_tmodel = globals::vmax * t_model;
+      for (int axis = 0; axis < 3; axis++) {
+        const double cellwidth = 2 * xmax_tmodel / ncoordgrid[axis];
+        const double cellpos_expected = -xmax_tmodel + (cellwidth * get_cellcoordindex(mgi, axis));
+        if (fabs(cellpos_expected - cellpos_in[axis]) > 0.5 * cellwidth) {
+          posmatch_xyz = false;
+        }
+        if (fabs(cellpos_expected - cellpos_in[2 - axis]) > 0.5 * cellwidth) {
+          posmatch_zyx = false;
+        }
+      }
+
+      if (min_den < 0. || min_den > rho_tmodel) {
+        min_den = rho_tmodel;
+      }
+    }
+
+    if (mgi == 0) {
+      first_cellindex = cellnumberin;
+      printlnlog("first_cellindex {}", first_cellindex);
+    }
+    assert_always(cellnumberin == mgi + first_cellindex);
+
+    if (rho_tmodel < 0) {
+      printlnlog("negative input density {:g} {}", rho_tmodel, mgi);
+      std::abort();
+    }
+
+    const bool keepcell = (rho_tmodel > 0);
+    set_rho_tmin(mgi, static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin)));
+
+    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
+
+    mgi++;
+  }
+
+  if (mgi != get_npts_model()) {
+    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
+    std::abort();
+  }
+
+  if (get_modelgridtype() == GridType::SPHERICAL1D) {
+    // for 1D models, vmax is the outer velocity of the last cell
+    globals::vmax = vout_model[get_npts_model() - 1];
   } else if (get_modelgridtype() == GridType::CARTESIAN3D) {
-    read_ejecta_model_cartesian3d(fmodel);
+    // posmatch_xyz and posmatch_zyx should be mutually exclusive: if both column orders matched, an
+    // infinity probably occurred in the calculated positions
+    if (posmatch_xyz) {
+      printlnlog("Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
+    }
+    if (posmatch_zyx) {
+      printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
+    }
+    if (!posmatch_xyz && !posmatch_zyx) {
+      printlnlog(
+          "WARNING: Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
+          "order.");
+    }
+    printlnlog("min_den {:g} [g/cm3]", min_den);
   }
 
   assert_always(get_npts_model() ==

--- a/grid.cc
+++ b/grid.cc
@@ -2034,11 +2034,9 @@ void read_ejecta_model() {
     // infinity probably occurred in the calculated positions
     if (posmatch_xyz) {
       printlnlog("Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
-    }
-    if (posmatch_zyx) {
+    } else if (posmatch_zyx) {
       printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
-    }
-    if (!posmatch_xyz && !posmatch_zyx) {
+    } else {
       printlnlog(
           "WARNING: Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
           "order.");

--- a/grid.cc
+++ b/grid.cc
@@ -1442,6 +1442,219 @@ template <BoundaryType boundarytype>
   return movingtowards && (overshoot >= 0.) && (overshoot <= cellbound_tolerance(boundarypos));
 }
 
+// read the cell lines of a 1D spherical model.txt. Each line has the cell number (integer), the
+// velocity at the outer boundary of the cell [km/s], log10 of the mass density [g/cm3], and the
+// radioabundance columns.
+void read_ejecta_model_spherical1d(std::istream& fmodel, const int npts_0) {
+  std::string line;
+  std::istringstream ssline;
+
+  ncoord_model[0] = npts_0;
+  ncoord_model[1] = 0;
+  ncoord_model[2] = 0;
+  vout_model.resize(get_npts_model(), NAN);
+
+  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
+
+  int mgi = 0;
+  while (std::getline(fmodel, line)) {
+    double vout_kmps{NAN};
+    double log_rho{NAN};
+    int cellnumberin = 0;
+    ssline.clear();
+    ssline.str(line);
+
+    if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
+      printlnlog("Unexpected number of values in model.txt");
+      printlnlog("line: {}", line);
+      assert_always(false);
+    }
+
+    if (mgi == 0) {
+      first_cellindex = cellnumberin;
+      printlnlog("first_cellindex {}", first_cellindex);
+    }
+    assert_always(cellnumberin == mgi + first_cellindex);
+
+    vout_model[mgi] = vout_kmps * 1.e5;
+
+    const auto rho_tmin = static_cast<float>(log_rho > -90 ? pow(10., log_rho) * pow3(t_model / globals::tmin) : 0.);
+    set_rho_tmin(mgi, rho_tmin);
+    const bool keepcell = (rho_tmin > 0);
+    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
+
+    mgi += 1;
+    if (mgi == get_npts_model()) {
+      break;
+    }
+  }
+
+  if (mgi != get_npts_model()) {
+    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
+    std::abort();
+  }
+
+  globals::vmax = vout_model[get_npts_model() - 1];
+}
+
+// read the cell lines of a 2D cylindrical model.txt. Each cell starts with a line holding the
+// cell number, its r and z midpoints, and the mass density, followed by the radioabundance
+// columns.
+void read_ejecta_model_cylindrical2d(std::istream& fmodel, const int npts_0, const int npts_1) {
+  std::string line;
+  std::istringstream ssline;
+
+  ncoord_model[0] = npts_0;
+  ncoord_model[1] = npts_1;
+  ncoord_model[2] = 0;
+  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
+
+  int mgi = 0;
+  while (std::getline(fmodel, line)) {
+    int cellnumberin = 0;
+    float cell_r_in{NAN};
+    float cell_z_in{NAN};
+    double rho_tmodel{NAN};
+    ssline.clear();
+    ssline.str(line);
+    assert_always(ssline >> cellnumberin >> cell_r_in >> cell_z_in >> rho_tmodel);
+
+    if (mgi == 0) {
+      first_cellindex = cellnumberin;
+    }
+    assert_always(cellnumberin == mgi + first_cellindex);
+
+    const int n_rcyl = (mgi % ncoord_model[0]);
+    const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
+    assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
+    const int n_z = (mgi / ncoord_model[0]);
+    const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
+    assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
+
+    if (rho_tmodel < 0) {
+      printlnlog("negative input density {:g} {}", rho_tmodel, mgi);
+      std::abort();
+    }
+
+    const bool keepcell = (rho_tmodel > 0);
+    const auto rho_tmin = static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin));
+    set_rho_tmin(mgi, rho_tmin);
+
+    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
+
+    mgi++;
+  }
+
+  if (mgi != get_npts_model()) {
+    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
+    std::abort();
+  }
+}
+
+// read the cell lines of a 3D Cartesian model.txt. Each cell starts with a line holding the
+// cell number, its x, y, and z midpoints, and the mass density, followed by the radioabundance
+// columns.
+void read_ejecta_model_cartesian3d(std::istream& fmodel) {
+  std::string line;
+  std::istringstream ssline;
+
+  ncoord_model[0] = static_cast<int>(round(std::cbrt(npts_model)));
+  ncoord_model[1] = ncoord_model[0];
+  ncoord_model[2] = ncoord_model[0];
+
+  assert_always(static_cast<ptrdiff_t>(ncoord_model[0]) * ncoord_model[1] * ncoord_model[2] == npts_model);
+  // for a 3D input model, the propagation cells will match the input cells exactly
+  ncoordgrid = ncoord_model;
+  ngrid = npts_model;
+
+  const double xmax_tmodel = globals::vmax * t_model;
+
+  // Now read in the lines of the model.
+  min_den = -1.;
+
+  // check if expected positions match in either xyz or zyx column order
+  // set false if a problem is detected
+  bool posmatch_xyz = true;
+  bool posmatch_zyx = true;
+
+  const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
+
+  // mgi is the index to the model grid - empty cells are sent to special value get_npts_model(),
+  // otherwise each input cell is one modelgrid cell
+  int mgi = 0;  // corresponds to model.txt index column, but zero indexed! (model.txt might be 1-indexed)
+  while (std::getline(fmodel, line)) {
+    int cellnumberin = 0;
+    std::array<float, 3> cellpos_in{};
+    float rho_model{NAN};
+    ssline.clear();
+    ssline.str(line);
+
+    assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model);
+
+    if (mgi == 0) {
+      first_cellindex = cellnumberin;
+    }
+    assert_always(cellnumberin == mgi + first_cellindex);
+
+    if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
+      printlnlog("read up to cell mgi {}", mgi);
+    }
+
+    // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
+    // however, the cellindex always should increment X first, then Y, then Z
+
+    for (int axis = 0; axis < 3; axis++) {
+      const double cellwidth = 2 * xmax_tmodel / ncoordgrid[axis];
+      const double cellpos_expected = -xmax_tmodel + (cellwidth * get_cellcoordindex(mgi, axis));
+      if (fabs(cellpos_expected - cellpos_in[axis]) > 0.5 * cellwidth) {
+        posmatch_xyz = false;
+      }
+      if (fabs(cellpos_expected - cellpos_in[2 - axis]) > 0.5 * cellwidth) {
+        posmatch_zyx = false;
+      }
+    }
+
+    if (rho_model < 0) {
+      printlnlog("negative input density {:g} {}", rho_model, mgi);
+      std::abort();
+    }
+
+    // in 3D cartesian, cellindex and modelgridindex are interchangeable
+    const bool keepcell = (rho_model > 0);
+    const auto rho_tmin = static_cast<float>(rho_model * pow3(t_model / globals::tmin));
+    set_rho_tmin(mgi, rho_tmin);
+
+    if (min_den < 0. || min_den > rho_model) {
+      min_den = rho_model;
+    }
+
+    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
+
+    mgi++;
+  }
+  if (mgi != npts_model) {
+    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, npts_model);
+    std::abort();
+  }
+
+  // posmatch_xyz and posmatch_zyx should be mutually exclusive: if both column orders matched, an
+  // infinity probably occurred in the calculated positions
+  if (posmatch_xyz) {
+    printlnlog("Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
+  }
+  if (posmatch_zyx) {
+    printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
+  }
+
+  if (!posmatch_xyz && !posmatch_zyx) {
+    printlnlog(
+        "WARNING: Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
+        "order.");
+  }
+
+  printlnlog("min_den {:g} [g/cm3]", min_den);
+}
+
 }  // anonymous namespace
 
 // for a uniform grid get the the extent along the x,y,z coordinate (x_2 - x_1, etc.) at time tmin
@@ -1913,206 +2126,11 @@ void read_ejecta_model() {
   nonemptymgi_of_mgi.resize(npts_model + 1, -1);
 
   if (get_modelgridtype() == GridType::SPHERICAL1D) {
-    ncoord_model[0] = npts_0;
-    ncoord_model[1] = 0;
-    ncoord_model[2] = 0;
-    vout_model.resize(get_npts_model(), NAN);
-
-    // Now read in the lines of the model. Each line has 5 entries: the
-    // cell number (integer) the velocity at outer boundary of cell (float),
-    // the mass density in the cell (float), the abundance of Ni56 by mass
-    // in the cell (float) and the total abundance of all Fe-grp elements
-    // in the cell (float). For now, the last number is recorded but never
-    // used.
-
-    const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
-
-    int mgi = 0;
-    while (std::getline(fmodel, line)) {
-      double vout_kmps{NAN};
-      double log_rho{NAN};
-      int cellnumberin = 0;
-      ssline.clear();
-      ssline.str(line);
-
-      if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
-        printlnlog("Unexpected number of values in model.txt");
-        printlnlog("line: {}", line);
-        assert_always(false);
-      }
-
-      if (mgi == 0) {
-        first_cellindex = cellnumberin;
-        printlnlog("first_cellindex {}", first_cellindex);
-      }
-      assert_always(cellnumberin == mgi + first_cellindex);
-
-      vout_model[mgi] = vout_kmps * 1.e5;
-
-      const auto rho_tmin = static_cast<float>(log_rho > -90 ? pow(10., log_rho) * pow3(t_model / globals::tmin) : 0.);
-      set_rho_tmin(mgi, rho_tmin);
-      const bool keepcell = (rho_tmin > 0);
-      read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-      mgi += 1;
-      if (mgi == get_npts_model()) {
-        break;
-      }
-    }
-
-    if (mgi != get_npts_model()) {
-      printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
-      std::abort();
-    }
-
-    globals::vmax = vout_model[get_npts_model() - 1];
+    read_ejecta_model_spherical1d(fmodel, npts_0);
   } else if (get_modelgridtype() == GridType::CYLINDRICAL2D) {
-    ncoord_model[0] = npts_0;
-    ncoord_model[1] = npts_1;
-    ncoord_model[2] = 0;
-    const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
-
-    // Now read in the model. Each point in the model has two lines of input.
-    // First is an index for the cell then its r-mid point then its z-mid point
-    // then its total mass density.
-    // Second is the total FeG mass, initial 56Ni mass, initial 56Co mass
-
-    int mgi = 0;
-    while (std::getline(fmodel, line)) {
-      int cellnumberin = 0;
-      float cell_r_in{NAN};
-      float cell_z_in{NAN};
-      double rho_tmodel{NAN};
-      ssline.clear();
-      ssline.str(line);
-      assert_always(ssline >> cellnumberin >> cell_r_in >> cell_z_in >> rho_tmodel);
-
-      if (mgi == 0) {
-        first_cellindex = cellnumberin;
-      }
-      assert_always(cellnumberin == mgi + first_cellindex);
-
-      const int n_rcyl = (mgi % ncoord_model[0]);
-      const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
-      assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
-      const int n_z = (mgi / ncoord_model[0]);
-      const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
-      assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
-
-      if (rho_tmodel < 0) {
-        printlnlog("negative input density {:g} {}", rho_tmodel, mgi);
-        std::abort();
-      }
-
-      const bool keepcell = (rho_tmodel > 0);
-      const auto rho_tmin = static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin));
-      set_rho_tmin(mgi, rho_tmin);
-
-      read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-      mgi++;
-    }
-
-    if (mgi != get_npts_model()) {
-      printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
-      std::abort();
-    }
+    read_ejecta_model_cylindrical2d(fmodel, npts_0, npts_1);
   } else if (get_modelgridtype() == GridType::CARTESIAN3D) {
-    ncoord_model[0] = static_cast<int>(round(std::cbrt(npts_model)));
-    ncoord_model[1] = ncoord_model[0];
-    ncoord_model[2] = ncoord_model[0];
-
-    assert_always(static_cast<ptrdiff_t>(ncoord_model[0]) * ncoord_model[1] * ncoord_model[2] == npts_model);
-    // for a 3D input model, the propagation cells will match the input cells exactly
-    ncoordgrid = ncoord_model;
-    ngrid = npts_model;
-
-    const double xmax_tmodel = globals::vmax * t_model;
-
-    // Now read in the lines of the model.
-    min_den = -1.;
-
-    // check if expected positions match in either xyz or zyx column order
-    // set false if a problem is detected
-    bool posmatch_xyz = true;
-    bool posmatch_zyx = true;
-
-    const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
-
-    // mgi is the index to the model grid - empty cells are sent to special value get_npts_model(),
-    // otherwise each input cell is one modelgrid cell
-    int mgi = 0;  // corresponds to model.txt index column, but zero indexed! (model.txt might be 1-indexed)
-    while (std::getline(fmodel, line)) {
-      int cellnumberin = 0;
-      std::array<float, 3> cellpos_in{};
-      float rho_model{NAN};
-      ssline.clear();
-      ssline.str(line);
-
-      assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model);
-
-      if (mgi == 0) {
-        first_cellindex = cellnumberin;
-      }
-      assert_always(cellnumberin == mgi + first_cellindex);
-
-      if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
-        printlnlog("read up to cell mgi {}", mgi);
-      }
-
-      // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
-      // however, the cellindex always should increment X first, then Y, then Z
-
-      for (int axis = 0; axis < 3; axis++) {
-        const double cellwidth = 2 * xmax_tmodel / ncoordgrid[axis];
-        const double cellpos_expected = -xmax_tmodel + (cellwidth * get_cellcoordindex(mgi, axis));
-        if (fabs(cellpos_expected - cellpos_in[axis]) > 0.5 * cellwidth) {
-          posmatch_xyz = false;
-        }
-        if (fabs(cellpos_expected - cellpos_in[2 - axis]) > 0.5 * cellwidth) {
-          posmatch_zyx = false;
-        }
-      }
-
-      if (rho_model < 0) {
-        printlnlog("negative input density {:g} {}", rho_model, mgi);
-        std::abort();
-      }
-
-      // in 3D cartesian, cellindex and modelgridindex are interchangeable
-      const bool keepcell = (rho_model > 0);
-      const auto rho_tmin = static_cast<float>(rho_model * pow3(t_model / globals::tmin));
-      set_rho_tmin(mgi, rho_tmin);
-
-      if (min_den < 0. || min_den > rho_model) {
-        min_den = rho_model;
-      }
-
-      read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-      mgi++;
-    }
-    if (mgi != npts_model) {
-      printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, npts_model);
-      std::abort();
-    }
-
-    // posmatch_xyz and posmatch_zyx should be mutually exclusive: if both column orders matched, an
-    // infinity probably occurred in the calculated positions
-    if (posmatch_xyz) {
-      printlnlog("Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
-    }
-    if (posmatch_zyx) {
-      printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
-    }
-
-    if (!posmatch_xyz && !posmatch_zyx) {
-      printlnlog(
-          "WARNING: Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
-          "order.");
-    }
-
-    printlnlog("min_den {:g} [g/cm3]", min_den);
+    read_ejecta_model_cartesian3d(fmodel);
   }
 
   assert_always(get_npts_model() ==

--- a/input.cc
+++ b/input.cc
@@ -74,7 +74,6 @@ struct IonTransitionsInput {
 };
 
 struct TempAllTransInput {
-  int lineindex;
   int targetlevelindex;
   float einstein_A;
   float coll_str;
@@ -576,11 +575,10 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
               .lowerlevelindex = lowerlevel,
           });
 
-          // the line list has not been sorted yet, so store the level index for now and
-          // the index into the sorted line list will be set later
+          // (each transition's index into the frequency-sorted linelist is set later by
+          // create_shared_alltranslist)
 
           temp_alltranslist[ion_levels[level].alltrans_startdown + nupperdowntrans - 1] = {
-              .lineindex = -1,
               .targetlevelindex = lowerlevel,
               .einstein_A = transition.A,
               .coll_str = transition.coll_str,
@@ -589,7 +587,6 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
           };
           const auto lowerstartup = ion_levels[lowerlevel].alltrans_startup();
           temp_alltranslist[lowerstartup + nloweruptrans - 1] = {
-              .lineindex = -1,
               .targetlevelindex = level,
               .einstein_A = transition.A,
               .coll_str = transition.coll_str,
@@ -1404,9 +1401,9 @@ void create_shared_levellist(std::vector<TempEnergyLevel>& temp_alllevels) {
 }
 
 // copy the transition data into node-shared memory arrays (globals::alltrans), freeing the
-// local copy. Returns the transitions' lineindex array, which establish_linelist_connections()
-// fills in after the frequency-sorted linelist has been created.
-auto create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslist) -> MPI_shared_array<int> {
+// local copy, and point every up and down transition at its index in the frequency-sorted
+// linelist. Requires globals::alllevels and globals::linelist to have been created already.
+void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslist) {
   const int updowntranscount = []() -> int {
     const int downtranscount = std::ranges::fold_left(globals::alllevels.ndowntrans, 0, std::plus<>{});
     const int uptranscount = std::ranges::fold_left(globals::alllevels.nuptrans, 0, std::plus<>{});
@@ -1430,7 +1427,6 @@ auto create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
   if (globals::rank_in_node == 0) {
     assert_always(std::ssize(temp_alltranslist) == updowntranscount);
     for (int t = 0; t < updowntranscount; t++) {
-      alltrans_lineindex[t] = temp_alltranslist[t].lineindex;
       alltrans_targetlevelindex[t] = temp_alltranslist[t].targetlevelindex;
       alltrans_einstein_A[t] = temp_alltranslist[t].einstein_A;
       alltrans_coll_str[t] = temp_alltranslist[t].coll_str;
@@ -1447,7 +1443,67 @@ auto create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
   globals::alltrans.osc_strength = std::move(alltrans_osc_strength);
   globals::alltrans.forbidden = std::move(alltrans_forbidden);
 
-  return alltrans_lineindex;
+  // make sure that all ranks can see the filled transition arrays before the striped loop below
+  MPI_Barrier_node();
+
+  printlnlog("establishing connection between transitions and sorted linelist...");
+
+  const auto time_start_establish_linelist_connections = std::chrono::steady_clock::now();
+
+  // every transition entry belongs to exactly one line (one down and one up entry per line), so
+  // the loop below writes every element of alltrans_lineindex
+  assert_always(updowntranscount == 2 * globals::nlines);
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+  for (int lineindex = 0; lineindex < globals::nlines; lineindex++) {
+    if (lineindex % globals::node_nprocs != globals::rank_in_node) {
+      continue;
+    }
+
+    const int element = globals::linelist.elementindex[lineindex];
+    const int ion = globals::linelist.ionindex[lineindex];
+    const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
+    const int upper_uniquelevelindex = globals::linelist.uniquelevelindex_upper[lineindex];
+    const auto lower_uniquelevelindex = globals::linelist.uniquelevelindex_lower[lineindex];
+    const auto upperlevel = upper_uniquelevelindex - ionuniquelevelindexstart;
+    const auto lowerlevel = lower_uniquelevelindex - ionuniquelevelindexstart;
+
+    // there is never more than one transition per pair of levels,
+    // so find the first up and the first down transition that match: element, ion, lowerlevel, upperlevel
+
+    const auto alltrans_startdown = get_alltrans_startdown(upper_uniquelevelindex);
+    const auto ndowntrans = get_ndowntrans(upper_uniquelevelindex);
+    int downtransid = -1;
+    for (int i = alltrans_startdown; i < alltrans_startdown + ndowntrans; i++) {
+      if (globals::alltrans.targetlevelindex[i] == lowerlevel) {
+        downtransid = i;
+        break;
+      }
+    }
+    assert_always(downtransid != -1);
+    alltrans_lineindex[downtransid] = lineindex;
+
+    const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
+    const auto nuptrans = get_nuptrans(lower_uniquelevelindex);
+    int uptransid = -1;
+    for (int i = alltrans_startup; i < alltrans_startup + nuptrans; i++) {
+      if (globals::alltrans.targetlevelindex[i] == upperlevel) {
+        uptransid = i;
+        break;
+      }
+    }
+    assert_always(uptransid != -1);
+    alltrans_lineindex[uptransid] = lineindex;
+  }
+  globals::alltrans.lineindex = std::move(alltrans_lineindex);
+
+  const auto establish_linelist_connections_duration =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - time_start_establish_linelist_connections)
+          .count();
+  printlnlog("  took {:.1f}s", establish_linelist_connections_duration);
+  MPI_Barrier_node();
 }
 
 // copy the line data into node-shared memory arrays (globals::linelist), calculating the
@@ -1508,64 +1564,6 @@ void create_shared_linelist(std::vector<TempLineTransitionInput>& temp_linelist)
   printlnlog("[info] mem_usage: linelist occupies {:.3f} MB (node shared memory)", linelist_mem_MB);
 }
 
-// point every up and down transition at its index in the frequency-sorted linelist and store
-// the result in globals::alltrans.lineindex
-void establish_linelist_connections(MPI_shared_array<int>& alltrans_lineindex) {
-  printlnlog("establishing connection between transitions and sorted linelist...");
-
-  const auto time_start_establish_linelist_connections = std::chrono::steady_clock::now();
-#ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic)
-#endif
-  for (int lineindex = 0; lineindex < globals::nlines; lineindex++) {
-    if (lineindex % globals::node_nprocs != globals::rank_in_node) {
-      continue;
-    }
-
-    const int element = globals::linelist.elementindex[lineindex];
-    const int ion = globals::linelist.ionindex[lineindex];
-    const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
-    const int upper_uniquelevelindex = globals::linelist.uniquelevelindex_upper[lineindex];
-    const auto lower_uniquelevelindex = globals::linelist.uniquelevelindex_lower[lineindex];
-    const auto upperlevel = upper_uniquelevelindex - ionuniquelevelindexstart;
-    const auto lowerlevel = lower_uniquelevelindex - ionuniquelevelindexstart;
-
-    // there is never more than one transition per pair of levels,
-    // so find the first up and the first down transition that match: element, ion, lowerlevel, upperlevel
-
-    const auto alltrans_startdown = get_alltrans_startdown(upper_uniquelevelindex);
-    const auto ndowntrans = get_ndowntrans(upper_uniquelevelindex);
-    int downtransid = -1;
-    for (int i = alltrans_startdown; i < alltrans_startdown + ndowntrans; i++) {
-      if (globals::alltrans.targetlevelindex[i] == lowerlevel) {
-        downtransid = i;
-        break;
-      }
-    }
-    assert_always(downtransid != -1);
-    alltrans_lineindex[downtransid] = lineindex;
-
-    const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
-    const auto nuptrans = get_nuptrans(lower_uniquelevelindex);
-    int uptransid = -1;
-    for (int i = alltrans_startup; i < alltrans_startup + nuptrans; i++) {
-      if (globals::alltrans.targetlevelindex[i] == upperlevel) {
-        uptransid = i;
-        break;
-      }
-    }
-    assert_always(uptransid != -1);
-    alltrans_lineindex[uptransid] = lineindex;
-  }
-  globals::alltrans.lineindex = std::move(alltrans_lineindex);
-
-  const auto establish_linelist_connections_duration =
-      std::chrono::duration<double>(std::chrono::steady_clock::now() - time_start_establish_linelist_connections)
-          .count();
-  printlnlog("  took {:.1f}s", establish_linelist_connections_duration);
-  MPI_Barrier_node();
-}
-
 // read the full atomic dataset: the composition (compositiondata.txt), then the levels and
 // transitions (adata.txt, transitiondata.txt) and photoionisation cross-sections
 // (phixsdata_v2.txt) for every included ion, building the global element/ion/level/line lists
@@ -1595,12 +1593,11 @@ void read_atomicdata_files() {
   // create a shared level list and copy data across, freeing the local copy
   create_shared_levellist(temp_alllevels);
 
-  auto alltrans_lineindex = create_shared_alltranslist(temp_alltranslist);
-
   // create a linelist shared on node and then copy data across, freeing the local copy
   create_shared_linelist(temp_linelist);
 
-  establish_linelist_connections(alltrans_lineindex);
+  // create the shared transitions list and point each transition at the sorted linelist
+  create_shared_alltranslist(temp_alltranslist);
 
   for (int element = 0; element < get_nelements(); element++) {
     const int nions = get_nions(element);

--- a/input.cc
+++ b/input.cc
@@ -1324,30 +1324,8 @@ void read_levels_and_transitions(std::vector<TempEnergyLevel>& temp_alllevels,
   printlnlog("nbfcheck {}", nbfcheck);
 }
 
-// read the full atomic dataset: the composition (compositiondata.txt), then the levels and
-// transitions (adata.txt, transitiondata.txt) and photoionisation cross-sections
-// (phixsdata_v2.txt) for every included ion, building the global element/ion/level/line lists
-void read_atomicdata_files() {
-  const auto nlevelsmax_readin = read_compositiondata();
-
-  printlnlog("SINGLE_LEVEL_TOP_ION: {}", SINGLE_LEVEL_TOP_ION ? "true" : "false");
-
-  std::vector<TempEnergyLevel> temp_alllevels;
-  std::vector<TempLineTransitionInput> temp_linelist;
-  std::vector<TempAllTransInput> temp_alltranslist;
-
-  if (globals::rank_in_node == 0) {
-    temp_linelist.reserve(1U << 22U);  // reserve initial space for 4 million lines to avoid too many reallocations
-    temp_alltranslist.reserve(1U << 22U);
-    read_levels_and_transitions(temp_alllevels, temp_linelist, temp_alltranslist, nlevelsmax_readin);
-  }
-  MPI_Barrier_node();
-
-  update_includedionslevels_maxnions();
-
-  MPI_Bcast_safe(globals::nlines, 0, globals::mpi_comm_node);
-  printlnlog("nlines {}", globals::nlines);
-
+// sort the temporary linelist by descending frequency and warn about any duplicate transitions
+void sort_temp_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
   if (globals::rank_in_node == 0) {
     assert_always(globals::nlines == std::ssize(temp_linelist));
     temp_linelist.shrink_to_fit();
@@ -1381,8 +1359,10 @@ void read_atomicdata_files() {
       }
     }
   }
+}
 
-  // create a shared level list and copy data across, freeing the local copy
+// copy the level data into node-shared memory arrays (globals::alllevels), freeing the local copy
+void create_shared_levellist(std::vector<TempEnergyLevel>& temp_alllevels) {
   ptrdiff_t nlevels = std::ssize(temp_alllevels);
   MPI_Bcast_safe(nlevels, 0, globals::mpi_comm_node);
 
@@ -1421,7 +1401,12 @@ void read_atomicdata_files() {
   globals::alllevels.matransblock_start = std::move(alllevels_matransblock_start);
   temp_alllevels.clear();
   temp_alllevels.shrink_to_fit();
+}
 
+// copy the transition data into node-shared memory arrays (globals::alltrans), freeing the
+// local copy. Returns the transitions' lineindex array, which establish_linelist_connections()
+// fills in after the frequency-sorted linelist has been created.
+auto create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslist) -> MPI_shared_array<int> {
   const int updowntranscount = []() -> int {
     const int downtranscount = std::ranges::fold_left(globals::alllevels.ndowntrans, 0, std::plus<>{});
     const int uptranscount = std::ranges::fold_left(globals::alllevels.nuptrans, 0, std::plus<>{});
@@ -1433,7 +1418,6 @@ void read_atomicdata_files() {
   printlnlog("[info] mem_usage: transition lists occupy {:.3f} MB (node shared memory)",
              updowntranscount * ((2 * sizeof(int)) + (3 * sizeof(float)) + sizeof(bool)) / 1024. / 1024.);
 
-  // create a shared all transitions list and then copy data across, freeing the local copy
   MPI_Barrier_node();
 
   auto alltrans_lineindex = MPI_shared_array<int>(updowntranscount);
@@ -1463,8 +1447,12 @@ void read_atomicdata_files() {
   globals::alltrans.osc_strength = std::move(alltrans_osc_strength);
   globals::alltrans.forbidden = std::move(alltrans_forbidden);
 
-  // create a linelist shared on node and then copy data across, freeing the local copy
+  return alltrans_lineindex;
+}
 
+// copy the line data into node-shared memory arrays (globals::linelist), calculating the
+// Einstein B coefficients, and free the local copy
+void create_shared_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
   auto linelist_nu = MPI_shared_array<double>(globals::nlines);
   auto linelist_elementindex = MPI_shared_array<int>(globals::nlines);
   auto linelist_ionindex = MPI_shared_array<int>(globals::nlines);
@@ -1518,7 +1506,11 @@ void read_atomicdata_files() {
       1024. / 1024;
 
   printlnlog("[info] mem_usage: linelist occupies {:.3f} MB (node shared memory)", linelist_mem_MB);
+}
 
+// point every up and down transition at its index in the frequency-sorted linelist and store
+// the result in globals::alltrans.lineindex
+void establish_linelist_connections(MPI_shared_array<int>& alltrans_lineindex) {
   printlnlog("establishing connection between transitions and sorted linelist...");
 
   const auto time_start_establish_linelist_connections = std::chrono::steady_clock::now();
@@ -1572,6 +1564,43 @@ void read_atomicdata_files() {
           .count();
   printlnlog("  took {:.1f}s", establish_linelist_connections_duration);
   MPI_Barrier_node();
+}
+
+// read the full atomic dataset: the composition (compositiondata.txt), then the levels and
+// transitions (adata.txt, transitiondata.txt) and photoionisation cross-sections
+// (phixsdata_v2.txt) for every included ion, building the global element/ion/level/line lists
+void read_atomicdata_files() {
+  const auto nlevelsmax_readin = read_compositiondata();
+
+  printlnlog("SINGLE_LEVEL_TOP_ION: {}", SINGLE_LEVEL_TOP_ION ? "true" : "false");
+
+  std::vector<TempEnergyLevel> temp_alllevels;
+  std::vector<TempLineTransitionInput> temp_linelist;
+  std::vector<TempAllTransInput> temp_alltranslist;
+
+  if (globals::rank_in_node == 0) {
+    temp_linelist.reserve(1U << 22U);  // reserve initial space for 4 million lines to avoid too many reallocations
+    temp_alltranslist.reserve(1U << 22U);
+    read_levels_and_transitions(temp_alllevels, temp_linelist, temp_alltranslist, nlevelsmax_readin);
+  }
+  MPI_Barrier_node();
+
+  update_includedionslevels_maxnions();
+
+  MPI_Bcast_safe(globals::nlines, 0, globals::mpi_comm_node);
+  printlnlog("nlines {}", globals::nlines);
+
+  sort_temp_linelist(temp_linelist);
+
+  // create a shared level list and copy data across, freeing the local copy
+  create_shared_levellist(temp_alllevels);
+
+  auto alltrans_lineindex = create_shared_alltranslist(temp_alltranslist);
+
+  // create a linelist shared on node and then copy data across, freeing the local copy
+  create_shared_linelist(temp_linelist);
+
+  establish_linelist_connections(alltrans_lineindex);
 
   for (int element = 0; element < get_nelements(); element++) {
     const int nions = get_nions(element);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1362,8 +1362,7 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 
     const int nlevels = get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0);
     for (int level = 0; level <= nlevels; level++) {
-      print_level_rates(nonemptymgi, timestep, element, ion, level, popvec, rate_matrices, first_ion_used,
-                        nions_used);
+      print_level_rates(nonemptymgi, timestep, element, ion, level, popvec, rate_matrices, first_ion_used, nions_used);
     }
   }
 }

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1166,79 +1166,20 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
   return true;
 }
 
-}  // anonymous namespace
-
-void solve_nlte_pops_element(const int element, const int nonemptymgi, const int timestep, const int nlte_iter) {
-  // solve the statistical balance equations to find NLTE level populations for all ions of an element
-  // (ionisation balance follows from this too). Failure modes can lead to quasi-LTE populations being set instead.
-
+// Assemble and solve the NLTE rate matrix, retrying with a reduced range of ion stages when the
+// solve fails and NLTE_LIMIT_ION_STAGES_AFTER_FAILURE allows an edge ion to be removed.
+// Returns whether a solution was found and the range of ions included in it.
+auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemptymgi, const double t_mid,
+                                             const double nnelement,
+                                             const std::vector<std::vector<double>>& s_renorm_allions,
+                                             RateMatrices& rate_matrices, std::vector<double>& popvec)
+    -> std::tuple<bool, int, int> {
   const int atomic_number = get_atomicnumber(element);
-  const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-
-  if (grid::get_elem_massfrac(nonemptymgi, element) <= 0.) {
-    // abundance of this element is zero, so do not store any NLTE populations
-    printlnlog(
-        "Not solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} due to zero "
-        "abundance",
-        modelgridindex, timestep, nlte_iter, atomic_number);
-
-    nltepop_reset_element(nonemptymgi, element);
-    return;
-  }
-
-  const double cell_Te = grid::get_Te(nonemptymgi);
-
-  if (cell_Te == MINTEMP) {
-    printlnlog(
-        "Not solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} due to low "
-        "temperature Te=MINTEMP={:g} K",
-        modelgridindex, timestep, nlte_iter, atomic_number, cell_Te);
-    set_element_pops_lte(nonemptymgi, element);
-    return;
-  }
-
-  const auto sys_time_start_nltesolver = std::chrono::steady_clock::now();
-
-  const double t_mid = globals::timesteps[timestep].mid;
   const int nions = get_nions(element);
-  const double nnelement = grid::get_elem_numberdens(nonemptymgi, element);
-
-  printlnlog(
-      "Solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} (mass fraction "
-      "{:.2e}, nnelement {:.2e} cm^-3)",
-      modelgridindex, timestep, nlte_iter, atomic_number, grid::get_elem_massfrac(nonemptymgi, element), nnelement);
-
-  const auto superlevel_partfuncs = get_element_superlevelpartfuncs(nonemptymgi, element);
+  const auto max_nlte_dimension = get_max_nlte_dimension();
   int nions_used = nions;
   int first_ion_used = 0;
   bool matrix_solve_success = false;
-
-  const auto max_nlte_dimension = get_max_nlte_dimension();
-
-  // will hold the un-normalised population densities [cm^-3]
-  THREADLOCALONHOST std::vector<double> popvec;
-  popvec.reserve(max_nlte_dimension);
-
-  // superlevel population renormalisation factors for every ion of the element:
-  // superlevel members get their Boltzmann fraction of the superlevel population, while levels
-  // with their own matrix entries (ground, NLTE excited, and autoionising levels) get a weight of 1.
-  THREADLOCALONHOST std::vector<std::vector<double>> s_renorm_allions;
-  s_renorm_allions.reserve(get_max_nions());
-  s_renorm_allions.resize(nions);
-  for (int ion = 0; ion < nions; ion++) {
-    const int nlevels = get_nlevels(element, ion);
-    s_renorm_allions[ion].resize(nlevels);
-    std::ranges::fill(s_renorm_allions[ion], 1.0);  // default to 1. for all levels
-    const int level_superlevel_start = get_nlevels_excited_nlte(element, ion) + 1;
-    const int first_autoion = get_nlevels_nonautoion(element, ion);
-
-    // set the superlevel renormalisation factors for all levels in the superlevel
-    for (int level = level_superlevel_start; level < first_autoion; level++) {
-      s_renorm_allions[ion][level] = superlevel_boltzmann(nonemptymgi, element, ion, level) / superlevel_partfuncs[ion];
-    }
-  }
-
-  THREADLOCALONHOST RateMatrices rate_matrices{max_nlte_dimension};
 
   bool matrix_solve_required = true;
   while (matrix_solve_required) {
@@ -1340,6 +1281,167 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
     }
   }
 
+  return {matrix_solve_success, first_ion_used, nions_used};
+}
+
+// Store the solved populations (ground level, NLTE excited levels, and superlevel) for every
+// ion of the element, then check that the total element population matches the element
+// abundance and print the periodic rates summaries.
+void nltepop_apply_solution(const int element, const int nonemptymgi, const int timestep, const int nlte_iter,
+                            const double nnelement, const std::vector<double>& superlevel_partfuncs,
+                            const std::vector<double>& popvec, const RateMatrices& rate_matrices,
+                            const int first_ion_used, const int nions_used) {
+  const int atomic_number = get_atomicnumber(element);
+  const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+  const int nions = get_nions(element);
+
+  // check calculated NLTE populations are valid
+  for (const auto pop : popvec) {
+    assert_always(std::isfinite(pop));
+    assert_always(pop >= 0.);
+  }
+
+  // set the ground level, excited level and possible superlevel populations for this element
+  for (int ion = 0; ion < nions; ion++) {
+    const int nlevels_excited_nlte = get_nlevels_excited_nlte(element, ion);
+
+    if (ion < first_ion_used || ion >= (first_ion_used + nions_used)) {
+      printlnlog("  WARNING: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to zero ",
+                 get_atomicnumber(element), get_ionstage(element, ion));
+
+      set_groundlevelpop(nonemptymgi, element, ion, 0.);
+
+      for (int level = 1; level <= nlevels_excited_nlte; level++) {
+        set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level, 0.);
+      }
+
+      if (ion_has_superlevel(element, ion)) {
+        set_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion, 0.);
+      }
+    } else {
+      // only valid for ions inside the solved range [first_ion_used, first_ion_used + nions_used)
+      const int index_gs = get_nlte_vector_index(element, ion, 0, first_ion_used);
+      set_groundlevelpop(nonemptymgi, element, ion, static_cast<float>(popvec[index_gs]));
+
+      for (int level = 1; level <= nlevels_excited_nlte; level++) {
+        const int index = get_nlte_vector_index(element, ion, level, first_ion_used);
+        set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level, popvec[index] / grid::get_rho(nonemptymgi));
+      }
+
+      if (ion_has_superlevel(element, ion)) {
+        const int index_sl = get_nlte_vector_index(element, ion, nlevels_excited_nlte + 1, first_ion_used);
+        set_nlte_superlevelpop_over_rho_over_slpartfunc(
+            nonemptymgi, element, ion, popvec[index_sl] / grid::get_rho(nonemptymgi) / superlevel_partfuncs[ion]);
+      }
+    }
+  }
+  calculate_cellpartfuncts(nonemptymgi, element);
+
+  const double elem_pop_matrix = std::accumulate(popvec.begin(), popvec.end(), 0.0,
+                                                 [](const double sum, const double pop) { return sum + fabs(pop); });
+  const double elem_pop_error_percent = fabs((nnelement / elem_pop_matrix) - 1) * 100;
+  if (elem_pop_error_percent > 1.0) {
+    printlnlog(
+        "  WARNING: timestep {} nlteiter {} Z={} element population is: {:g} (from abundance) and {:g} (from matrix "
+        "solution), error: {:.2f}%. Forcing element pops to LTE.",
+        timestep, nlte_iter, atomic_number, nnelement, elem_pop_matrix, elem_pop_error_percent);
+    set_element_pops_lte(nonemptymgi, element);
+  }
+
+  // output NLTE stats every nth timestep for the first NLTE iteration only
+  if ((timestep % 5 == 0) && (nlte_iter == 0)) {
+    print_element_rates_summary(element, modelgridindex, timestep, nlte_iter, popvec, rate_matrices, first_ion_used,
+                                nions_used);
+  }
+
+  // detailed levels stats (very verbose, only for debugging)
+  const bool print_detailed_level_stats = false;
+  if (print_detailed_level_stats) {
+    const int ionstage = 2;
+    const int ion = ionstage - get_ionstage(element, 0);
+
+    const int nlevels = get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0);
+    for (int level = 0; level <= nlevels; level++) {
+      print_level_rates(nonemptymgi, timestep, element, ion, level, popvec, rate_matrices, first_ion_used,
+                        nions_used);
+    }
+  }
+}
+
+}  // anonymous namespace
+
+void solve_nlte_pops_element(const int element, const int nonemptymgi, const int timestep, const int nlte_iter) {
+  // solve the statistical balance equations to find NLTE level populations for all ions of an element
+  // (ionisation balance follows from this too). Failure modes can lead to quasi-LTE populations being set instead.
+
+  const int atomic_number = get_atomicnumber(element);
+  const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+
+  if (grid::get_elem_massfrac(nonemptymgi, element) <= 0.) {
+    // abundance of this element is zero, so do not store any NLTE populations
+    printlnlog(
+        "Not solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} due to zero "
+        "abundance",
+        modelgridindex, timestep, nlte_iter, atomic_number);
+
+    nltepop_reset_element(nonemptymgi, element);
+    return;
+  }
+
+  const double cell_Te = grid::get_Te(nonemptymgi);
+
+  if (cell_Te == MINTEMP) {
+    printlnlog(
+        "Not solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} due to low "
+        "temperature Te=MINTEMP={:g} K",
+        modelgridindex, timestep, nlte_iter, atomic_number, cell_Te);
+    set_element_pops_lte(nonemptymgi, element);
+    return;
+  }
+
+  const auto sys_time_start_nltesolver = std::chrono::steady_clock::now();
+
+  const double t_mid = globals::timesteps[timestep].mid;
+  const int nions = get_nions(element);
+  const double nnelement = grid::get_elem_numberdens(nonemptymgi, element);
+
+  printlnlog(
+      "Solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} (mass fraction "
+      "{:.2e}, nnelement {:.2e} cm^-3)",
+      modelgridindex, timestep, nlte_iter, atomic_number, grid::get_elem_massfrac(nonemptymgi, element), nnelement);
+
+  const auto superlevel_partfuncs = get_element_superlevelpartfuncs(nonemptymgi, element);
+
+  const auto max_nlte_dimension = get_max_nlte_dimension();
+
+  // will hold the un-normalised population densities [cm^-3]
+  THREADLOCALONHOST std::vector<double> popvec;
+  popvec.reserve(max_nlte_dimension);
+
+  // superlevel population renormalisation factors for every ion of the element:
+  // superlevel members get their Boltzmann fraction of the superlevel population, while levels
+  // with their own matrix entries (ground, NLTE excited, and autoionising levels) get a weight of 1.
+  THREADLOCALONHOST std::vector<std::vector<double>> s_renorm_allions;
+  s_renorm_allions.reserve(get_max_nions());
+  s_renorm_allions.resize(nions);
+  for (int ion = 0; ion < nions; ion++) {
+    const int nlevels = get_nlevels(element, ion);
+    s_renorm_allions[ion].resize(nlevels);
+    std::ranges::fill(s_renorm_allions[ion], 1.0);  // default to 1. for all levels
+    const int level_superlevel_start = get_nlevels_excited_nlte(element, ion) + 1;
+    const int first_autoion = get_nlevels_nonautoion(element, ion);
+
+    // set the superlevel renormalisation factors for all levels in the superlevel
+    for (int level = level_superlevel_start; level < first_autoion; level++) {
+      s_renorm_allions[ion][level] = superlevel_boltzmann(nonemptymgi, element, ion, level) / superlevel_partfuncs[ion];
+    }
+  }
+
+  THREADLOCALONHOST RateMatrices rate_matrices{max_nlte_dimension};
+
+  const auto [matrix_solve_success, first_ion_used, nions_used] = nltepop_solve_matrix_with_ion_reduction(
+      element, nonemptymgi, t_mid, nnelement, s_renorm_allions, rate_matrices, popvec);
+
   if (!matrix_solve_success) {
     printlnlog(
         "WARNING: Can't solve for NLTE populations in cell {} at timestep {} for element Z={} due to singular matrix, "
@@ -1348,77 +1450,8 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
         modelgridindex, timestep, atomic_number);
     set_element_pops_lte(nonemptymgi, element);
   } else {
-    // check calculated NLTE populations are valid
-    for (const auto pop : popvec) {
-      assert_always(std::isfinite(pop));
-      assert_always(pop >= 0.);
-    }
-
-    // set the ground level, excited level and possible superlevel populations for this element
-    for (int ion = 0; ion < nions; ion++) {
-      const int nlevels_excited_nlte = get_nlevels_excited_nlte(element, ion);
-
-      if (ion < first_ion_used || ion >= (first_ion_used + nions_used)) {
-        printlnlog("  WARNING: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to zero ",
-                   get_atomicnumber(element), get_ionstage(element, ion));
-
-        set_groundlevelpop(nonemptymgi, element, ion, 0.);
-
-        for (int level = 1; level <= nlevels_excited_nlte; level++) {
-          set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level, 0.);
-        }
-
-        if (ion_has_superlevel(element, ion)) {
-          set_nlte_superlevelpop_over_rho_over_slpartfunc(nonemptymgi, element, ion, 0.);
-        }
-      } else {
-        // only valid for ions inside the solved range [first_ion_used, first_ion_used + nions_used)
-        const int index_gs = get_nlte_vector_index(element, ion, 0, first_ion_used);
-        set_groundlevelpop(nonemptymgi, element, ion, static_cast<float>(popvec[index_gs]));
-
-        for (int level = 1; level <= nlevels_excited_nlte; level++) {
-          const int index = get_nlte_vector_index(element, ion, level, first_ion_used);
-          set_nlte_levelpop_over_rho(nonemptymgi, element, ion, level, popvec[index] / grid::get_rho(nonemptymgi));
-        }
-
-        if (ion_has_superlevel(element, ion)) {
-          const int index_sl = get_nlte_vector_index(element, ion, nlevels_excited_nlte + 1, first_ion_used);
-          set_nlte_superlevelpop_over_rho_over_slpartfunc(
-              nonemptymgi, element, ion, popvec[index_sl] / grid::get_rho(nonemptymgi) / superlevel_partfuncs[ion]);
-        }
-      }
-    }
-    calculate_cellpartfuncts(nonemptymgi, element);
-
-    const double elem_pop_matrix = std::accumulate(popvec.begin(), popvec.end(), 0.0,
-                                                   [](const double sum, const double pop) { return sum + fabs(pop); });
-    const double elem_pop_error_percent = fabs((nnelement / elem_pop_matrix) - 1) * 100;
-    if (elem_pop_error_percent > 1.0) {
-      printlnlog(
-          "  WARNING: timestep {} nlteiter {} Z={} element population is: {:g} (from abundance) and {:g} (from matrix "
-          "solution), error: {:.2f}%. Forcing element pops to LTE.",
-          timestep, nlte_iter, atomic_number, nnelement, elem_pop_matrix, elem_pop_error_percent);
-      set_element_pops_lte(nonemptymgi, element);
-    }
-
-    // output NLTE stats every nth timestep for the first NLTE iteration only
-    if ((timestep % 5 == 0) && (nlte_iter == 0)) {
-      print_element_rates_summary(element, modelgridindex, timestep, nlte_iter, popvec, rate_matrices, first_ion_used,
-                                  nions_used);
-    }
-
-    // detailed levels stats (very verbose, only for debugging)
-    const bool print_detailed_level_stats = false;
-    if (print_detailed_level_stats) {
-      const int ionstage = 2;
-      const int ion = ionstage - get_ionstage(element, 0);
-
-      const int nlevels = get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0);
-      for (int level = 0; level <= nlevels; level++) {
-        print_level_rates(nonemptymgi, timestep, element, ion, level, popvec, rate_matrices, first_ion_used,
-                          nions_used);
-      }
-    }
+    nltepop_apply_solution(element, nonemptymgi, timestep, nlte_iter, nnelement, superlevel_partfuncs, popvec,
+                           rate_matrices, first_ion_used, nions_used);
   }
 
   if (const auto duration_nltesolver =


### PR DESCRIPTION
Restructures the four largest functions in the codebase for readability, with simulation output verified to be unchanged.

## Summary

Three of the largest functions (`init_nuclides()`, `solve_nlte_pops_element()`, and `read_atomicdata_files()`) are split into focused helper functions by pure code motion. `read_ejecta_model()` instead keeps a single cell-reading loop but shares the previously triplicated logic between the 1D, 2D, and 3D branches. The atomic-data pipeline also drops a dead placeholder data flow around the transition-to-linelist mapping.

## Key Changes

**grid.cc — model reading deduplication:**
- `read_ejecta_model()` now reads cells in one shared loop for all geometries; the 1D/2D/3D branches are reduced to parsing their own line format and validating cell midpoint positions
- The column-name setup, `first_cellindex` bookkeeping and cell-number check, negative-density check, density scaling from `t_model` to `tmin`, radioabundance reading, and the cell-count check are now written once instead of three times (~87 lines of duplication removed)

**decay.cc — nuclide initialisation:**
- `init_nuclides()` is now a short orchestrator calling `add_standard_nuclides()`, the four decay-data file readers (`read_betaminus_decaydata()`, `read_alpha_decaydata()`, `read_spontfission_decaydata()`, `read_fissionproduct_data()`), `add_custom_and_daughter_nuclides()`, and `check_nuclide_data()`

**nltepop.cc — NLTE solver:**
- `nltepop_solve_matrix_with_ion_reduction()` holds the matrix assembly, solve, and ion-range-reduction retry loop
- `nltepop_apply_solution()` stores the solved populations, checks the element population against the abundance, and prints the rate summaries

**input.cc — atomic data reading:**
- `read_atomicdata_files()` is now a short orchestrator calling `sort_temp_linelist()`, `create_shared_levellist()`, `create_shared_linelist()`, and `create_shared_alltranslist()`
- The always -1 `lineindex` placeholder member of `TempAllTransInput` is removed: the shared linelist is created before the shared transition list (linelist creation does not read the transition arrays), and `create_shared_alltranslist()` now points each transition at the frequency-sorted linelist itself, eliminating the separate `establish_linelist_connections()` pass and the cross-function array handoff
- A new assertion documents the invariant that makes this safe: each line writes exactly one down- and one up-transition entry, so all `updowntranscount == 2 * nlines` elements are covered

## Verification

- Line-by-line diff audit: the extractions are verbatim code motion; no logic line was altered, reordered, or lost
- Byte-identical outputs: built this branch and `develop` with `REPRODUCIBLE=ON TESTMODE=OFF MAX_NODE_SIZE=2 FASTMATH=OFF` (gcc-14/OpenMPI) and ran the kilonova_1d and kilonova_2d tests with 4 MPI ranks — every output file (packets, estimators, grid saves, spectra, light curves) is md5-identical between the two binaries (27/27 and 24/24 files)
- The remaining CI checksum jobs cover the 3D and nebular/classic modes
- Note: the NVIDIA NVHPC CI job fails before compiling anything — a 404 installing `nvhpc-26-1` from NVIDIA's apt repo (version pinned in `ci-checks.yml`); unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBanjhUwYyuwzc3M5nrdt5