### PR TITLE
Fix defects in log messages

### DIFF
--- a/decay.cc
+++ b/decay.cc
@@ -103,8 +103,8 @@ std::vector<Nuclide> nuclides;
 std::vector<DecayPath> decaypaths;
 std::vector<bool> alldecaytypes_is_used;
 
-[[nodiscard]] constexpr auto decay_daughters_z_a_prob(const int z_parent, const int a_parent, const DecayType decaytype)
-    -> std::vector<DecayDaughter> {
+[[nodiscard]] constexpr auto decay_daughters_z_a_prob(const int z_parent, const int a_parent,
+                                                      const DecayType decaytype) -> std::vector<DecayDaughter> {
   assert_always(decaytype >= 0);
   assert_always(decaytype < DecayType::DECAYTYPE_COUNT);
 
@@ -313,7 +313,12 @@ void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
       // check for nuclide in existing path, which would indicate a loop
       for (const auto [z, a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
         if (z == daughter.z && a == daughter.a) {
-          printlnlog("\nERROR: Loop found in nuclear decay chain.");
+          std::string chainstr;
+          for (const auto [chain_z, chain_a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
+            chainstr += std::format("(Z={},A={}) -> ", chain_z, chain_a);
+          }
+          printlnlog("ERROR: loop in nuclear decay chain: {}(Z={},A={}) already occurred. aborting", chainstr,
+                     daughter.z, daughter.a);
           std::abort();
         }
       }
@@ -457,8 +462,8 @@ void filter_unused_nuclides(const std::span<const int> custom_zlist, const std::
   }
 }
 
-auto sample_decaytime(const int decaypathindex, const double tdecaymin, const double tdecaymax, rngstate_type& rngstate)
-    -> double {
+auto sample_decaytime(const int decaypathindex, const double tdecaymin, const double tdecaymax,
+                      rngstate_type& rngstate) -> double {
   double tdecay = -1;
   const double t_model = grid::get_t_model();
   // rejection method. draw random times with the right distribution until they are within the correct range.
@@ -570,8 +575,8 @@ auto get_nuc_massfrac(const int nonemptymgi, const int nucindex, const double ti
 // Get the decay energy [erg/g] that would be released from time tstart [s] to time infinity by a given decaypath
 // e.g. Ni56 -> Co56, represents the decays of Co56 nuclei that were produced from Ni56 in the initial abundance.
 // Decays from Co56 due to the initial abundance of Co56 are not counted here, nor is the energy from Ni56 decays
-auto get_endecay_to_tinf_per_ejectamass_at_time(const int modelgridindex, const int decaypathindex, const double time)
-    -> double {
+auto get_endecay_to_tinf_per_ejectamass_at_time(const int modelgridindex, const int decaypathindex,
+                                                const double time) -> double {
   assert_testmodeonly(decaypathindex >= 0);
   assert_testmodeonly(decaypathindex < get_num_decaypaths());
   const auto& decaypath = decaypaths[decaypathindex];
@@ -1148,9 +1153,8 @@ auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(const int nonemptym
 
 // get the decay energy that will be released during the simulation time [(tmodel if initial packets else tmin) to tmax]
 // indexed by nonemptymgi and decaypathindex [erg/g]
-auto get_modelcell_simtime_endecay_per_mass(const int nonemptymgi,
-                                            const std::span<const double> energy_per_mass_nonemptymgi_decaypath)
-    -> double {
+auto get_modelcell_simtime_endecay_per_mass(
+    const int nonemptymgi, const std::span<const double> energy_per_mass_nonemptymgi_decaypath) -> double {
   const auto num_decaypaths = get_num_decaypaths();
   double endecay_per_mass = 0.;
   for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
@@ -1192,8 +1196,8 @@ auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const doubl
 }
 
 // energy release rate in form of kinetic energy of positrons, electrons, and alpha particles in [erg/s/g]
-[[nodiscard]] auto get_particle_injection_rate(const int nonemptymgi, const double t, const DecayType decaytype)
-    -> double {
+[[nodiscard]] auto get_particle_injection_rate(const int nonemptymgi, const double t,
+                                               const DecayType decaytype) -> double {
   double dep_sum = 0.;
   const auto num_nuclides = std::ssize(nuclides);
   for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {

--- a/decay.cc
+++ b/decay.cc
@@ -1169,7 +1169,7 @@ auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const doubl
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
   printlog(
       "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
-      "[MB] (node shared memory)...",
+      "MB (node shared memory)...",
       nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
   auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
   printlnlog("done.");

--- a/decay.cc
+++ b/decay.cc
@@ -103,8 +103,8 @@ std::vector<Nuclide> nuclides;
 std::vector<DecayPath> decaypaths;
 std::vector<bool> alldecaytypes_is_used;
 
-[[nodiscard]] constexpr auto decay_daughters_z_a_prob(const int z_parent, const int a_parent,
-                                                      const DecayType decaytype) -> std::vector<DecayDaughter> {
+[[nodiscard]] constexpr auto decay_daughters_z_a_prob(const int z_parent, const int a_parent, const DecayType decaytype)
+    -> std::vector<DecayDaughter> {
   assert_always(decaytype >= 0);
   assert_always(decaytype < DecayType::DECAYTYPE_COUNT);
 
@@ -462,8 +462,8 @@ void filter_unused_nuclides(const std::span<const int> custom_zlist, const std::
   }
 }
 
-auto sample_decaytime(const int decaypathindex, const double tdecaymin, const double tdecaymax,
-                      rngstate_type& rngstate) -> double {
+auto sample_decaytime(const int decaypathindex, const double tdecaymin, const double tdecaymax, rngstate_type& rngstate)
+    -> double {
   double tdecay = -1;
   const double t_model = grid::get_t_model();
   // rejection method. draw random times with the right distribution until they are within the correct range.
@@ -575,8 +575,8 @@ auto get_nuc_massfrac(const int nonemptymgi, const int nucindex, const double ti
 // Get the decay energy [erg/g] that would be released from time tstart [s] to time infinity by a given decaypath
 // e.g. Ni56 -> Co56, represents the decays of Co56 nuclei that were produced from Ni56 in the initial abundance.
 // Decays from Co56 due to the initial abundance of Co56 are not counted here, nor is the energy from Ni56 decays
-auto get_endecay_to_tinf_per_ejectamass_at_time(const int modelgridindex, const int decaypathindex,
-                                                const double time) -> double {
+auto get_endecay_to_tinf_per_ejectamass_at_time(const int modelgridindex, const int decaypathindex, const double time)
+    -> double {
   assert_testmodeonly(decaypathindex >= 0);
   assert_testmodeonly(decaypathindex < get_num_decaypaths());
   const auto& decaypath = decaypaths[decaypathindex];
@@ -1153,8 +1153,9 @@ auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(const int nonemptym
 
 // get the decay energy that will be released during the simulation time [(tmodel if initial packets else tmin) to tmax]
 // indexed by nonemptymgi and decaypathindex [erg/g]
-auto get_modelcell_simtime_endecay_per_mass(
-    const int nonemptymgi, const std::span<const double> energy_per_mass_nonemptymgi_decaypath) -> double {
+auto get_modelcell_simtime_endecay_per_mass(const int nonemptymgi,
+                                            const std::span<const double> energy_per_mass_nonemptymgi_decaypath)
+    -> double {
   const auto num_decaypaths = get_num_decaypaths();
   double endecay_per_mass = 0.;
   for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
@@ -1167,11 +1168,12 @@ auto get_modelcell_simtime_endecay_per_mass(
 // decay energy per mass [erg/g] released by chain i in cell mgi during the simulation time range tmin to tmax
 auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const double> {
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
-  auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
-  printlnlog(
+  printlog(
       "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
-      "MB (node shared memory)",
+      "MB (node shared memory)...",
       nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
+  auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
+  printlnlog("done.");
 
   MPI_Barrier_allranks();
   const auto time_min_decay = INITIAL_PACKETS_ON ? grid::get_t_model() : globals::tmin;
@@ -1194,8 +1196,8 @@ auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const doubl
 }
 
 // energy release rate in form of kinetic energy of positrons, electrons, and alpha particles in [erg/s/g]
-[[nodiscard]] auto get_particle_injection_rate(const int nonemptymgi, const double t,
-                                               const DecayType decaytype) -> double {
+[[nodiscard]] auto get_particle_injection_rate(const int nonemptymgi, const double t, const DecayType decaytype)
+    -> double {
   double dep_sum = 0.;
   const auto num_nuclides = std::ssize(nuclides);
   for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {

--- a/decay.cc
+++ b/decay.cc
@@ -292,8 +292,7 @@ void printout_decaypath(const int decaypathindex) {
   printlnlog("");
 }
 
-// follow decays at the ends of the current list of decaypaths
-// to get decaypaths from all descendants
+// follow decays at the ends of the current list of decaypaths to get decaypaths from all descendants
 void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
   const auto initial_last_decaypath = localdecaypaths.back();
 

--- a/decay.cc
+++ b/decay.cc
@@ -313,12 +313,11 @@ void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
       // check for nuclide in existing path, which would indicate a loop
       for (const auto [z, a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
         if (z == daughter.z && a == daughter.a) {
-          std::string chainstr;
+          printlog("[error] loop in nuclear decay chain: ");
           for (const auto [chain_z, chain_a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
-            chainstr += std::format("(Z={},A={}) -> ", chain_z, chain_a);
+            printlog("(Z={},A={}) -> ", chain_z, chain_a);
           }
-          printlnlog("[error] loop in nuclear decay chain: {}(Z={},A={}) already occurred. aborting", chainstr,
-                     daughter.z, daughter.a);
+          printlnlog("(Z={},A={}) already occurred. aborting", daughter.z, daughter.a);
           std::abort();
         }
       }

--- a/decay.cc
+++ b/decay.cc
@@ -942,7 +942,7 @@ void read_spontfission_decaydata() {
     nuclides.back().branchprobs[DECAYTYPE_SPONTFISSION] = 1.;
     nuclides.back().endecay_q[DECAYTYPE_SPONTFISSION] = q_fission_mev * MEV;
     nuclides.back().endecay_fission = q_fission_mev * MEV;  // will be overwritten if we have fission product data
-    printlnlog("  added spontaneous fission nuclide: (Z={}){}{} meanlife {:.1e} days", z_in, get_elname(z_in), a_in,
+    printlnlog("  added spontaneous fission nuclide: (Z={}){}{} meanlife {:.1e} [days]", z_in, get_elname(z_in), a_in,
                tau_sec / DAY);
   }
 }
@@ -1106,13 +1106,13 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   gammapkt::init_gamma_data();
 
   // TODO: generalise this to all included nuclides
-  printlnlog("decayenergy(NI56) {:g} MeV, decayenergy(CO56) {:g} MeV, decayenergy_gamma(CO56) {:g} MeV",
+  printlnlog("decayenergy(NI56) {:g} [MeV], decayenergy(CO56) {:g} [MeV], decayenergy_gamma(CO56) {:g} [MeV]",
              nucdecayenergytotal(28, 56) / MEV, nucdecayenergytotal(27, 56) / MEV, nucdecayenergygamma(27, 56) / MEV);
-  printlnlog("decayenergy(NI57) {:g} MeV, decayenergy_gamma(NI57) {:g} MeV, decayenergy(CO57) {:g} MeV",
+  printlnlog("decayenergy(NI57) {:g} [MeV], decayenergy_gamma(NI57) {:g} [MeV], decayenergy(CO57) {:g} [MeV]",
              nucdecayenergytotal(28, 57) / MEV, nucdecayenergygamma(28, 57) / MEV, nucdecayenergytotal(27, 57) / MEV);
-  printlnlog("decayenergy(CR48) {:g} MeV, decayenergy(V48) {:g} MeV", nucdecayenergytotal(24, 48) / MEV,
+  printlnlog("decayenergy(CR48) {:g} [MeV], decayenergy(V48) {:g} [MeV]", nucdecayenergytotal(24, 48) / MEV,
              nucdecayenergytotal(23, 48) / MEV);
-  printlnlog("decayenergy(FE52) {:g} MeV, decayenergy(MN52) {:g} MeV", nucdecayenergytotal(26, 52) / MEV,
+  printlnlog("decayenergy(FE52) {:g} [MeV], decayenergy(MN52) {:g} [MeV]", nucdecayenergytotal(26, 52) / MEV,
              nucdecayenergytotal(25, 52) / MEV);
 
   if (globals::my_rank == 0 && !globals::simulation_continued_from_saved) {
@@ -1170,7 +1170,7 @@ auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const doubl
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
   printlog(
       "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
-      "MB (node shared memory)...",
+      "[MB] (node shared memory)...",
       nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
   auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
   printlnlog("done.");

--- a/decay.cc
+++ b/decay.cc
@@ -317,7 +317,7 @@ void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
           for (const auto [chain_z, chain_a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
             chainstr += std::format("(Z={},A={}) -> ", chain_z, chain_a);
           }
-          printlnlog("ERROR: loop in nuclear decay chain: {}(Z={},A={}) already occurred. aborting", chainstr,
+          printlnlog("[error] loop in nuclear decay chain: {}(Z={},A={}) already occurred. aborting", chainstr,
                      daughter.z, daughter.a);
           std::abort();
         }
@@ -740,7 +740,7 @@ auto write_nuclides_list() {
   if (nucindex >= 0) {
     return nucindex;
   }
-  printlnlog("ERROR: nuclide Z={} A={} not found in nuclide list", z, a);
+  printlnlog("[error] nuclide Z={} A={} not found in nuclide list", z, a);
   assert_always(false);  // nuclide not found
   return -1;
 }
@@ -1106,13 +1106,13 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   gammapkt::init_gamma_data();
 
   // TODO: generalise this to all included nuclides
-  printlnlog("decayenergy(NI56), decayenergy(CO56), decayenergy_gamma(CO56): {:g}, {:g}, {:g}",
+  printlnlog("decayenergy(NI56) {:g} MeV, decayenergy(CO56) {:g} MeV, decayenergy_gamma(CO56) {:g} MeV",
              nucdecayenergytotal(28, 56) / MEV, nucdecayenergytotal(27, 56) / MEV, nucdecayenergygamma(27, 56) / MEV);
-  printlnlog("decayenergy(NI57), decayenergy_gamma(NI57), nucdecayenergy(CO57): {:g}, {:g}, {:g}",
+  printlnlog("decayenergy(NI57) {:g} MeV, decayenergy_gamma(NI57) {:g} MeV, decayenergy(CO57) {:g} MeV",
              nucdecayenergytotal(28, 57) / MEV, nucdecayenergygamma(28, 57) / MEV, nucdecayenergytotal(27, 57) / MEV);
-  printlnlog("decayenergy(CR48), decayenergy(V48): {:g} {:g}", nucdecayenergytotal(24, 48) / MEV,
+  printlnlog("decayenergy(CR48) {:g} MeV, decayenergy(V48) {:g} MeV", nucdecayenergytotal(24, 48) / MEV,
              nucdecayenergytotal(23, 48) / MEV);
-  printlnlog("decayenergy(FE52), decayenergy(MN52): {:g} {:g}", nucdecayenergytotal(26, 52) / MEV,
+  printlnlog("decayenergy(FE52) {:g} MeV, decayenergy(MN52) {:g} MeV", nucdecayenergytotal(26, 52) / MEV,
              nucdecayenergytotal(25, 52) / MEV);
 
   if (globals::my_rank == 0 && !globals::simulation_continued_from_saved) {
@@ -1167,13 +1167,11 @@ auto get_modelcell_simtime_endecay_per_mass(
 // decay energy per mass [erg/g] released by chain i in cell mgi during the simulation time range tmin to tmax
 auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const double> {
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
-  printlog(
-      "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
-      "MB (node shared "
-      "memory)...",
-      nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
   auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
-  printlnlog("done.");
+  printlnlog(
+      "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
+      "MB (node shared memory)",
+      nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
 
   MPI_Barrier_allranks();
   const auto time_min_decay = INITIAL_PACKETS_ON ? grid::get_t_model() : globals::tmin;

--- a/decay.cc
+++ b/decay.cc
@@ -1166,12 +1166,11 @@ auto get_modelcell_simtime_endecay_per_mass(const int nonemptymgi,
 // decay energy per mass [erg/g] released by chain i in cell mgi during the simulation time range tmin to tmax
 auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const double> {
   const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
-  printlog(
+  printlnlog(
       "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
-      "MB (node shared memory)...",
+      "MB (node shared memory).",
       nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
   auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
-  printlnlog("done.");
 
   MPI_Barrier_allranks();
   const auto time_min_decay = INITIAL_PACKETS_ON ? grid::get_t_model() : globals::tmin;

--- a/exspec.cc
+++ b/exspec.cc
@@ -12,7 +12,6 @@
 #include <cstdlib>
 #include <filesystem>
 #include <format>
-#include <limits>
 #include <span>
 #include <vector>
 
@@ -64,11 +63,6 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
   THREADLOCALONHOST Spectra gamma_spectra;
   init_spectra(gamma_spectra, nu_min_gamma, nu_max_gamma, false);
   assert_always(globals::nprocs_exspec > 0);
-  ptrdiff_t nesc_rpkt_total = 0;
-  ptrdiff_t nesc_gamma_total = 0;
-  int nesc_rpkt_min = std::numeric_limits<int>::max();
-  int nesc_rpkt_max = 0;
-  int ranks_with_no_escapes = 0;
   for (int p = 0; p < globals::nprocs_exspec; p++) {
     const auto& pkts_thisrank = packets_by_rank[p];
 
@@ -93,23 +87,7 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
       }
     }
     if (dirbin == -1) {
-      nesc_rpkt_total += nesc_rpkt;
-      nesc_gamma_total += nesc_gamma;
-      nesc_rpkt_min = std::min(nesc_rpkt_min, nesc_rpkt);
-      nesc_rpkt_max = std::max(nesc_rpkt_max, nesc_rpkt);
-      if (nesc_rpkt == 0 && nesc_gamma == 0) {
-        ranks_with_no_escapes++;
-        printlnlog("[warning] packet file of rank {} contains no escaped packets", p);
-      }
-    }
-  }
-
-  if (dirbin == -1) {
-    printlnlog("  {} ranks: {} escaped r-packets (per-rank min {} max {}) and {} escaped gamma-packets",
-               globals::nprocs_exspec, nesc_rpkt_total, nesc_rpkt_min, nesc_rpkt_max, nesc_gamma_total);
-    if (ranks_with_no_escapes > 0) {
-      printlnlog("[warning] {} of {} rank packet files contained no escaped packets", ranks_with_no_escapes,
-                 globals::nprocs_exspec);
+      printlnlog("  rank {}: {} escaped r-packets and {} escaped gamma-pkts", p, nesc_rpkt, nesc_gamma);
     }
   }
 

--- a/exspec.cc
+++ b/exspec.cc
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <format>
+#include <limits>
 #include <span>
 #include <vector>
 
@@ -63,6 +64,11 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
   THREADLOCALONHOST Spectra gamma_spectra;
   init_spectra(gamma_spectra, nu_min_gamma, nu_max_gamma, false);
   assert_always(globals::nprocs_exspec > 0);
+  ptrdiff_t nesc_rpkt_total = 0;
+  ptrdiff_t nesc_gamma_total = 0;
+  int nesc_rpkt_min = std::numeric_limits<int>::max();
+  int nesc_rpkt_max = 0;
+  int ranks_with_no_escapes = 0;
   for (int p = 0; p < globals::nprocs_exspec; p++) {
     const auto& pkts_thisrank = packets_by_rank[p];
 
@@ -87,7 +93,23 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
       }
     }
     if (dirbin == -1) {
-      printlnlog("  rank {}: {} escaped r-packets and {} escaped gamma-pkts", p, nesc_rpkt, nesc_gamma);
+      nesc_rpkt_total += nesc_rpkt;
+      nesc_gamma_total += nesc_gamma;
+      nesc_rpkt_min = std::min(nesc_rpkt_min, nesc_rpkt);
+      nesc_rpkt_max = std::max(nesc_rpkt_max, nesc_rpkt);
+      if (nesc_rpkt == 0 && nesc_gamma == 0) {
+        ranks_with_no_escapes++;
+        printlnlog("[warning] packet file of rank {} contains no escaped packets", p);
+      }
+    }
+  }
+
+  if (dirbin == -1) {
+    printlnlog("  {} ranks: {} escaped r-packets (per-rank min {} max {}) and {} escaped gamma-packets",
+               globals::nprocs_exspec, nesc_rpkt_total, nesc_rpkt_min, nesc_rpkt_max, nesc_gamma_total);
+    if (ranks_with_no_escapes > 0) {
+      printlnlog("[warning] {} of {} rank packet files contained no escaped packets", ranks_with_no_escapes,
+                 globals::nprocs_exspec);
     }
   }
 

--- a/exspec.cc
+++ b/exspec.cc
@@ -130,7 +130,7 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
                     rpkt_spectra_Q, rpkt_spectra_U);
     }
 
-    printlnlog("finished direction bin {} of {}", dirbin + 1, MABINS);
+    printlnlog("finished direction bin {} (highest bin is {})", dirbin, MABINS - 1);
   }
 }
 

--- a/exspec.cc
+++ b/exspec.cc
@@ -129,7 +129,7 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
       write_spectra("gamma_spec.out", "", "", "", gamma_spectra, globals::ntimesteps);
     }
 
-    printlnlog("finished angle-averaged stuff");
+    printlnlog("wrote the angle-averaged light curves and spectra");
   } else {
     // direction bin a
     // line-of-sight dependent spectra and light curves
@@ -152,7 +152,7 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
                     rpkt_spectra_Q, rpkt_spectra_U);
     }
 
-    printlnlog("Did {} of {} angle bins.", dirbin + 1, MABINS);
+    printlnlog("finished direction bin {} of {}", dirbin + 1, MABINS);
   }
 }
 
@@ -171,11 +171,11 @@ auto main(int argc, char* argv[]) -> int {
     set_log_file("exspec.txt");
   }
 
-  printlnlog("git branch {}", GIT_BRANCH);
+  printlnlog("git branch: {}", GIT_BRANCH);
 
   printlnlog("git version: {}", GIT_VERSION);
 
-  printlnlog("git status {}", GIT_STATUS);
+  printlnlog("git status: {}", GIT_STATUS);
 
   printlnlog("exspec compiled at {} on {}", __TIME__, __DATE__);
 

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -177,10 +177,10 @@ void read_decaydata() {
     decay::set_nucdecayenergygamma(decay::get_nucindex(25, 52), 3.415 * MEV);  // Mn52
   }
 
-  printlnlog("read gamma-ray line tables for {} nuclides", tables_found);
+  printlnlog("[info] read gamma-ray line tables for {} nuclides", tables_found);
   if (nuclides_without_table > 0) {
     printlnlog(
-        "[warning] no gamma-ray line table found for {} nuclides with non-zero gamma decay energy, so a single line "
+        "[info] no gamma-ray line table found for {} nuclides with non-zero gamma decay energy, so a single line "
         "carrying the mean gamma energy per decay is used for each",
         nuclides_without_table);
   }

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <tuple>
 #include <vector>
 
@@ -109,13 +110,23 @@ void set_trivial_gamma_spectrum(const int nucindex) {
 void read_decaydata() {
   // migrate from old filenames that didn't specify the nuclide mass number
   if (!std::filesystem::exists("gamma_ni56.txt") && std::filesystem::exists("ni_lines.txt")) {
-    printlnlog("Moving ni_lines.txt to gamma_ni56.txt");
-    std::rename("ni_lines.txt", "gamma_ni56.txt");
+    std::error_code rename_error;
+    std::filesystem::rename("ni_lines.txt", "gamma_ni56.txt", rename_error);
+    if (rename_error) {
+      printlnlog("ERROR: failed to move ni_lines.txt to gamma_ni56.txt: {}", rename_error.message());
+    } else {
+      printlnlog("Moved ni_lines.txt to gamma_ni56.txt");
+    }
   }
 
   if (!std::filesystem::exists("gamma_co56.txt") && std::filesystem::exists("co_lines.txt")) {
-    printlnlog("Moving co_lines.txt to gamma_co56.txt");
-    std::rename("co_lines.txt", "gamma_co56.txt");
+    std::error_code rename_error;
+    std::filesystem::rename("co_lines.txt", "gamma_co56.txt", rename_error);
+    if (rename_error) {
+      printlnlog("ERROR: failed to move co_lines.txt to gamma_co56.txt: {}", rename_error.message());
+    } else {
+      printlnlog("Moved co_lines.txt to gamma_co56.txt");
+    }
   }
 
   gamma_spectra.resize(decay::get_num_nuclides(), {});
@@ -438,8 +449,8 @@ void compton_scatter(Packet& pkt) {
 }
 
 // calculate the absorption coefficient [cm^-1] for photo electric effect scattering in the co-moving frame
-[[nodiscard]] auto get_chi_photo_electric_cmf(const int nonemptymgi, const double ffegrp, const double nu_cmf)
-    -> double {
+[[nodiscard]] auto get_chi_photo_electric_cmf(const int nonemptymgi, const double ffegrp,
+                                              const double nu_cmf) -> double {
   const double rho = grid::get_rho(nonemptymgi);
 
   if constexpr (GAMMA_USE_KAPPA_GREY.has_value()) {

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -69,9 +69,7 @@ constexpr double nu_1p5mev = 3.61990e+20;
 
 void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   // read the gamma ray lines and store the average energy in gamma rays per nuclear decay
-  printlog("reading gamma spectrum for Z={} A={} from {}...", decay::get_nuc_z(nucindex), decay::get_nuc_a(nucindex),
-           filename);
-
+  // (the total table and line counts are reported by read_decaydata and init_gamma_linelist)
   auto gammafile = fstream_required(filename, std::ios::in);
   std::string line;
   get_noncommentline(gammafile, line);
@@ -95,8 +93,6 @@ void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   }
 
   decay::set_nucdecayenergygamma(nucindex, E_gamma_avg);
-
-  printlnlog("nlines {} avg_en_gamma {:g} MeV", nlines, E_gamma_avg / MEV);
 }
 
 void set_trivial_gamma_spectrum(const int nucindex) {

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -328,8 +328,7 @@ auto thomson_angle(rngstate_type& rngstate) -> double {
 
 // scattering a direction through angle theta.
 [[nodiscard]] auto scatter_dir(const Vec3d& dir_in, const double cos_theta, rngstate_type& rngstate) -> Vec3d {
-  // begin with setting the direction in coordinates where original direction
-  // is parallel to z-hat.
+  // begin with setting the direction in coordinates where original direction is parallel to z-hat.
 
   assert_testmodeonly(std::fabs(vec_len(dir_in) - 1.) < 1e-10);  // dir_in must be a unit vector
 
@@ -350,8 +349,7 @@ auto thomson_angle(rngstate_type& rngstate) -> double {
     return dir_out;
   }
 
-  // Now need to derotate the coordinates back to real x,y,z.
-  // Rotation matrix is determined by dir_in.
+  // Now need to derotate the coordinates back to real x,y,z. Rotation matrix is determined by dir_in.
 
   const double norm1 = 1. / std::sqrt(pow2(dir_in[0]) + pow2(dir_in[1]));
   const double norm2 = 1. / vec_len(dir_in);
@@ -390,8 +388,7 @@ void compton_scatter(Packet& pkt) {
   // scattering angle. Probability of scattering into particular angle
   // (i.e. final energy) is related to the partial cross-section.
 
-  // Choose a random number to get the energy. Want to find the
-  // factor by which the energy changes "f" such that
+  // Choose a random number to get the energy. Want to find the factor by which the energy changes "f" such that
   // sigma_partial/sigma_tot = zrand
 
   // initialise with Thomson limit case (no energy loss)
@@ -407,8 +404,7 @@ void compton_scatter(Packet& pkt) {
   }
 
   if (stay_gamma) {
-    // It stays as a gamma ray. Change frequency and direction in
-    // co-moving frame then transfer back to rest frame.
+    // It stays as a gamma ray. Change frequency and direction in co-moving frame then transfer back to rest frame.
 
     pkt.nu_cmf = pkt.nu_cmf / f;  // reduce frequency
 
@@ -434,8 +430,7 @@ void compton_scatter(Packet& pkt) {
 
     assert_testmodeonly(std::fabs(vec_len(pkt.dir) - 1.) < 1e-10);
 
-    // It now has a rest frame direction and a co-moving frequency.
-    //  Just need to set the rest frame energy.
+    // It now has a rest frame direction and a co-moving frequency. Just need to set the rest frame energy.
     set_pkt_restframe_from_cmf(pkt);
   } else {
     // energy loss of the gamma becomes energy of the electron (needed to calculate time-dependent thermalisation rate)
@@ -716,13 +711,11 @@ void pair_production(Packet& pkt) {
 
 // move a gamma packet until time t2
 void transport_gamma(Packet& pkt, const double t2) {
-  // Assign optical depth to next physical event. And start counter of
-  // optical depth for this path.
+  // Assign optical depth to next physical event. And start counter of optical depth for this path.
   const double tau_next = -std::log(static_cast<double>(rng_uniform_pos(get_rngstate(pkt))));
 
   // Start by finding the distance to the crossing of the grid cell
-  // boundaries. boundarydist is the boundary distance and next_cellindex is the
-  // grid cell into which we pass.
+  // boundaries. boundarydist is the boundary distance and next_cellindex is the grid cell into which we pass.
 
   const auto [boundarydist, next_cellindex] = grid::boundary_distance(pkt.dir, pkt.pos, pkt.prop_time, pkt.cellindex);
 
@@ -960,8 +953,7 @@ void init_gamma_data() {
 
 // convert a pellet to a gamma ray (or kpkt if no gamma spec loaded)
 DEVICE_FUNC void pellet_gamma_decay(Packet& pkt) {
-  // Start by getting the position of the pellet at the point of decay. Pellet
-  // is moving with the matter.
+  // Start by getting the position of the pellet at the point of decay. Pellet is moving with the matter.
 
   // if no gamma spectra is known, then convert straight to kpkts (e.g., Fe52, Mn52)
   if (pkt.nu_cmf < 0) {

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -96,7 +96,7 @@ void read_gamma_spectrum(const int nucindex, const std::string& filename) {
 
   decay::set_nucdecayenergygamma(nucindex, E_gamma_avg);
 
-  printlnlog("nlines {} avg_en_gamma {:g} MeV", nlines, E_gamma_avg / MEV);
+  printlnlog("nlines {} avg_en_gamma {:g} [MeV]", nlines, E_gamma_avg / MEV);
 }
 
 void set_trivial_gamma_spectrum(const int nucindex) {

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -131,7 +131,6 @@ void read_decaydata() {
 
   gamma_spectra.resize(decay::get_num_nuclides(), {});
   int tables_found = 0;
-  std::string trivial_spectrum_nuclides;
   for (int nucindex = 0; nucindex < decay::get_num_nuclides(); nucindex++) {
     gamma_spectra[nucindex].clear();
     const int z = decay::get_nuc_z(nucindex);
@@ -172,7 +171,10 @@ void read_decaydata() {
       assert_always(z != 28 || a != 57);  // Ni-57 must have a gamma spectrum if present in list of nuclides
       assert_always(z != 27 || a != 57);  // Co-57 must have a gamma spectrum if present in list of nuclides
       set_trivial_gamma_spectrum(nucindex);
-      trivial_spectrum_nuclides += std::format(" (Z={},A={})", z, a);
+      printlnlog(
+          "[warning] no gamma-ray line table found for Z={} A={} despite its non-zero gamma decay energy, so a single "
+          "line carrying the mean gamma energy per decay will be used",
+          z, a);
     }
   }
 
@@ -184,12 +186,6 @@ void read_decaydata() {
   }
 
   printlnlog("read gamma-ray table files for {} nuclides", tables_found);
-  if (!trivial_spectrum_nuclides.empty()) {
-    printlnlog(
-        "[warning] no gamma-ray line table found for the following nuclides with non-zero gamma decay energy, so a "
-        "single line carrying the mean gamma energy per decay will be used:{}",
-        trivial_spectrum_nuclides);
-  }
 }
 
 // construct an energy ordered gamma ray line list.

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -68,9 +68,6 @@ constexpr double nu_1p5mev = 3.61990e+20;
 
 void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   // read the gamma ray lines and store the average energy in gamma rays per nuclear decay
-  printlog("reading gamma spectrum for Z={} A={} from {}...", decay::get_nuc_z(nucindex), decay::get_nuc_a(nucindex),
-           filename);
-
   auto gammafile = fstream_required(filename, std::ios::in);
   std::string line;
   get_noncommentline(gammafile, line);
@@ -94,8 +91,6 @@ void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   }
 
   decay::set_nucdecayenergygamma(nucindex, E_gamma_avg);
-
-  printlnlog("nlines {} avg_en_gamma {:g} [MeV]", nlines, E_gamma_avg / MEV);
 }
 
 void set_trivial_gamma_spectrum(const int nucindex) {
@@ -130,6 +125,7 @@ void read_decaydata() {
 
   gamma_spectra.resize(decay::get_num_nuclides(), {});
   int tables_found = 0;
+  int nuclides_without_table = 0;
   for (int nucindex = 0; nucindex < decay::get_num_nuclides(); nucindex++) {
     gamma_spectra[nucindex].clear();
     const int z = decay::get_nuc_z(nucindex);
@@ -170,10 +166,7 @@ void read_decaydata() {
       assert_always(z != 28 || a != 57);  // Ni-57 must have a gamma spectrum if present in list of nuclides
       assert_always(z != 27 || a != 57);  // Co-57 must have a gamma spectrum if present in list of nuclides
       set_trivial_gamma_spectrum(nucindex);
-      printlnlog(
-          "[warning] no gamma-ray line table found for Z={} A={} despite its non-zero gamma decay energy, so a single "
-          "line carrying the mean gamma energy per decay will be used",
-          z, a);
+      nuclides_without_table++;
     }
   }
 
@@ -184,7 +177,13 @@ void read_decaydata() {
     decay::set_nucdecayenergygamma(decay::get_nucindex(25, 52), 3.415 * MEV);  // Mn52
   }
 
-  printlnlog("read gamma-ray table files for {} nuclides", tables_found);
+  printlnlog("read gamma-ray line tables for {} nuclides", tables_found);
+  if (nuclides_without_table > 0) {
+    printlnlog(
+        "[warning] no gamma-ray line table found for {} nuclides with non-zero gamma decay energy, so a single line "
+        "carrying the mean gamma energy per decay is used for each",
+        nuclides_without_table);
+  }
 }
 
 // construct an energy ordered gamma ray line list.

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -109,7 +109,7 @@ void read_decaydata() {
     std::error_code rename_error;
     std::filesystem::rename("ni_lines.txt", "gamma_ni56.txt", rename_error);
     if (rename_error) {
-      printlnlog("ERROR: failed to move ni_lines.txt to gamma_ni56.txt: {}", rename_error.message());
+      printlnlog("[error] failed to move ni_lines.txt to gamma_ni56.txt: {}", rename_error.message());
     } else {
       printlnlog("Moved ni_lines.txt to gamma_ni56.txt");
     }
@@ -119,7 +119,7 @@ void read_decaydata() {
     std::error_code rename_error;
     std::filesystem::rename("co_lines.txt", "gamma_co56.txt", rename_error);
     if (rename_error) {
-      printlnlog("ERROR: failed to move co_lines.txt to gamma_co56.txt: {}", rename_error.message());
+      printlnlog("[error] failed to move co_lines.txt to gamma_co56.txt: {}", rename_error.message());
     } else {
       printlnlog("Moved co_lines.txt to gamma_co56.txt");
     }
@@ -182,7 +182,7 @@ void read_decaydata() {
   printlnlog("read gamma-ray table files for {} nuclides", tables_found);
   if (!trivial_spectrum_nuclides.empty()) {
     printlnlog(
-        "WARNING: no gamma-ray line table found for the following nuclides with non-zero gamma decay energy, so a "
+        "[warning] no gamma-ray line table found for the following nuclides with non-zero gamma decay energy, so a "
         "single line carrying the mean gamma energy per decay will be used:{}",
         trivial_spectrum_nuclides);
   }

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -127,6 +127,7 @@ void read_decaydata() {
 
   gamma_spectra.resize(decay::get_num_nuclides(), {});
   int tables_found = 0;
+  std::string trivial_spectrum_nuclides;
   for (int nucindex = 0; nucindex < decay::get_num_nuclides(); nucindex++) {
     gamma_spectra[nucindex].clear();
     const int z = decay::get_nuc_z(nucindex);
@@ -167,6 +168,7 @@ void read_decaydata() {
       assert_always(z != 28 || a != 57);  // Ni-57 must have a gamma spectrum if present in list of nuclides
       assert_always(z != 27 || a != 57);  // Co-57 must have a gamma spectrum if present in list of nuclides
       set_trivial_gamma_spectrum(nucindex);
+      trivial_spectrum_nuclides += std::format(" (Z={},A={})", z, a);
     }
   }
 
@@ -178,6 +180,12 @@ void read_decaydata() {
   }
 
   printlnlog("read gamma-ray table files for {} nuclides", tables_found);
+  if (!trivial_spectrum_nuclides.empty()) {
+    printlnlog(
+        "WARNING: no gamma-ray line table found for the following nuclides with non-zero gamma decay energy, so a "
+        "single line carrying the mean gamma energy per decay will be used:{}",
+        trivial_spectrum_nuclides);
+  }
 }
 
 // construct an energy ordered gamma ray line list.

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -9,7 +9,6 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
-#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <format>

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -69,7 +69,9 @@ constexpr double nu_1p5mev = 3.61990e+20;
 
 void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   // read the gamma ray lines and store the average energy in gamma rays per nuclear decay
-  // (the total table and line counts are reported by read_decaydata and init_gamma_linelist)
+  printlog("reading gamma spectrum for Z={} A={} from {}...", decay::get_nuc_z(nucindex), decay::get_nuc_a(nucindex),
+           filename);
+
   auto gammafile = fstream_required(filename, std::ios::in);
   std::string line;
   get_noncommentline(gammafile, line);
@@ -93,6 +95,8 @@ void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   }
 
   decay::set_nucdecayenergygamma(nucindex, E_gamma_avg);
+
+  printlnlog("nlines {} avg_en_gamma {:g} MeV", nlines, E_gamma_avg / MEV);
 }
 
 void set_trivial_gamma_spectrum(const int nucindex) {
@@ -453,8 +457,8 @@ void compton_scatter(Packet& pkt) {
 }
 
 // calculate the absorption coefficient [cm^-1] for photo electric effect scattering in the co-moving frame
-[[nodiscard]] auto get_chi_photo_electric_cmf(const int nonemptymgi, const double ffegrp,
-                                              const double nu_cmf) -> double {
+[[nodiscard]] auto get_chi_photo_electric_cmf(const int nonemptymgi, const double ffegrp, const double nu_cmf)
+    -> double {
   const double rho = grid::get_rho(nonemptymgi);
 
   if constexpr (GAMMA_USE_KAPPA_GREY.has_value()) {

--- a/grid.cc
+++ b/grid.cc
@@ -2288,7 +2288,6 @@ void init_grid() {
   MPI_Barrier_allranks();
 
   if (globals::rank_in_node == 0) {
-    printlnlog("Calculating initial grey opacities for model cells.");
     for (int nonemptymgi = 0; nonemptymgi < get_nonempty_npts_model(); nonemptymgi++) {
       kappagrey_allcells[nonemptymgi] = calculate_cell_kappagrey(nonemptymgi);
     }

--- a/grid.cc
+++ b/grid.cc
@@ -336,7 +336,7 @@ void set_elem_untrackedstable_massfrac(const int nonemptymgi, const int element,
   if (massfrac_untrackedstable < 0.) {
     //  allow some roundoff error before we complain
     if (std::abs(massfrac_allisotopes - elem_massfrac) > 1e-4) {
-      printlnlog("WARNING: cell {} Z={} element massfrac is less than the sum of its radioisotope massfracs", mgi,
+      printlnlog("[warning] cell {} Z={} element massfrac is less than the sum of its radioisotope massfracs", mgi,
                  atomic_number);
       printlnlog("  massfrac(Z) {:g} massfrac_radioisotopes(Z) {:g}", elem_massfrac, massfrac_allisotopes);
       printlnlog("  increasing elemental massfrac to {:g} and setting stable isotopic massfrac to zero",
@@ -635,7 +635,7 @@ void map_modeltogrid_direct() {
 void read_elem_abundances() {
   // barrier to make sure node master has set values in node shared memory
   MPI_Barrier_allranks();
-  printlog("reading abundances.txt...");
+  printlnlog("reading abundances.txt...");
   const bool threedimensional = (get_modelgridtype() == GridType::CARTESIAN3D);
 
   // Open the abundances file
@@ -706,7 +706,7 @@ void read_elem_abundances() {
 
   // barrier to make sure node master has set values in node shared memory
   MPI_Barrier_allranks();
-  printlnlog("done.");
+  printlnlog("finished reading abundances.txt");
 }
 
 void parse_model_headerline(const std::string& line, std::vector<int>& zlist, std::vector<int>& alist,
@@ -986,7 +986,7 @@ void read_grid_restart_data(const int timestep) {
                          &globals::dep_estimator_alpha[nonemptymgi], &nne_in, &nnetot_in) == 12);
 
     if (mgi_in != mgi) {
-      printlnlog("ERROR: read_grid_restart_data: cell mismatch in {}: read cellnumber {}, expected {}. aborting",
+      printlnlog("[error] read_grid_restart_data: cell mismatch in {}: read cellnumber {}, expected {}. aborting",
                  filename, mgi_in, mgi);
       assert_always(mgi_in == mgi);
     }
@@ -1099,7 +1099,7 @@ void assign_initial_temperatures() {
   printlnlog("  cells above MAXTEMP {:g} K: {}", MAXTEMP, cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
     printlnlog(
-        "WARNING: {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
+        "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
         "rho_tmin {:g} g/cm3 and decayed energy {:g} erg/g)",
         cells_nonfinite_temp, first_nonfinite_mgi, first_nonfinite_rho_tmin, first_nonfinite_endecay);
   }
@@ -1191,7 +1191,7 @@ void setup_grid_cartesian_3d() {
   // vmax is per coordinate, but the simulation volume corners will
   // have a higher expansion velocity than the sides
   const double vmax_corner = sqrt(3 * pow2(globals::vmax));
-  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
+  printlnlog("corner vmax {:g} cm/s ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
   if (!FORCE_SPHERICAL_ESCAPE_SURFACE) {
     assert_always(vmax_corner < CLIGHT);
   }
@@ -1240,7 +1240,7 @@ void setup_grid_spherical_1d() {
 
 void setup_grid_cylindrical_2d() {
   const double vmax_corner = sqrt(2 * pow2(globals::vmax));
-  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
+  printlnlog("corner vmax {:g} cm/s ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
   assert_always(vmax_corner < CLIGHT);
 
   assert_always(get_modelgridtype() == GridType::CYLINDRICAL2D);
@@ -2001,7 +2001,7 @@ void read_ejecta_model() {
       double log_rho{NAN};
       if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
         printlnlog(
-            "ERROR: model.txt cell {}: expected at least 3 values (inputcellid vel_r_max_kmps log10rho) but could "
+            "[error] model.txt cell {}: expected at least 3 values (inputcellid vel_r_max_kmps log10rho) but could "
             "not parse line: {}",
             mgi, line);
         assert_always(false);
@@ -2053,7 +2053,7 @@ void read_ejecta_model() {
     assert_always(cellnumberin == mgi + first_cellindex);
 
     if (rho_tmodel < 0) {
-      printlnlog("ERROR: model.txt cell {} (inputcellid {}) has negative density {:g} g/cm3 at t_model. aborting", mgi,
+      printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} g/cm3 at t_model. aborting", mgi,
                  cellnumberin, rho_tmodel);
       std::abort();
     }
@@ -2067,7 +2067,7 @@ void read_ejecta_model() {
   }
 
   if (mgi != get_npts_model()) {
-    printlnlog("ERROR in model.txt. Found only {} cells instead of {} expected.", mgi, get_npts_model());
+    printlnlog("[error] model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
     std::abort();
   }
 
@@ -2083,25 +2083,25 @@ void read_ejecta_model() {
       printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
     } else {
       printlnlog(
-          "WARNING: Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
+          "[warning] Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
           "order.");
     }
-    printlnlog("min_den {:g} [g/cm3]", min_den);
+    printlnlog("minimum model density {:g} g/cm3", min_den);
   }
 
   assert_always(get_npts_model() ==
                 std::max(1, ncoord_model[0]) * std::max(1, ncoord_model[1]) * std::max(1, ncoord_model[2]));
   printlnlog("npts_model: {}", get_npts_model());
   globals::rmax = globals::vmax * globals::tmin;
-  printlnlog("vmax {:g} [cm/s] ({:.2f}c)", globals::vmax, globals::vmax / CLIGHT);
+  printlnlog("vmax {:g} cm/s ({:.2f}c)", globals::vmax, globals::vmax / CLIGHT);
   assert_always(globals::vmax < CLIGHT);
-  printlnlog("tmin {:g} [s] = {:.2f} [d]", globals::tmin, globals::tmin / DAY);
-  printlnlog("rmax {:g} [cm] (at t=tmin)", globals::rmax);
+  printlnlog("tmin {:g} s = {:.2f} d", globals::tmin, globals::tmin / DAY);
+  printlnlog("rmax {:g} cm (at t=tmin)", globals::rmax);
 
   calc_modelinit_totmassnuclides();
 
-  printlnlog("Total input model mass: {:9.3e} [Msun]", mtot_input / MSUN);
-  printlnlog("Nuclide masses at t=t_model_init [Msun]:");
+  printlnlog("Total input model mass: {:9.3e} Msun", mtot_input / MSUN);
+  printlnlog("Nuclide masses at t=t_model_init in Msun:");
   printlnlog("  56Ni: {:9.3e}  56Co: {:9.3e}  52Fe: {:9.3e}  48Cr: {:9.3e}", get_totmassnuclide_tmodel(28, 56) / MSUN,
              get_totmassnuclide_tmodel(27, 56) / MSUN, get_totmassnuclide_tmodel(26, 52) / MSUN,
              get_totmassnuclide_tmodel(24, 48) / MSUN);
@@ -2116,7 +2116,7 @@ void read_ejecta_model() {
       columnliststr += std::format(" '{}'", colname);
     }
     printlnlog(
-        "WARNING: ignored model.txt columns not recognised as a known nuclide, X_Fegroup, Ye, q, or tracercount:{}",
+        "[warning] ignored model.txt columns not recognised as a known nuclide, X_Fegroup, Ye, q, or tracercount:{}",
         columnliststr);
   }
 
@@ -2127,7 +2127,6 @@ void write_grid_restart_data(const int timestep) {
   const auto filename = std::format("gridsave_ts{}.tmp", timestep);
 
   const auto sys_time_start_write_restart = std::chrono::steady_clock::now();
-  printlog("Write grid restart data to {}...", filename);
 
   FILE* gridsave_file = fopen_required(filename, "w");
 
@@ -2178,7 +2177,7 @@ void write_grid_restart_data(const int timestep) {
   fclose(gridsave_file);
   const auto write_restart_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_write_restart).count();
-  printlnlog("done in {:.1f} seconds.", write_restart_duration);
+  printlnlog("wrote grid restart data to {} in {:.1f} seconds", filename, write_restart_duration);
 }
 
 // get lowest modelgridindex assigned to this rank (for update_grid and output files)
@@ -2444,7 +2443,7 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
         if (isoutside_error) {
 #ifndef GPU_ON
           printlnlog(
-              "ERROR: timestep {}: packet outside coord {} {}{} boundary of cell {} by delta {:g}. vel {:g} initpos "
+              "[error] timestep {}: packet outside coord {} {}{} boundary of cell {} by delta {:g}. vel {:g} initpos "
               "{:g} cellcoordmin {:g} cellcoordmax {:g} dir [{:g}, {:g}, {:g}] tmin {:g} s tstart {:g} s",
               globals::timestep, d, pos_component_vel_relative_to_flow ? '+' : '-', get_coordlabel(prop_gridtype, d),
               cellindex, delta, pktvelgridcoord[d], pktposgridcoord[d], cellcoordmin[d] / globals::tmin * tstart,

--- a/grid.cc
+++ b/grid.cc
@@ -1094,8 +1094,8 @@ void assign_initial_temperatures() {
       thick_allcells[nonemptymgi] = 0;
     }
   }
-  printlog("  cells below MINTEMP {:g} [K]: {}. Above MAXTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp, MAXTEMP,
-           cells_above_maxtemp);
+  printlnlog("  cells below MINTEMP {:g} [K]: {}. Above MAXTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp, MAXTEMP,
+             cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
     printlnlog(
         "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "

--- a/grid.cc
+++ b/grid.cc
@@ -24,6 +24,7 @@
 #include <numbers>
 #include <optional>
 #include <print>
+#include <set>
 #include <span>
 #include <sstream>
 #include <string>
@@ -142,7 +143,7 @@ void set_initelectronfrac(const int modelgridindex, const float electronfrac) {
 
 void read_possible_yefile() {
   if (!std::filesystem::exists("Ye.txt")) {
-    printlnlog("Ye.txt not found");
+    printlnlog("Ye.txt not present, so no initial electron fractions will be applied from it");
     return;
   }
 
@@ -150,6 +151,8 @@ void read_possible_yefile() {
   int nlines_in = 0;
   assert_always(fscanf(filein.get(), "%d", &nlines_in) == 1);
 
+  int cells_set = 0;
+  int entries_ignored = 0;
   for (int n = 0; n < nlines_in; n++) {
     int mgiplusone = -1;
     float initelecfrac = 0.;
@@ -157,8 +160,13 @@ void read_possible_yefile() {
     const int mgi = mgiplusone - 1;
     if (mgi >= 0 && mgi < get_npts_model()) {
       set_initelectronfrac(mgi, initelecfrac);
+      cells_set++;
+    } else {
+      entries_ignored++;
     }
   }
+  printlnlog("Ye.txt: set the initial electron fraction for {} of {} model cells ({} out-of-range entries ignored)",
+             cells_set, get_npts_model(), entries_ignored);
 }
 
 [[gnu::pure]] DEVICE_FUNC auto get_propgridtype() -> GridType {
@@ -233,6 +241,9 @@ double most_negative_input_massfrac = 0.;
 int first_negative_massfrac_mgi = -1;
 int first_negative_massfrac_z = -1;  // -1 means the Fe-group mass fraction column
 int first_negative_massfrac_a = -1;
+
+// names of model.txt columns that were not recognised, reported after the model read
+std::set<std::string> ignored_model_columns;
 
 void count_negative_input_massfrac(const int modelgridindex, const int z, const int a, const double massfrac) {
   n_negative_input_massfrac++;
@@ -790,10 +801,8 @@ void read_model_radioabundances(std::istream& fmodel, std::istringstream& ssline
     } else if (colnames[i] == "tracercount") {
       ;
     } else {
-      if (mgi == 0) {
-        printlnlog("WARNING: ignoring column '{}' nucindex {} valuein[mgi=0] {:g}", colnames[i], nucindexlist[i],
-                   valuein);
-      }
+      // reported once after the model read (checking only mgi == 0 could miss it entirely if cell 0 is empty)
+      ignored_model_columns.insert(colnames[i]);
     }
   }
   double valuein = 0.;
@@ -2100,6 +2109,16 @@ void read_ejecta_model() {
              get_totmassnuclide_tmodel(28, 57) / MSUN, get_totmassnuclide_tmodel(27, 57) / MSUN);
 
   report_negative_input_massfracs();
+
+  if (!ignored_model_columns.empty()) {
+    std::string columnliststr;
+    for (const auto& colname : ignored_model_columns) {
+      columnliststr += std::format(" '{}'", colname);
+    }
+    printlnlog(
+        "WARNING: ignored model.txt columns not recognised as a known nuclide, X_Fegroup, Ye, q, or tracercount:{}",
+        columnliststr);
+  }
 
   read_possible_yefile();
 }

--- a/grid.cc
+++ b/grid.cc
@@ -1047,7 +1047,7 @@ void assign_initial_temperatures() {
   // according to the local energy density resulting from the 56Ni decay.
   // The dilution factor is W=1 in LTE.
 
-  printlnlog("Assigning initial temperatures...");
+  printlog("Assigning initial temperatures...");
 
   const double tstart = globals::timesteps[0].mid;
   int cells_below_mintemp = 0;
@@ -1094,8 +1094,8 @@ void assign_initial_temperatures() {
       thick_allcells[nonemptymgi] = 0;
     }
   }
-  printlnlog("  cells below MINTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp);
-  printlnlog("  cells above MAXTEMP {:g} [K]: {}", MAXTEMP, cells_above_maxtemp);
+  printlog("  cells below MINTEMP {:g} [K]: {}. Above MAXTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp, MAXTEMP,
+           cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
     printlnlog(
         "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "

--- a/grid.cc
+++ b/grid.cc
@@ -1491,8 +1491,8 @@ auto get_element_meanweight(const std::ptrdiff_t nonemptymgi, const int element)
 template <BoundaryType boundarytype>
 [[nodiscard]] constexpr auto is_boundary_overshoot_within_tolerance(const double pktposgridcoord,
                                                                     const double pktvelgridcoord,
-                                                                    const double boundarypos_tmin,
-                                                                    const double tstart) -> bool {
+                                                                    const double boundarypos_tmin, const double tstart)
+    -> bool {
   const double boundaryvel = boundarypos_tmin / globals::tmin;
   const double boundarypos = boundaryvel * tstart;
   const double overshoot =
@@ -1640,8 +1640,8 @@ void set_elem_massfrac(const ptrdiff_t nonemptymgi, const int element, const flo
 }
 
 // mass fraction of an element (all isotopes combined)
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_elem_numberdens(const ptrdiff_t nonemptymgi,
-                                                                 const int element) -> double {
+[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_elem_numberdens(const ptrdiff_t nonemptymgi, const int element)
+    -> double {
   return get_elem_massfrac(nonemptymgi, element) / static_cast<double>(get_element_meanweight(nonemptymgi, element)) *
          get_rho(nonemptymgi);
 }
@@ -2127,6 +2127,7 @@ void write_grid_restart_data(const int timestep) {
   const auto filename = std::format("gridsave_ts{}.tmp", timestep);
 
   const auto sys_time_start_write_restart = std::chrono::steady_clock::now();
+  printlog("Write grid restart data to {}...", filename);
 
   FILE* gridsave_file = fopen_required(filename, "w");
 
@@ -2177,7 +2178,7 @@ void write_grid_restart_data(const int timestep) {
   fclose(gridsave_file);
   const auto write_restart_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_write_restart).count();
-  printlnlog("wrote grid restart data to {} in {:.1f} seconds", filename, write_restart_duration);
+  printlnlog("done in {:.1f} seconds.", write_restart_duration);
 }
 
 // get lowest modelgridindex assigned to this rank (for update_grid and output files)

--- a/grid.cc
+++ b/grid.cc
@@ -225,10 +225,44 @@ auto get_cell_r_inner(const int cellindex, const GridType prop_gridtype) -> doub
   return NAN;
 }
 
+// Negative input mass fractions (within roundoff of zero) are counted as they are clamped during
+// the model read and summarised once at the end of read_ejecta_model() rather than being logged
+// per cell and nuclide, which could produce millions of lines for hydro-derived models.
+int n_negative_input_massfrac = 0;
+double most_negative_input_massfrac = 0.;
+int first_negative_massfrac_mgi = -1;
+int first_negative_massfrac_z = -1;  // -1 means the Fe-group mass fraction column
+int first_negative_massfrac_a = -1;
+
+void count_negative_input_massfrac(const int modelgridindex, const int z, const int a, const double massfrac) {
+  n_negative_input_massfrac++;
+  most_negative_input_massfrac = std::min(most_negative_input_massfrac, massfrac);
+  if (first_negative_massfrac_mgi < 0) {
+    first_negative_massfrac_mgi = modelgridindex;
+    first_negative_massfrac_z = z;
+    first_negative_massfrac_a = a;
+  }
+}
+
+void report_negative_input_massfracs() {
+  if (n_negative_input_massfrac > 0) {
+    const auto first_species = (first_negative_massfrac_z < 0)
+                                   ? std::string("X_Fegroup")
+                                   : std::format("Z={} A={}", first_negative_massfrac_z, first_negative_massfrac_a);
+    printlnlog(
+        "[warning] {} negative mass fraction(s) in the input model were clamped to zero (most negative {:g}; first "
+        "in cell {} for {})",
+        n_negative_input_massfrac, most_negative_input_massfrac, first_negative_massfrac_mgi, first_species);
+  }
+}
+
 void set_ffegrp(const int modelgridindex, float x) {
   if (!(x >= 0.)) {
-    printlnlog("WARNING: Fe-group mass fraction {:g} is negative in cell {}", x, modelgridindex);
+    if (!(x > -1e-6)) {
+      printlnlog("[error] Fe-group mass fraction {:g} is negative in cell {}", x, modelgridindex);
+    }
     assert_always(x > -1e-6);
+    count_negative_input_massfrac(modelgridindex, -1, -1, x);
     x = 0.;
   }
 
@@ -250,9 +284,12 @@ void set_modelinitnucmassfrac(const int modelgridindex, const int nucindex, floa
   // initnucmassfrac array is in node shared memory
   assert_always(nucindex >= 0);
   if (!(abund >= 0.)) {
-    printlnlog("WARNING: nuclear mass fraction for nucindex {} = {:g} is negative in cell {}", nucindex, abund,
-               modelgridindex);
+    if (!(abund > -1e-6)) {
+      printlnlog("[error] mass fraction {:g} for Z={} A={} is negative in cell {}", abund, decay::get_nuc_z(nucindex),
+                 decay::get_nuc_a(nucindex), modelgridindex);
+    }
     assert_always(abund > -1e-6);
+    count_negative_input_massfrac(modelgridindex, decay::get_nuc_z(nucindex), decay::get_nuc_a(nucindex), abund);
     abund = 0.;
   }
 
@@ -1648,21 +1685,7 @@ void set_nnetot(const int nonemptymgi) {
 
 void set_kappagrey(const int nonemptymgi, const float kappagrey) { kappagrey_allcells[nonemptymgi] = kappagrey; }
 
-void set_Te(const int nonemptymgi, const float Te) {
-  if (Te > 0.) {
-    // ignore the zero initialisation value for this check
-    const double nu_peak = 5.879e10 * Te;
-    if (nu_peak > NU_MAX_R || nu_peak < NU_MIN_R) {
-      const auto modelgridindex = get_mgi_of_nonemptymgi(nonemptymgi);
-      printlnlog(
-          "[warning] modelgridindex {} B_planck(Te={:g} K) peak at {:g} Hz is outside frequency range NU_MIN_R {:g} "
-          "NU_MAX_R {:g}",
-          modelgridindex, Te, nu_peak, NU_MIN_R, NU_MAX_R);
-    }
-  }
-
-  Te_allcells[nonemptymgi] = Te;
-}
+void set_Te(const int nonemptymgi, const float Te) { Te_allcells[nonemptymgi] = Te; }
 
 void set_TR(const int nonemptymgi, const float TR) { TR_allcells[nonemptymgi] = TR; }
 
@@ -1979,10 +2002,6 @@ void read_ejecta_model() {
       assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model_in);
       rho_tmodel = rho_model_in;
 
-      if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
-        printlnlog("read up to cell mgi {}", mgi);
-      }
-
       // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
       // however, the cellindex always should increment X first, then Y, then Z
       const double xmax_tmodel = globals::vmax * t_model;
@@ -2062,6 +2081,8 @@ void read_ejecta_model() {
              get_totmassnuclide_tmodel(24, 48) / MSUN);
   printlnlog("  Fe-group: {:9.3e}  57Ni: {:9.3e}  57Co: {:9.3e}", mfegroup / MSUN,
              get_totmassnuclide_tmodel(28, 57) / MSUN, get_totmassnuclide_tmodel(27, 57) / MSUN);
+
+  report_negative_input_massfracs();
 
   read_possible_yefile();
 }

--- a/grid.cc
+++ b/grid.cc
@@ -1004,10 +1004,10 @@ void read_grid_restart_data(const int timestep) {
 
     if (globals::rank_in_node == 0) {
       // node-shared arrays are written by the node master only (all ranks read identical values from the file)
-      set_TR(nonemptymgi, T_R);
-      set_Te(nonemptymgi, T_e);
-      set_W(nonemptymgi, W);
-      set_TJ(nonemptymgi, T_J);
+      TR_allcells[nonemptymgi] = T_R;
+      Te_allcells[nonemptymgi] = T_e;
+      W_allcells[nonemptymgi] = W;
+      TJ_allcells[nonemptymgi] = T_J;
       thick_allcells[nonemptymgi] = thick;
       nne_allcells[nonemptymgi] = nne_in;
       nnetot_allcells[nonemptymgi] = nnetot_in;
@@ -1090,10 +1090,10 @@ void assign_initial_temperatures() {
       // set the initial temperatures in the modelgrid
       // this is only done by the node master, so that the values are shared
       // in the node shared memory
-      set_Te(nonemptymgi, T_initial);
-      set_TJ(nonemptymgi, T_initial);
-      set_TR(nonemptymgi, T_initial);
-      set_W(nonemptymgi, 1.);
+      Te_allcells[nonemptymgi] = T_initial;
+      TJ_allcells[nonemptymgi] = T_initial;
+      TR_allcells[nonemptymgi] = T_initial;
+      W_allcells[nonemptymgi] = 1.;
       thick_allcells[nonemptymgi] = 0;
     }
   }
@@ -1648,34 +1648,6 @@ void set_elem_massfrac(const ptrdiff_t nonemptymgi, const int element, const flo
          get_rho(nonemptymgi);
 }
 
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_kappagrey(const int nonemptymgi) -> float {
-  return kappagrey_allcells[nonemptymgi];
-}
-
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_Te(const int nonemptymgi) -> float {
-  assert_testmodeonly(nonemptymgi >= 0);
-  assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return Te_allcells[nonemptymgi];
-}
-
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_TR(const int nonemptymgi) -> float {
-  assert_testmodeonly(nonemptymgi >= 0);
-  assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return TR_allcells[nonemptymgi];
-}
-
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_TJ(const int nonemptymgi) -> float {
-  assert_testmodeonly(nonemptymgi >= 0);
-  assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return TJ_allcells[nonemptymgi];
-}
-
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_W(const int nonemptymgi) -> float {
-  assert_testmodeonly(nonemptymgi >= 0);
-  assert_testmodeonly(nonemptymgi < get_nonempty_npts_model());
-  return W_allcells[nonemptymgi];
-}
-
 void set_rho(const int nonemptymgi, const float rho) {
   assert_always(rho >= 0.);
   assert_always(std::isfinite(rho));
@@ -1707,16 +1679,6 @@ void set_nnetot(const int nonemptymgi) {
   assert_always(f_nnetot >= 0.);
   nnetot_allcells[nonemptymgi] = f_nnetot;
 }
-
-void set_kappagrey(const int nonemptymgi, const float kappagrey) { kappagrey_allcells[nonemptymgi] = kappagrey; }
-
-void set_Te(const int nonemptymgi, const float Te) { Te_allcells[nonemptymgi] = Te; }
-
-void set_TR(const int nonemptymgi, const float TR) { TR_allcells[nonemptymgi] = TR; }
-
-void set_TJ(const int nonemptymgi, const float TJ) { TJ_allcells[nonemptymgi] = TJ; }
-
-void set_W(const int nonemptymgi, const float W) { W_allcells[nonemptymgi] = W; }
 
 DEVICE_FUNC auto get_modelgridtype() -> GridType {
   assert_testmodeonly(model_type.has_value());
@@ -1865,7 +1827,7 @@ void set_elements_uppermost_ion(const int nonemptymgi, const int element, const 
       // grey opacity used in Just+2022, https://ui.adsabs.harvard.edu/abs/2022MNRAS.510.2820J/abstract
       // kappa is a simple analytic function of temperature and lanthanide mass fraction
       // adapted to best fit lightcurves from Kasen+2017 in ALCAR simulations
-      const double T_rad = get_TR(nonemptymgi);
+      const double T_rad = TR_allcells[nonemptymgi];
       double X_lan = 0.;
       for (int element = 0; element < get_nelements(); element++) {
         const int z = get_atomicnumber(element);
@@ -2160,11 +2122,11 @@ void write_grid_restart_data(const int timestep) {
     const int mgi = get_mgi_of_nonemptymgi(nonemptymgi);
 
     assert_always(globals::dep_estimator_gamma[nonemptymgi] >= 0.);
-    fprintf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", mgi, get_TR(nonemptymgi), get_Te(nonemptymgi),
-            get_W(nonemptymgi), get_TJ(nonemptymgi), static_cast<int>(thick_allcells[nonemptymgi]),
-            globals::dep_estimator_gamma[nonemptymgi], globals::dep_estimator_positron[nonemptymgi],
-            globals::dep_estimator_electron[nonemptymgi], globals::dep_estimator_alpha[nonemptymgi],
-            nne_allcells[nonemptymgi], nnetot_allcells[nonemptymgi]);
+    fprintf(gridsave_file, "%d %a %a %a %a %d %la %la %la %la %a %a", mgi, TR_allcells[nonemptymgi],
+            Te_allcells[nonemptymgi], W_allcells[nonemptymgi], TJ_allcells[nonemptymgi],
+            static_cast<int>(thick_allcells[nonemptymgi]), globals::dep_estimator_gamma[nonemptymgi],
+            globals::dep_estimator_positron[nonemptymgi], globals::dep_estimator_electron[nonemptymgi],
+            globals::dep_estimator_alpha[nonemptymgi], nne_allcells[nonemptymgi], nnetot_allcells[nonemptymgi]);
 
     if constexpr (USE_LUT_PHOTOION) {
       for (int i = 0; i < globals::nbfcontinua_ground; i++) {
@@ -2332,7 +2294,7 @@ void init_grid() {
   if (globals::rank_in_node == 0) {
     printlnlog("Calculating initial grey opacities for model cells.");
     for (int nonemptymgi = 0; nonemptymgi < get_nonempty_npts_model(); nonemptymgi++) {
-      set_kappagrey(nonemptymgi, calculate_cell_kappagrey(nonemptymgi));
+      kappagrey_allcells[nonemptymgi] = calculate_cell_kappagrey(nonemptymgi);
     }
   }
 

--- a/grid.cc
+++ b/grid.cc
@@ -977,8 +977,8 @@ void read_grid_restart_data(const int timestep) {
                          &globals::dep_estimator_alpha[nonemptymgi], &nne_in, &nnetot_in) == 12);
 
     if (mgi_in != mgi) {
-      printlnlog("[fatal] read_grid_restart_data: cell mismatch in reading input gridsave.dat ... abort");
-      printlnlog("[fatal] read_grid_restart_data: read cellnumber {}, expected cellnumber {}", mgi_in, mgi);
+      printlnlog("ERROR: read_grid_restart_data: cell mismatch in {}: read cellnumber {}, expected {}. aborting",
+                 filename, mgi_in, mgi);
       assert_always(mgi_in == mgi);
     }
 
@@ -1043,6 +1043,10 @@ void assign_initial_temperatures() {
   const double tstart = globals::timesteps[0].mid;
   int cells_below_mintemp = 0;
   int cells_above_maxtemp = 0;
+  int cells_nonfinite_temp = 0;
+  int first_nonfinite_mgi = -1;
+  double first_nonfinite_rho_tmin = 0.;
+  double first_nonfinite_endecay = 0.;
 
   for (int nonemptymgi = 0; nonemptymgi < get_nonempty_npts_model(); nonemptymgi++) {
     const int mgi = get_mgi_of_nonemptymgi(nonemptymgi);
@@ -1056,9 +1060,13 @@ void assign_initial_temperatures() {
 
     if (!std::isfinite(T_initial)) {
       // check this first: a NaN would fall through every comparison below and be stored unclamped
-      printlnlog("mgi {}: T_initial of {:g} is not finite! Setting to MINTEMP.", mgi, T_initial);
+      cells_nonfinite_temp++;
+      if (first_nonfinite_mgi < 0) {
+        first_nonfinite_mgi = mgi;
+        first_nonfinite_rho_tmin = get_rho_tmin(mgi);
+        first_nonfinite_endecay = decayedenergy_per_mass;
+      }
       T_initial = MINTEMP;
-      cells_below_mintemp++;
     } else if (T_initial < MINTEMP) {
       T_initial = MINTEMP;
       cells_below_mintemp++;
@@ -1078,8 +1086,14 @@ void assign_initial_temperatures() {
       thick_allcells[nonemptymgi] = 0;
     }
   }
-  printlnlog("  cells below MINTEMP {:g}: {}", MINTEMP, cells_below_mintemp);
-  printlnlog("  cells above MAXTEMP {:g}: {}", MAXTEMP, cells_above_maxtemp);
+  printlnlog("  cells below MINTEMP {:g} K: {}", MINTEMP, cells_below_mintemp);
+  printlnlog("  cells above MAXTEMP {:g} K: {}", MAXTEMP, cells_above_maxtemp);
+  if (cells_nonfinite_temp > 0) {
+    printlnlog(
+        "WARNING: {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
+        "rho_tmin {:g} g/cm3 and decayed energy {:g} erg/g)",
+        cells_nonfinite_temp, first_nonfinite_mgi, first_nonfinite_rho_tmin, first_nonfinite_endecay);
+  }
   MPI_Barrier_allranks();
 }
 
@@ -1977,8 +1991,10 @@ void read_ejecta_model() {
       double vout_kmps{NAN};
       double log_rho{NAN};
       if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
-        printlnlog("Unexpected number of values in model.txt");
-        printlnlog("line: {}", line);
+        printlnlog(
+            "ERROR: model.txt cell {}: expected at least 3 values (inputcellid vel_r_max_kmps log10rho) but could "
+            "not parse line: {}",
+            mgi, line);
         assert_always(false);
       }
       vout_model[mgi] = vout_kmps * 1.e5;
@@ -2028,7 +2044,8 @@ void read_ejecta_model() {
     assert_always(cellnumberin == mgi + first_cellindex);
 
     if (rho_tmodel < 0) {
-      printlnlog("negative input density {:g} {}", rho_tmodel, mgi);
+      printlnlog("ERROR: model.txt cell {} (inputcellid {}) has negative density {:g} g/cm3 at t_model. aborting", mgi,
+                 cellnumberin, rho_tmodel);
       std::abort();
     }
 
@@ -2408,15 +2425,11 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
         if (isoutside_error) {
 #ifndef GPU_ON
           printlnlog(
-              "[ERROR] packet outside coord {} {}{} boundary of cell {}. vel {:g} initpos {:g} "
-              "cellcoordmin {:g}, cellcoordmax {:g}",
-              d, pos_component_vel_relative_to_flow ? '+' : '-', get_coordlabel(prop_gridtype, d), cellindex,
-              pktvelgridcoord[d], pktposgridcoord[d], cellcoordmin[d] / globals::tmin * tstart,
-              cellcoordmax[d] / globals::tmin * tstart);
-          printlnlog("globals::tmin {:g} tstart {:g} tstart/globals::tmin {:g}", globals::tmin, tstart,
-                     tstart / globals::tmin);
-          printlnlog(" delta {:g}", delta);
-          printlnlog("packet dir [{:g}, {:g}, {:g}]", dir[0], dir[1], dir[2]);
+              "ERROR: timestep {}: packet outside coord {} {}{} boundary of cell {} by delta {:g}. vel {:g} initpos "
+              "{:g} cellcoordmin {:g} cellcoordmax {:g} dir [{:g}, {:g}, {:g}] tmin {:g} s tstart {:g} s",
+              globals::timestep, d, pos_component_vel_relative_to_flow ? '+' : '-', get_coordlabel(prop_gridtype, d),
+              cellindex, delta, pktvelgridcoord[d], pktposgridcoord[d], cellcoordmin[d] / globals::tmin * tstart,
+              cellcoordmax[d] / globals::tmin * tstart, dir[0], dir[1], dir[2], globals::tmin, tstart);
 #endif
 
           // this should not happen! Leave the check until late 2026 and if it never triggers on any runs, we can remove
@@ -2427,7 +2440,7 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
           if ((cellcoordidx[d] == (ncoordgrid[d] - 1) && pos_component_vel_relative_to_flow) ||
               (cellcoordidx[d] == 0 && !pos_component_vel_relative_to_flow) || (next_cellindex < 0)) {
 #ifndef GPU_ON
-            printlnlog("[warning] escaping packet");
+            printlnlog("[warning] treating out-of-boundary packet in cell {} as escaping the grid", cellindex);
 #endif
             return {0., -99};
           }

--- a/grid.cc
+++ b/grid.cc
@@ -257,13 +257,15 @@ void count_negative_input_massfrac(const int modelgridindex, const int z, const 
 
 void report_negative_input_massfracs() {
   if (n_negative_input_massfrac > 0) {
-    const auto first_species = (first_negative_massfrac_z < 0)
-                                   ? std::string("X_Fegroup")
-                                   : std::format("Z={} A={}", first_negative_massfrac_z, first_negative_massfrac_a);
-    printlnlog(
+    printlog(
         "[warning] {} negative mass fraction(s) in the input model were clamped to zero (most negative {:g}; first "
-        "in cell {} for {})",
-        n_negative_input_massfrac, most_negative_input_massfrac, first_negative_massfrac_mgi, first_species);
+        "in cell {} for ",
+        n_negative_input_massfrac, most_negative_input_massfrac, first_negative_massfrac_mgi);
+    if (first_negative_massfrac_z < 0) {
+      printlnlog("X_Fegroup)");
+    } else {
+      printlnlog("Z={} A={})", first_negative_massfrac_z, first_negative_massfrac_a);
+    }
   }
 }
 
@@ -2115,13 +2117,12 @@ void read_ejecta_model() {
   report_negative_input_massfracs();
 
   if (!ignored_model_columns.empty()) {
-    std::string columnliststr;
+    printlog(
+        "[warning] ignored model.txt columns not recognised as a known nuclide, X_Fegroup, Ye, q, or tracercount:");
     for (const auto& colname : ignored_model_columns) {
-      columnliststr += std::format(" '{}'", colname);
+      printlog(" '{}'", colname);
     }
-    printlnlog(
-        "[warning] ignored model.txt columns not recognised as a known nuclide, X_Fegroup, Ye, q, or tracercount:{}",
-        columnliststr);
+    printlnlog("");
   }
 
   read_possible_yefile();

--- a/grid.cc
+++ b/grid.cc
@@ -176,8 +176,7 @@ void read_possible_yefile() {
   return get_modelgridtype();
 }
 
-// how much do we change the cellindex to move along a coordinately axis (e.g., the x, y, z directions, or r
-// direction)
+// how much do we change the cellindex to move along a coordinately axis (e.g., the x, y, z directions, or r direction)
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_coordcellindexstride(const int axis) -> int {
   int stride = 1;
   for (int a = 0; a < axis; ++a) {
@@ -588,8 +587,7 @@ void map_1dmodelto3dgrid() {
       assert_always(vout_model[mgi] >= cellvmid);
       assert_always((mgi > 0 ? vout_model[mgi - 1] : 0.0) <= cellvmid);
     } else {
-      // corner cells outside of the outermost model shell are empty
-      // and so are any shells with zero density
+      // corner cells outside of the outermost model shell are empty and so are any shells with zero density
       set_propcell_modelgridindex(cellindex, -1);
     }
   }
@@ -1088,8 +1086,7 @@ void assign_initial_temperatures() {
 
     if (globals::rank_in_node == 0) {
       // set the initial temperatures in the modelgrid
-      // this is only done by the node master, so that the values are shared
-      // in the node shared memory
+      // this is only done by the node master, so that the values are shared in the node shared memory
       Te_allcells[nonemptymgi] = T_initial;
       TJ_allcells[nonemptymgi] = T_initial;
       TR_allcells[nonemptymgi] = T_initial;
@@ -1190,8 +1187,7 @@ void setup_nstart_ndo() {
 
 // set up a uniform cuboidal grid.
 void setup_grid_cartesian_3d() {
-  // vmax is per coordinate, but the simulation volume corners will
-  // have a higher expansion velocity than the sides
+  // vmax is per coordinate, but the simulation volume corners will have a higher expansion velocity than the sides
   const double vmax_corner = sqrt(3 * pow2(globals::vmax));
   printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
   if (!FORCE_SPHERICAL_ESCAPE_SURFACE) {
@@ -2554,8 +2550,7 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
 
   } else if (prop_gridtype == GridType::CARTESIAN3D) {
     // There are six possible boundary crossings. Each of the three
-    // cartesian coordinates may be taken in turn. For x, the packet
-    // trajectory is
+    // cartesian coordinates may be taken in turn. For x, the packet trajectory is
     // x = x0 + (dir.x) * c * (t - tstart)
     // the boundaries follow
     // x+/- = x+/-(tmin) * (t/tmin)
@@ -2563,8 +2558,7 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
     // t - tstart = (x0 - x+/-(tmin)/tmin * tstart) / (x+/-(tmin)/tmin - (dir.x)*c)
     // distance = c * (t - tstart)
 
-    // Modified so that it also returns the distance to the closest cell
-    // boundary, regardless of direction.
+    // Modified so that it also returns the distance to the closest cell boundary, regardless of direction.
 
     for (int d = 0; d < 3; d++) {
       if (pktvelgridcoord[d] > (cellcoordmax[d] / globals::tmin)) {

--- a/grid.cc
+++ b/grid.cc
@@ -864,7 +864,7 @@ auto read_model_columns(std::istream& fmodel) -> std::tuple<std::vector<std::str
   fmodel.seekg(pos_data_start);  // get back to start of data
 
   if (header_specified) {
-    printlnlog("model.txt has header line: {}", headerline);
+    printlnlog("model.txt has a header line.");
   } else {
     printlnlog("model.txt has no header line. Using default: {}", headerline);
   }

--- a/grid.cc
+++ b/grid.cc
@@ -496,7 +496,7 @@ void allocate_nonemptymodelcells() {
   const auto modelgrid_mem_usage =
       nonempty_npts_model * ((sizeof(float) * (USE_MICROCLUMPING ? 10 : 9)) + sizeof(double) + sizeof(int));
   printlnlog(
-      "[info] mem_usage: the modelgrid properties (temperatures and electron densities) occupies {:.3f} MB (node "
+      "[info] mem_usage: the modelgrid properties (temperatures and electron densities) occupies {:.3f} [MB] (node "
       "shared memory)",
       modelgrid_mem_usage / 1024. / 1024.);
 
@@ -571,7 +571,7 @@ void allocate_nonemptymodelcells() {
   MPI_Barrier_allranks();
 
   printlnlog(
-      "[info] mem_usage: NLTE populations for all allocated cells occupy a total of {:.3f} MB (node shared memory)",
+      "[info] mem_usage: NLTE populations for all allocated cells occupy a total of {:.3f} [MB] (node shared memory)",
       static_cast<ptrdiff_t>(get_nonempty_npts_model()) * globals::total_nlte_levels * sizeof(double) / 1024. / 1024.);
 }
 
@@ -884,7 +884,7 @@ auto read_model_columns(std::istream& fmodel) -> std::tuple<std::vector<std::str
 
   initnucmassfrac_allcells = MPI_shared_array<float>((npts_model + 1) * num_nuclides, 0.);
   printlnlog(
-      "[info] mem_usage: input abundance data for {} nuclides for {} cells occupies {:.3f} MB (node shared memory)",
+      "[info] mem_usage: input abundance data for {} nuclides for {} cells occupies {:.3f} [MB] (node shared memory)",
       num_nuclides, npts_model, (initnucmassfrac_allcells.size() * sizeof(float)) / 1024. / 1024.);
 
   return {colnames, nucindexlist, one_line_per_cell};
@@ -1095,12 +1095,12 @@ void assign_initial_temperatures() {
       thick_allcells[nonemptymgi] = 0;
     }
   }
-  printlnlog("  cells below MINTEMP {:g} K: {}", MINTEMP, cells_below_mintemp);
-  printlnlog("  cells above MAXTEMP {:g} K: {}", MAXTEMP, cells_above_maxtemp);
+  printlnlog("  cells below MINTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp);
+  printlnlog("  cells above MAXTEMP {:g} [K]: {}", MAXTEMP, cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
     printlnlog(
         "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
-        "rho_tmin {:g} g/cm3 and decayed energy {:g} erg/g)",
+        "rho_tmin {:g} [g/cm3] and decayed energy {:g} [erg/g])",
         cells_nonfinite_temp, first_nonfinite_mgi, first_nonfinite_rho_tmin, first_nonfinite_endecay);
   }
   MPI_Barrier_allranks();
@@ -1191,7 +1191,7 @@ void setup_grid_cartesian_3d() {
   // vmax is per coordinate, but the simulation volume corners will
   // have a higher expansion velocity than the sides
   const double vmax_corner = sqrt(3 * pow2(globals::vmax));
-  printlnlog("corner vmax {:g} cm/s ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
+  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
   if (!FORCE_SPHERICAL_ESCAPE_SURFACE) {
     assert_always(vmax_corner < CLIGHT);
   }
@@ -1240,7 +1240,7 @@ void setup_grid_spherical_1d() {
 
 void setup_grid_cylindrical_2d() {
   const double vmax_corner = sqrt(2 * pow2(globals::vmax));
-  printlnlog("corner vmax {:g} cm/s ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
+  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
   assert_always(vmax_corner < CLIGHT);
 
   assert_always(get_modelgridtype() == GridType::CYLINDRICAL2D);
@@ -2027,6 +2027,10 @@ void read_ejecta_model() {
       assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model_in);
       rho_tmodel = rho_model_in;
 
+      if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
+        printlnlog("read up to cell mgi {}", mgi);
+      }
+
       // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
       // however, the cellindex always should increment X first, then Y, then Z
       const double xmax_tmodel = globals::vmax * t_model;
@@ -2053,8 +2057,8 @@ void read_ejecta_model() {
     assert_always(cellnumberin == mgi + first_cellindex);
 
     if (rho_tmodel < 0) {
-      printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} g/cm3 at t_model. aborting", mgi,
-                 cellnumberin, rho_tmodel);
+      printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model. aborting",
+                 mgi, cellnumberin, rho_tmodel);
       std::abort();
     }
 
@@ -2086,22 +2090,22 @@ void read_ejecta_model() {
           "[warning] Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
           "order.");
     }
-    printlnlog("minimum model density {:g} g/cm3", min_den);
+    printlnlog("minimum model density {:g} [g/cm3]", min_den);
   }
 
   assert_always(get_npts_model() ==
                 std::max(1, ncoord_model[0]) * std::max(1, ncoord_model[1]) * std::max(1, ncoord_model[2]));
   printlnlog("npts_model: {}", get_npts_model());
   globals::rmax = globals::vmax * globals::tmin;
-  printlnlog("vmax {:g} cm/s ({:.2f}c)", globals::vmax, globals::vmax / CLIGHT);
+  printlnlog("vmax {:g} [cm/s] ({:.2f}c)", globals::vmax, globals::vmax / CLIGHT);
   assert_always(globals::vmax < CLIGHT);
-  printlnlog("tmin {:g} s = {:.2f} d", globals::tmin, globals::tmin / DAY);
-  printlnlog("rmax {:g} cm (at t=tmin)", globals::rmax);
+  printlnlog("tmin {:g} [s] = {:.2f} [d]", globals::tmin, globals::tmin / DAY);
+  printlnlog("rmax {:g} [cm] (at t=tmin)", globals::rmax);
 
   calc_modelinit_totmassnuclides();
 
-  printlnlog("Total input model mass: {:9.3e} Msun", mtot_input / MSUN);
-  printlnlog("Nuclide masses at t=t_model_init in Msun:");
+  printlnlog("Total input model mass: {:9.3e} [Msun]", mtot_input / MSUN);
+  printlnlog("Nuclide masses at t=t_model_init [Msun]:");
   printlnlog("  56Ni: {:9.3e}  56Co: {:9.3e}  52Fe: {:9.3e}  48Cr: {:9.3e}", get_totmassnuclide_tmodel(28, 56) / MSUN,
              get_totmassnuclide_tmodel(27, 56) / MSUN, get_totmassnuclide_tmodel(26, 52) / MSUN,
              get_totmassnuclide_tmodel(24, 48) / MSUN);

--- a/grid.cc
+++ b/grid.cc
@@ -892,7 +892,7 @@ void calc_modelinit_totmassnuclides() {
 void read_grid_restart_data(const int timestep) {
   const auto filename = std::format("gridsave_ts{}.tmp", timestep);
 
-  printlnlog("READIN GRID SNAPSHOT from {}", filename);
+  printlnlog("reading grid restart snapshot from {}", filename);
   FILE* gridsave_file = fopen_required(filename, "r");
 
   int ntimesteps_in = -1;
@@ -1431,8 +1431,8 @@ auto get_element_meanweight(const std::ptrdiff_t nonemptymgi, const int element)
 template <BoundaryType boundarytype>
 [[nodiscard]] constexpr auto is_boundary_overshoot_within_tolerance(const double pktposgridcoord,
                                                                     const double pktvelgridcoord,
-                                                                    const double boundarypos_tmin, const double tstart)
-    -> bool {
+                                                                    const double boundarypos_tmin,
+                                                                    const double tstart) -> bool {
   const double boundaryvel = boundarypos_tmin / globals::tmin;
   const double boundarypos = boundaryvel * tstart;
   const double overshoot =
@@ -1580,8 +1580,8 @@ void set_elem_massfrac(const ptrdiff_t nonemptymgi, const int element, const flo
 }
 
 // mass fraction of an element (all isotopes combined)
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_elem_numberdens(const ptrdiff_t nonemptymgi, const int element)
-    -> double {
+[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_elem_numberdens(const ptrdiff_t nonemptymgi,
+                                                                 const int element) -> double {
   return get_elem_massfrac(nonemptymgi, element) / static_cast<double>(get_element_meanweight(nonemptymgi, element)) *
          get_rho(nonemptymgi);
 }

--- a/grid.cc
+++ b/grid.cc
@@ -498,7 +498,7 @@ void allocate_nonemptymodelcells() {
   const auto modelgrid_mem_usage =
       nonempty_npts_model * ((sizeof(float) * (USE_MICROCLUMPING ? 10 : 9)) + sizeof(double) + sizeof(int));
   printlnlog(
-      "[info] mem_usage: the modelgrid properties (temperatures and electron densities) occupies {:.3f} [MB] (node "
+      "[info] mem_usage: the modelgrid properties (temperatures and electron densities) occupies {:.3f} MB (node "
       "shared memory)",
       modelgrid_mem_usage / 1024. / 1024.);
 
@@ -573,7 +573,7 @@ void allocate_nonemptymodelcells() {
   MPI_Barrier_allranks();
 
   printlnlog(
-      "[info] mem_usage: NLTE populations for all allocated cells occupy a total of {:.3f} [MB] (node shared memory)",
+      "[info] mem_usage: NLTE populations for all allocated cells occupy a total of {:.3f} MB (node shared memory)",
       static_cast<ptrdiff_t>(get_nonempty_npts_model()) * globals::total_nlte_levels * sizeof(double) / 1024. / 1024.);
 }
 
@@ -886,7 +886,7 @@ auto read_model_columns(std::istream& fmodel) -> std::tuple<std::vector<std::str
 
   initnucmassfrac_allcells = MPI_shared_array<float>((npts_model + 1) * num_nuclides, 0.);
   printlnlog(
-      "[info] mem_usage: input abundance data for {} nuclides for {} cells occupies {:.3f} [MB] (node shared memory)",
+      "[info] mem_usage: input abundance data for {} nuclides for {} cells occupies {:.3f} MB (node shared memory)",
       num_nuclides, npts_model, (initnucmassfrac_allcells.size() * sizeof(float)) / 1024. / 1024.);
 
   return {colnames, nucindexlist, one_line_per_cell};

--- a/grid.h
+++ b/grid.h
@@ -55,19 +55,9 @@ void set_elements_uppermost_ion(int nonemptymgi, int element, int uppermost_ion)
 void set_elem_massfrac(std::ptrdiff_t nonemptymgi, int element, float newmassfrac);
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_elem_numberdens(std::ptrdiff_t nonemptymgi, int element) -> double;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_initenergyq(int modelgridindex) -> double;
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_kappagrey(int nonemptymgi) -> float;
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_Te(int nonemptymgi) -> float;
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_TR(int nonemptymgi) -> float;
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_TJ(int nonemptymgi) -> float;
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_W(int nonemptymgi) -> float;
 void set_nne(int nonemptymgi, float nne);
 void set_nnetot(int nonemptymgi);
-void set_kappagrey(int nonemptymgi, float kappagrey);
 void set_rho(int nonemptymgi, float rho);
-void set_Te(int nonemptymgi, float Te);
-void set_TR(int nonemptymgi, float TR);
-void set_TJ(int nonemptymgi, float TJ);
-void set_W(int nonemptymgi, float W);
 void init_grid();
 [[gnu::pure]] [[nodiscard]] auto get_modelinitnucmassfrac(int modelgridindex, int nucindex) -> float;
 [[gnu::pure]] [[nodiscard]] auto get_elem_untrackedstable_initmassfrac(std::ptrdiff_t nonemptymgi, int element)

--- a/input.cc
+++ b/input.cc
@@ -1340,9 +1340,6 @@ void sort_temp_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
              std::tie(b.elementindex, b.ionindex, b.lowerlevelindex, b.upperlevelindex, b.einstein_A);
     });
 
-    int duplicate_count = 0;
-    int duplicate_exact_nu_count = 0;
-    constexpr int max_duplicates_shown = 10;
     for (int i = 0; i < globals::nlines - 1; i++) {
       const double nu = temp_linelist[i].nu;
       const double nu_next = temp_linelist[i + 1].nu;
@@ -1352,26 +1349,15 @@ void sort_temp_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
 
         if ((a1.elementindex == a2.elementindex) && (a1.ionindex == a2.ionindex) &&
             (a1.lowerlevelindex == a2.lowerlevelindex) && (a1.upperlevelindex == a2.upperlevelindex)) {
-          duplicate_count++;
-          if (a1.nu == a2.nu) {
-            duplicate_exact_nu_count++;
-          }
-          if (duplicate_count <= max_duplicates_shown) {
-            printlnlog(
-                "[warning] duplicate bb-transition Z={} ionstage {} levels {} to {}: nu {:g} [Hz] and {:g} [Hz] "
-                "(lambda "
-                "{:.2f} [Angstrom])",
-                get_atomicnumber(a1.elementindex), get_ionstage(a1.elementindex, a1.ionindex), a1.lowerlevelindex,
-                a1.upperlevelindex, a1.nu, a2.nu, 1e8 * CLIGHT / a1.nu);
-          }
+          printlnlog("Duplicate transition line? {}", a1.nu == a2.nu ? "nu match exact" : "close to nu match");
+          printlnlog("a: Z={} ionstage {} lower {} upper {} nu {:g} [Hz] lambda {:g} [Angstrom]",
+                     get_atomicnumber(a1.elementindex), get_ionstage(a1.elementindex, a1.ionindex), a1.lowerlevelindex,
+                     a1.upperlevelindex, a1.nu, 1e8 * CLIGHT / a1.nu);
+          printlnlog("b: Z={} ionstage {} lower {} upper {} nu {:g} [Hz] lambda {:g} [Angstrom]",
+                     get_atomicnumber(a2.elementindex), get_ionstage(a2.elementindex, a2.ionindex), a2.lowerlevelindex,
+                     a2.upperlevelindex, a2.nu, 1e8 * CLIGHT / a2.nu);
         }
       }
-    }
-    if (duplicate_count > 0) {
-      printlnlog(
-          "[warning] found {} duplicate bb-transitions in the linelist ({} with exactly matching nu; first {} "
-          "listed above)",
-          duplicate_count, duplicate_exact_nu_count, std::min(duplicate_count, max_duplicates_shown));
     }
   }
 }

--- a/input.cc
+++ b/input.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -173,8 +174,10 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
         probability_sum += phixstargetprobability;
       }
       if (fabs(probability_sum - 1.0) > 0.01) {
-        printlog("ERROR: photoionisation table for Z={} ionstage {} has probabilities that sum to {:g}",
-                 get_atomicnumber(element), get_ionstage(element, lowerion), probability_sum);
+        printlnlog(
+            "ERROR: photoionisation table for Z={} ionstage {} level {} has target probabilities that sum to "
+            "{:g} (expected 1.0 +/- 0.01)",
+            get_atomicnumber(element), get_ionstage(element, lowerion), lowerlevel, probability_sum);
         assert_always(false);
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
@@ -1939,11 +1942,16 @@ void update_parameterfile(const int nts) {
   fileout.close();
   file.close();
 
+  std::error_code rename_error;
   if (nts < 0) {
-    std::rename("input.txt.tmp", "input-newrun.txt");  // back up the original for starting a new simulation
+    // back up the original for starting a new simulation
+    std::filesystem::rename("input.txt.tmp", "input-newrun.txt", rename_error);
   } else {
-    std::remove("input.txt");
-    std::rename("input.txt.tmp", "input.txt");
+    std::filesystem::rename("input.txt.tmp", "input.txt", rename_error);
+  }
+  if (rename_error) {
+    printlnlog("ERROR: failed to move input.txt.tmp to {}: {}", (nts < 0) ? "input-newrun.txt" : "input.txt",
+               rename_error.message());
   }
 
   printlnlog("done");

--- a/input.cc
+++ b/input.cc
@@ -175,7 +175,7 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
       }
       if (fabs(probability_sum - 1.0) > 0.01) {
         printlnlog(
-            "ERROR: photoionisation table for Z={} ionstage {} level {} has target probabilities that sum to "
+            "[error] photoionisation table for Z={} ionstage {} level {} has target probabilities that sum to "
             "{:g} (expected 1.0 +/- 0.01)",
             get_atomicnumber(element), get_ionstage(element, lowerion), lowerlevel, probability_sum);
         assert_always(false);
@@ -712,7 +712,7 @@ auto search_groundphixslist(const double nu_edge, const int element_in, const in
     }
 
     printlnlog(
-        "ERROR: search_groundphixslist: element {}, ion {}, level {} has edge_frequency {:g} equal to the bluest "
+        "[error] search_groundphixslist: element {}, ion {}, level {} has edge_frequency {:g} equal to the bluest "
         "ground-level continuum",
         element_in, ion_in, level_in, nu_edge);
     printlnlog("  search_groundphixslist: bluest ground level continuum is element {}, ion {} at nu_edge {:g}", element,
@@ -742,8 +742,8 @@ auto search_groundphixslist(const double nu_edge, const int element_in, const in
 // set up the photoionisation transition lists
 // and temporary gamma/kappa lists for each thread
 void setup_phixs_list() {
-  printlnlog("[info] read_atomicdata: number of bfcontinua {}", globals::nbfcontinua);
-  printlnlog("[info] read_atomicdata: number of ground-level bfcontinua {}", globals::nbfcontinua_ground);
+  printlnlog("[info] setup_phixs_list: number of bfcontinua {}", globals::nbfcontinua);
+  printlnlog("[info] setup_phixs_list: number of ground-level bfcontinua {}", globals::nbfcontinua_ground);
 
   struct TempGroundPhotoion {
     double nu_edge;
@@ -1140,7 +1140,7 @@ void read_phixs_data() {
           const int phixstargetlevels = get_phixsupperlevel(element, ion - 1, 0, nphixstargets - 1) + 1;
 
           if (nlevels_groundterm != phixstargetlevels) {
-            printlnlog("WARNING: Z={} ionstage {} nlevels_groundterm {} phixstargetlevels(ion-1) {}.",
+            printlnlog("[warning] Z={} ionstage {} nlevels_groundterm {} phixstargetlevels(ion-1) {}.",
                        get_atomicnumber(element), get_ionstage(element, ion), nlevels_groundterm, phixstargetlevels);
           }
         }
@@ -1258,7 +1258,7 @@ void read_levels_and_transitions(std::vector<TempEnergyLevel>& temp_alllevels,
       const int nlevelskept = (nlevelslimit < 0) ? nlevels_in_file : std::min(nlevelslimit, nlevels_in_file);
 
       if (nlevels_in_file > nlevelskept) {
-        printlnlog("[info] read_atomicdata: reduce number of levels from {} to {} for Z {:2} ionstage {}",
+        printlnlog("[info] read_levels_and_transitions: reduce number of levels from {} to {} for Z {:2} ionstage {}",
                    nlevels_in_file, nlevelskept, adata_Z_in, adata_ionstage_in);
       }
       assert_always(nlevelskept > 0);
@@ -1519,7 +1519,8 @@ void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
   const auto establish_linelist_connections_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - time_start_establish_linelist_connections)
           .count();
-  printlnlog("  took {:.1f}s", establish_linelist_connections_duration);
+  printlnlog("established connections between transitions and sorted linelist (took {:.1f} seconds)",
+             establish_linelist_connections_duration);
   MPI_Barrier_node();
 }
 
@@ -1740,7 +1741,7 @@ void read_parameterfile(std::span<Packet> packets) {
   } else {
 #if defined REPRODUCIBLE && REPRODUCIBLE
     printlnlog(
-        "ERROR: REPRODUCIBLE mode requires a positive random number seed on the first non-comment line of input.txt "
+        "[error] REPRODUCIBLE mode requires a positive random number seed on the first non-comment line of input.txt "
         "(found {})",
         pre_zseed);
     std::abort();
@@ -1897,11 +1898,6 @@ void read_parameterfile(std::span<Packet> packets) {
 // write out an updated input.txt to restart the simulation
 void update_parameterfile(const int nts) {
   assert_always(globals::my_rank == 0);
-  if (nts >= 0) {
-    printlog("Update input.txt for restart at timestep {}...", nts);
-  } else {
-    printlog("Copying input.txt to input-newrun.txt...");
-  }
 
   auto file = fstream_required("input.txt", std::ios::in);
 
@@ -1967,11 +1963,15 @@ void update_parameterfile(const int nts) {
     std::filesystem::rename("input.txt.tmp", "input.txt", rename_error);
   }
   if (rename_error) {
-    printlnlog("ERROR: failed to move input.txt.tmp to {}: {}", (nts < 0) ? "input-newrun.txt" : "input.txt",
+    printlnlog("[error] failed to move input.txt.tmp to {}: {}", (nts < 0) ? "input-newrun.txt" : "input.txt",
                rename_error.message());
   }
 
-  printlnlog("done");
+  if (nts >= 0) {
+    printlnlog("updated input.txt for restart at timestep {}", nts);
+  } else {
+    printlnlog("copied input.txt to input-newrun.txt");
+  }
 }
 
 void read_atomicdata() {

--- a/input.cc
+++ b/input.cc
@@ -379,7 +379,7 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
     }
   }
 
-  printlnlog("[info] mem_usage: photoionisation tables occupy {:.3f} [MB]", mem_usage_phixs / 1024. / 1024.);
+  printlnlog("[info] mem_usage: photoionisation tables occupy {:.3f} MB", mem_usage_phixs / 1024. / 1024.);
 }
 
 constexpr auto downtranslevelstart(const int level) {
@@ -797,7 +797,7 @@ void setup_phixs_list() {
   globals::groundcont_ion = std::move(groundcont_ion);
 
   auto allcont = MPI_shared_array<TempPhotoionTransitionInput>(globals::nbfcontinua);
-  printlnlog("[info] mem_usage: photoionisation list occupies {:.3f} [MB]",
+  printlnlog("[info] mem_usage: photoionisation list occupies {:.3f} MB",
              globals::nbfcontinua * (sizeof(TempPhotoionTransitionInput)) / 1024. / 1024.);
   const auto groundcontindices = std::ranges::iota_view{0, globals::nbfcontinua_ground};
   int allcontindex = 0;
@@ -1416,7 +1416,7 @@ void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
     printlnlog("total downtrans {}", downtranscount);
     return downtranscount + uptranscount;
   }();
-  printlnlog("[info] mem_usage: transition lists occupy {:.3f} [MB] (node shared memory)",
+  printlnlog("[info] mem_usage: transition lists occupy {:.3f} MB (node shared memory)",
              updowntranscount * ((2 * sizeof(int)) + (3 * sizeof(float)) + sizeof(bool)) / 1024. / 1024.);
 
   MPI_Barrier_node();
@@ -1566,7 +1566,7 @@ void create_shared_linelist(std::vector<TempLineTransitionInput>& temp_linelist)
        ) /
       1024. / 1024;
 
-  printlnlog("[info] mem_usage: linelist occupies {:.3f} [MB] (node shared memory)", linelist_mem_MB);
+  printlnlog("[info] mem_usage: linelist occupies {:.3f} MB (node shared memory)", linelist_mem_MB);
 }
 
 // read the full atomic dataset: the composition (compositiondata.txt), then the levels and

--- a/input.cc
+++ b/input.cc
@@ -1,6 +1,5 @@
 // Reading of the main input files: the atomic dataset (adata.txt, compositiondata.txt,
-// transitiondata.txt, phixsdata_v2.txt) and the run parameters (input.txt), plus the setup of
-// the simulation timesteps.
+// transitiondata.txt, phixsdata_v2.txt) and the run parameters (input.txt), plus the setup of the simulation timesteps.
 
 #include "input.h"
 
@@ -254,10 +253,8 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
     }
   }
 
-  // The level contributes to the ionisinglevels if its energy
-  // is below the ionisation potential and the level doesn't
-  // belong to the topmost ion included.
-  // Rate coefficients are only available for ionising levels.
+  // The level contributes to the ionisinglevels if its energy is below the ionisation potential and the level doesn't
+  // belong to the topmost ion included. Rate coefficients are only available for ionising levels.
   //  also need (levelenergy < ionpot && ...)?
   if (lowerion < get_nions(element) - 1) {
     for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
@@ -370,8 +367,7 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
         if (phixs_file_version == 1) {
           assert_always(get_noncommentline(phixsfile, phixsline));
         } else {
-          // one day we might want to put all of the cross section points onto a single line,
-          // so don't use getline here
+          // one day we might want to put all of the cross section points onto a single line, so don't use getline here
           float phixs = 0;
           assert_always(phixsfile >> phixs);
         }
@@ -416,8 +412,7 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
       });
 
       // The level contributes to the ionisinglevels if its energy
-      // is below the ionisation potential and the level doesn't
-      // belong to the topmost ion included.
+      // is below the ionisation potential and the level doesn't belong to the topmost ion included.
       // Rate coefficients are only available for ionising levels.
       if (levelenergy_ev < ionpot_ev && ion < nions - 1) {
         globals::elements[element].ions[ion].nlevels_ionising++;
@@ -546,8 +541,7 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
         continue;
       }
 
-      // Make sure that we don't allow duplicate. In that case take only the lines
-      // first occurrence
+      // Make sure that we don't allow duplicate. In that case take only the lines first occurrence
       int& downtranslineindex = iondowntranstmplineindices[downtranslevelstart(level) + lowerlevel];
 
       // negative means that the transition hasn't been seen yet
@@ -578,8 +572,7 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
               .lowerlevelindex = lowerlevel,
           });
 
-          // (each transition's index into the frequency-sorted linelist is set later by
-          // create_shared_alltranslist)
+          // (each transition's index into the frequency-sorted linelist is set later by create_shared_alltranslist)
 
           temp_alltranslist[ion_levels[level].alltrans_startdown + nupperdowntrans - 1] = {
               .targetlevelindex = lowerlevel,
@@ -718,9 +711,7 @@ auto search_groundphixslist(const double nu_edge, const int element_in, const in
     printlnlog("  search_groundphixslist: bluest ground level continuum is element {}, ion {} at nu_edge {:g}", element,
                ion, globals::groundcont_nu_edge[i - 1]);
     printlnlog("  search_groundphixslist: i {}, nbfcontinua_ground {}", i, globals::nbfcontinua_ground);
-    printlnlog(
-        "  This shouldn't happen, but is possible if there are multiple levels in the adata file at "
-        "energy=0");
+    printlnlog("  This shouldn't happen, but is possible if there are multiple levels in the adata file at energy=0");
     const int nlevels_in = get_nlevels(element_in, ion_in);
     constexpr int maxshownlevels = 10;
     for (int looplevels = 0; looplevels < std::min(nlevels_in, maxshownlevels); looplevels++) {

--- a/input.cc
+++ b/input.cc
@@ -1898,6 +1898,11 @@ void read_parameterfile(std::span<Packet> packets) {
 // write out an updated input.txt to restart the simulation
 void update_parameterfile(const int nts) {
   assert_always(globals::my_rank == 0);
+  if (nts >= 0) {
+    printlog("Update input.txt for restart at timestep {}...", nts);
+  } else {
+    printlog("Copying input.txt to input-newrun.txt...");
+  }
 
   auto file = fstream_required("input.txt", std::ios::in);
 
@@ -1967,11 +1972,7 @@ void update_parameterfile(const int nts) {
                rename_error.message());
   }
 
-  if (nts >= 0) {
-    printlnlog("updated input.txt for restart at timestep {}", nts);
-  } else {
-    printlnlog("copied input.txt to input-newrun.txt");
-  }
+  printlnlog("done");
 }
 
 void read_atomicdata() {

--- a/input.cc
+++ b/input.cc
@@ -599,12 +599,12 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
             (temp_linelist[downtranslineindex].ionindex != ion) ||
             (temp_linelist[downtranslineindex].upperlevelindex != level) ||
             (temp_linelist[downtranslineindex].lowerlevelindex != lowerlevel)) {
-          printlnlog("[input] Failure to identify level pair for duplicate bb-transition ... going to abort now");
-          printlnlog("[input]   element {} ion {} targetlevel {} level {}", element, ion, lowerlevel, level);
-          printlnlog("[input]   transitions[level].to[targetlevel]=lineindex {}", downtranslineindex);
-          printlnlog("[input]   A_ul {:g}, coll_str {:g}", transition.A, transition.coll_str);
+          printlnlog("[error] Failure to identify level pair for duplicate bb-transition ... going to abort now");
+          printlnlog("   element {} ion {} targetlevel {} level {}", element, ion, lowerlevel, level);
+          printlnlog("   transitions[level].to[targetlevel]=lineindex {}", downtranslineindex);
+          printlnlog("   A_ul {:g}, coll_str {:g}", transition.A, transition.coll_str);
           printlnlog(
-              "[input]   globals::linelist[lineindex].elementindex {}, globals::linelist[lineindex].ionindex {}, "
+              "   globals::linelist[lineindex].elementindex {}, globals::linelist[lineindex].ionindex {}, "
               "globals::linelist[lineindex].upperlevelindex {}, globals::linelist[lineindex].lowerlevelindex {}",
               temp_linelist[downtranslineindex].elementindex, temp_linelist[downtranslineindex].ionindex,
               temp_linelist[downtranslineindex].upperlevelindex, temp_linelist[downtranslineindex].lowerlevelindex);
@@ -1691,7 +1691,7 @@ void setup_nlte_levels() {
           n_super_levels++;
         }
 
-        printlnlog("[input]  element {:2} Z={:2} ionstage {:2} has {:5} NLTE excited levels{}. Starting at index {}",
+        printlnlog("[info]  element {:2} Z={:2} ionstage {:2} has {:5} NLTE excited levels{}. Starting at index {}",
                    element, get_atomicnumber(element), get_ionstage(element, ion),
                    get_nlevels_excited_nlte(element, ion), has_superlevel ? " plus a superlevel" : "",
                    get_allnltelevelsindexstart(element, ion));
@@ -1699,7 +1699,7 @@ void setup_nlte_levels() {
     }
   }
 
-  printlnlog("[input] Total NLTE levels: {}, of which {} are superlevels", globals::total_nlte_levels, n_super_levels);
+  printlnlog("[info] Total NLTE levels: {}, of which {} are superlevels", globals::total_nlte_levels, n_super_levels);
 }
 
 }  // anonymous namespace
@@ -1821,12 +1821,13 @@ void read_parameterfile(std::span<Packet> packets) {
 
   if (NT_ON) {
     if (NT_SOLVE_SPENCERFANO) {
-      printlnlog("input: Non-thermal ionisation with a Spencer-Fano solution is switched on for this run.");
+      printlnlog("NT_ON = true: Non-thermal ionisation with a Spencer-Fano solution is switched on for this run.");
     } else {
-      printlnlog("input: Non-thermal ionisation with the work function approximation is switched on for this run.");
+      printlnlog(
+          "NT_ON = true: Non-thermal ionisation with the work function approximation is switched on for this run.");
     }
   } else {
-    printlnlog("input: No non-thermal ionisation is used in this run.");
+    printlnlog("NT_ON = false: No non-thermal ionisation is used in this run.");
   }
 
   if (USE_LUT_PHOTOION) {
@@ -1963,10 +1964,8 @@ void read_atomicdata() {
   int includedionisinglevels = 0;
   int includedboundboundtransitions = 0;
   int includedphotoiontransitions = 0;
-  printlnlog("[input] this simulation contains");
-  printlnlog("----------------------------------");
   for (int element = 0; element < get_nelements(); element++) {
-    printlnlog("[input]  element {} (Z={:2} {})", element, get_atomicnumber(element),
+    printlnlog("[info]  element {} (Z={:2} {})", element, get_atomicnumber(element),
                decay::get_elname(get_atomicnumber(element)));
     const int nions = get_nions(element);
     for (int ion = 0; ion < nions; ion++) {
@@ -1978,7 +1977,7 @@ void read_atomicdata() {
       }
 
       printlnlog(
-          "[input]    ionstage {}: {:4} levels ({:4} ionising) {:7} lines {:6} bf transitions ("
+          "[info]    ionstage {}: {:4} levels ({:4} ionising) {:7} lines {:6} bf transitions ("
           "epsilon_ground: {:7.2f} [eV])",
           get_ionstage(element, ion), get_nlevels(element, ion), get_nlevels_ionising(element, ion), ion_bbtransitions,
           ion_photoiontransitions, epsilon(element, ion, 0) / EV);
@@ -1991,7 +1990,7 @@ void read_atomicdata() {
   assert_always(includedphotoiontransitions == globals::nbfcontinua);
   assert_always(globals::nlines == includedboundboundtransitions);
 
-  printlnlog("[input]  in total {} ions, {} levels ({} ionising), {} lines, {} photoionisation transitions",
+  printlnlog("[info]  in total {} ions, {} levels ({} ionising), {} lines, {} photoionisation transitions",
              get_includedions(), get_includedlevels(), includedionisinglevels, globals::nlines, globals::nbfcontinua);
 
   write_bflist_file();

--- a/input.cc
+++ b/input.cc
@@ -379,7 +379,7 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
     }
   }
 
-  printlnlog("[info] mem_usage: photoionisation tables occupy {:.3f} MB", mem_usage_phixs / 1024. / 1024.);
+  printlnlog("[info] mem_usage: photoionisation tables occupy {:.3f} [MB]", mem_usage_phixs / 1024. / 1024.);
 }
 
 constexpr auto downtranslevelstart(const int level) {
@@ -797,7 +797,7 @@ void setup_phixs_list() {
   globals::groundcont_ion = std::move(groundcont_ion);
 
   auto allcont = MPI_shared_array<TempPhotoionTransitionInput>(globals::nbfcontinua);
-  printlnlog("[info] mem_usage: photoionisation list occupies {:.3f} MB",
+  printlnlog("[info] mem_usage: photoionisation list occupies {:.3f} [MB]",
              globals::nbfcontinua * (sizeof(TempPhotoionTransitionInput)) / 1024. / 1024.);
   const auto groundcontindices = std::ranges::iota_view{0, globals::nbfcontinua_ground};
   int allcontindex = 0;
@@ -1358,8 +1358,9 @@ void sort_temp_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
           }
           if (duplicate_count <= max_duplicates_shown) {
             printlnlog(
-                "[warning] duplicate bb-transition Z={} ionstage {} levels {} to {}: nu {:g} Hz and {:g} Hz (lambda "
-                "{:.2f} Angstrom)",
+                "[warning] duplicate bb-transition Z={} ionstage {} levels {} to {}: nu {:g} [Hz] and {:g} [Hz] "
+                "(lambda "
+                "{:.2f} [Angstrom])",
                 get_atomicnumber(a1.elementindex), get_ionstage(a1.elementindex, a1.ionindex), a1.lowerlevelindex,
                 a1.upperlevelindex, a1.nu, a2.nu, 1e8 * CLIGHT / a1.nu);
           }
@@ -1429,7 +1430,7 @@ void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
     printlnlog("total downtrans {}", downtranscount);
     return downtranscount + uptranscount;
   }();
-  printlnlog("[info] mem_usage: transition lists occupy {:.3f} MB (node shared memory)",
+  printlnlog("[info] mem_usage: transition lists occupy {:.3f} [MB] (node shared memory)",
              updowntranscount * ((2 * sizeof(int)) + (3 * sizeof(float)) + sizeof(bool)) / 1024. / 1024.);
 
   MPI_Barrier_node();
@@ -1579,7 +1580,7 @@ void create_shared_linelist(std::vector<TempLineTransitionInput>& temp_linelist)
        ) /
       1024. / 1024;
 
-  printlnlog("[info] mem_usage: linelist occupies {:.3f} MB (node shared memory)", linelist_mem_MB);
+  printlnlog("[info] mem_usage: linelist occupies {:.3f} [MB] (node shared memory)", linelist_mem_MB);
 }
 
 // read the full atomic dataset: the composition (compositiondata.txt), then the levels and
@@ -2001,7 +2002,7 @@ void read_atomicdata() {
 
       printlnlog(
           "[input]    ionstage {}: {:4} levels ({:4} ionising) {:7} lines {:6} bf transitions ("
-          "epsilon_ground: {:7.2f} eV)",
+          "epsilon_ground: {:7.2f} [eV])",
           get_ionstage(element, ion), get_nlevels(element, ion), get_nlevels_ionising(element, ion), ion_bbtransitions,
           ion_photoiontransitions, epsilon(element, ion, 0) / EV);
 
@@ -2150,8 +2151,8 @@ void setup_timesteps() {
     return "unknown";
   }();
   printlnlog(
-      "timesteps: {} steps from tmin {:.4f} d to tmax {:.4f} d with {} sizing (first width {:.4f} d, last "
-      "width {:.4f} d)",
+      "timesteps: {} steps from tmin {:.4f} [d] to tmax {:.4f} [d] with {} sizing (first width {:.4f} [d], last "
+      "width {:.4f} [d])",
       globals::ntimesteps, globals::tmin / DAY, globals::tmax / DAY, method_name, globals::timesteps[0].width / DAY,
       globals::timesteps[globals::ntimesteps - 1].width / DAY);
 }

--- a/input.cc
+++ b/input.cc
@@ -1738,14 +1738,17 @@ void read_parameterfile(std::span<Packet> packets) {
   if (pre_zseed > 0) {
     printlnlog("input.txt specified random number seed is {}", pre_zseed);
   } else {
+#if defined REPRODUCIBLE && REPRODUCIBLE
+    printlnlog(
+        "ERROR: REPRODUCIBLE mode requires a positive random number seed on the first non-comment line of input.txt "
+        "(found {})",
+        pre_zseed);
+    std::abort();
+#endif
     pre_zseed = get_rng_random_seed();
     // broadcast randomly-generated seed from rank 0 to all ranks
     MPI_Bcast_safe(pre_zseed, 0, MPI_COMM_WORLD);
     printlnlog("randomly-generated random number seed is {}", pre_zseed);
-#if defined REPRODUCIBLE && REPRODUCIBLE
-    printlnlog("ERROR: reproducible mode is on, so random number seed is required.");
-    std::abort();
-#endif
   }
 
   if (!packets.empty()) {
@@ -2131,4 +2134,23 @@ void setup_timesteps() {
   const auto tsfinal_end =
       globals::timesteps[globals::ntimesteps - 1].start + globals::timesteps[globals::ntimesteps - 1].width;
   assert_always(fabs((tsfinal_end / globals::tmax) - 1.) < 0.001);
+
+  const auto* const method_name = [] {
+    switch (TIMESTEP_SIZE_METHOD) {
+      case TimeStepSizeMethod::LOGARITHMIC:
+        return "logarithmic";
+      case TimeStepSizeMethod::CONSTANT:
+        return "constant";
+      case TimeStepSizeMethod::LOGARITHMIC_THEN_CONSTANT:
+        return "logarithmic then constant";
+      case TimeStepSizeMethod::CONSTANT_THEN_LOGARITHMIC:
+        return "constant then logarithmic";
+    }
+    return "unknown";
+  }();
+  printlnlog(
+      "timesteps: {} steps from tmin {:.4f} d to tmax {:.4f} d with {} sizing (first width {:.4f} d, last "
+      "width {:.4f} d)",
+      globals::ntimesteps, globals::tmin / DAY, globals::tmax / DAY, method_name, globals::timesteps[0].width / DAY,
+      globals::timesteps[globals::ntimesteps - 1].width / DAY);
 }

--- a/input.cc
+++ b/input.cc
@@ -721,9 +721,14 @@ auto search_groundphixslist(const double nu_edge, const int element_in, const in
     printlnlog(
         "  This shouldn't happen, but is possible if there are multiple levels in the adata file at "
         "energy=0");
-    for (int looplevels = 0; looplevels < get_nlevels(element_in, ion_in); looplevels++) {
+    const int nlevels_in = get_nlevels(element_in, ion_in);
+    constexpr int maxshownlevels = 10;
+    for (int looplevels = 0; looplevels < std::min(nlevels_in, maxshownlevels); looplevels++) {
       printlnlog("  element {}, ion {}, level {}, energy {:g}", element_in, ion_in, looplevels,
                  epsilon(element_in, ion_in, looplevels));
+    }
+    if (nlevels_in > maxshownlevels) {
+      printlnlog("  (energies of the remaining {} levels omitted)", nlevels_in - maxshownlevels);
     }
     assert_always(false);
     return i - 1;
@@ -949,10 +954,12 @@ void read_autoion_data() {
   double autoion_A = -1;
   bool allautoion_levels_are_not_nlte = true;
   bool allautoion_levels_are_nlte = true;
+  int autoion_transitions_read = 0;
 
   while (get_noncommentline(autoionfile, autoionline)) {
     assert_always(std::istringstream(autoionline) >> Z >> upperionstage >> upperlevel_in >> lowerionstage >>
                   lowerlevel_in >> autoion_A);
+    autoion_transitions_read++;
 
     assert_always(Z > 0);
     assert_always(upperionstage >= 2);
@@ -979,9 +986,6 @@ void read_autoion_data() {
         allautoion_levels_are_not_nlte = allautoion_levels_are_not_nlte && !level_is_nlte;
         allautoion_levels_are_nlte = allautoion_levels_are_nlte && level_is_nlte;
 
-        printlnlog("Got to noting data for Z {} upperion {} upperlvl {} lowerion {} lowerlvl {} with A {:g}", Z,
-                   upperion, upperlevel, lowerion, lowerlevel, autoion_A);
-
         const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
         const auto upper_uniquelevelindex = get_uniquelevelindex(element, upperion, upperlevel);
 
@@ -1007,6 +1011,9 @@ void read_autoion_data() {
   }
 
   assert_always(allautoion_levels_are_not_nlte || allautoion_levels_are_nlte);
+
+  printlnlog("autoion.txt: read {} autoionisation transitions, stored {} for the included ions",
+             autoion_transitions_read, temp_allautoion.size());
 
   globals::allautoion = MPI_shared_array<globals::LevelAutoion>(temp_allautoion.size());
   if (globals::rank_in_node == 0) {
@@ -1096,7 +1103,6 @@ void read_phixs_data() {
       }
     }
   }
-  printlnlog("cont_index {}", cont_index);
   assert_always(cont_index == std::ssize(tmpallphixstargets));
 
   if (!tmpallphixs.empty()) {
@@ -1210,7 +1216,6 @@ void read_levels_and_transitions(std::vector<TempEnergyLevel>& temp_alllevels,
   auto adata = fstream_required("adata.txt", std::ios::in);
   auto ftransitiondata = fstream_required("transitiondata.txt", std::ios::in);
   int uniquelevelindex = 0;  // index into list of all levels of all ions of all elements
-  int nbfcheck = 0;
   for (int element = 0; element < get_nelements(); element++) {
     // now read in data for all ions of the current element. before doing so initialize
     // energy scale for the current element (all level energies are stored relative to
@@ -1277,9 +1282,6 @@ void read_levels_and_transitions(std::vector<TempEnergyLevel>& temp_alllevels,
                       temp_alllevels);
       uniquelevelindex += get_nlevels(element, ion);
 
-      if (ion < nions - 1) {
-        nbfcheck += get_nlevels_ionising(element, ion);
-      }
       // and proceed through the transitionlist till we match this ionstage (if it was not the neutral one)
       int transdata_Z_in = -1;
       int transdata_ionstage_in = -1;
@@ -1321,7 +1323,6 @@ void read_levels_and_transitions(std::vector<TempEnergyLevel>& temp_alllevels,
       }
     }
   }
-  printlnlog("nbfcheck {}", nbfcheck);
 }
 
 // sort the temporary linelist by descending frequency and warn about any duplicate transitions
@@ -1339,6 +1340,9 @@ void sort_temp_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
              std::tie(b.elementindex, b.ionindex, b.lowerlevelindex, b.upperlevelindex, b.einstein_A);
     });
 
+    int duplicate_count = 0;
+    int duplicate_exact_nu_count = 0;
+    constexpr int max_duplicates_shown = 10;
     for (int i = 0; i < globals::nlines - 1; i++) {
       const double nu = temp_linelist[i].nu;
       const double nu_next = temp_linelist[i + 1].nu;
@@ -1348,15 +1352,25 @@ void sort_temp_linelist(std::vector<TempLineTransitionInput>& temp_linelist) {
 
         if ((a1.elementindex == a2.elementindex) && (a1.ionindex == a2.ionindex) &&
             (a1.lowerlevelindex == a2.lowerlevelindex) && (a1.upperlevelindex == a2.upperlevelindex)) {
-          printlnlog("Duplicate transition line? {}", a1.nu == a2.nu ? "nu match exact" : "close to nu match");
-          printlnlog("a: Z={} ionstage {} lower {} upper {} nu {:g} lambda {:g}", get_atomicnumber(a1.elementindex),
-                     get_ionstage(a1.elementindex, a1.ionindex), a1.lowerlevelindex, a1.upperlevelindex, a1.nu,
-                     1e8 * CLIGHT / a1.nu);
-          printlnlog("b: Z={} ionstage {} lower {} upper {} nu {:g} lambda {:g}", get_atomicnumber(a2.elementindex),
-                     get_ionstage(a2.elementindex, a2.ionindex), a2.lowerlevelindex, a2.upperlevelindex, a2.nu,
-                     1e8 * CLIGHT / a2.nu);
+          duplicate_count++;
+          if (a1.nu == a2.nu) {
+            duplicate_exact_nu_count++;
+          }
+          if (duplicate_count <= max_duplicates_shown) {
+            printlnlog(
+                "[warning] duplicate bb-transition Z={} ionstage {} levels {} to {}: nu {:g} Hz and {:g} Hz (lambda "
+                "{:.2f} Angstrom)",
+                get_atomicnumber(a1.elementindex), get_ionstage(a1.elementindex, a1.ionindex), a1.lowerlevelindex,
+                a1.upperlevelindex, a1.nu, a2.nu, 1e8 * CLIGHT / a1.nu);
+          }
         }
       }
+    }
+    if (duplicate_count > 0) {
+      printlnlog(
+          "[warning] found {} duplicate bb-transitions in the linelist ({} with exactly matching nu; first {} "
+          "listed above)",
+          duplicate_count, duplicate_exact_nu_count, std::min(duplicate_count, max_duplicates_shown));
     }
   }
 }

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -53,7 +53,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
                                  std::span<double> ion_contribs, double* const C_ff, double* const C_fb,
                                  double* const C_exc, double* const C_ionisation) -> double {
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   double C_ion = 0.;
   // cursor into this ion's slice of the cooling list, only advanced when we are filling the cellcache
@@ -367,7 +367,7 @@ DEVICE_FUNC void do_kpkt_blackbody(Packet& pkt) {
   if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() && grid::thick_allcells[nonemptymgi] != 1) {
     pkt.nu_cmf = sample_planck_times_expansion_opacity(nonemptymgi, get_rngstate(pkt));
   } else {
-    pkt.nu_cmf = sample_planck_montecarlo(grid::get_Te(nonemptymgi), get_rngstate(pkt));
+    pkt.nu_cmf = sample_planck_montecarlo(grid::Te_allcells[nonemptymgi], get_rngstate(pkt));
   }
 
   assert_always(std::isfinite(pkt.nu_cmf));
@@ -453,7 +453,7 @@ DEVICE_FUNC void do_kpkt(Packet& pkt, const double t2, const int nts) {
   const auto i = ionstart + ionoffset;
 
   const auto rndcoolingtype = coolinglist_type[i];
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   if (rndcoolingtype == CoolingType::FREEFREE) {
     // The k-packet converts directly into a r-packet by free-free emission.

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -276,7 +276,7 @@ void setup_coolinglist() {
   auto temp_coolinglist_level = MPI_shared_array<int>(ncoolingterms);
   auto temp_coolinglist_upperlevel = MPI_shared_array<int>(ncoolingterms);
   const size_t mem_usage_coolinglist = ncoolingterms * (sizeof(CoolingType) + (2 * sizeof(int)));
-  printlnlog("[info] mem_usage: coolinglist occupies {:.3f} MB", mem_usage_coolinglist / 1024. / 1024.);
+  printlnlog("[info] mem_usage: coolinglist occupies {:.3f} [MB]", mem_usage_coolinglist / 1024. / 1024.);
 
   int i = 0;  // cooling list index
   for (int element = 0; element < get_nelements(); element++) {

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -276,7 +276,7 @@ void setup_coolinglist() {
   auto temp_coolinglist_level = MPI_shared_array<int>(ncoolingterms);
   auto temp_coolinglist_upperlevel = MPI_shared_array<int>(ncoolingterms);
   const size_t mem_usage_coolinglist = ncoolingterms * (sizeof(CoolingType) + (2 * sizeof(int)));
-  printlnlog("[info] mem_usage: coolinglist occupies {:.3f} [MB]", mem_usage_coolinglist / 1024. / 1024.);
+  printlnlog("[info] mem_usage: coolinglist occupies {:.3f} MB", mem_usage_coolinglist / 1024. / 1024.);
 
   int i = 0;  // cooling list index
   for (int element = 0; element < get_nelements(); element++) {

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -342,7 +342,7 @@ void setup_coolinglist() {
   }
 
   assert_always(ncoolingterms == i);  // if this doesn't match, we miscalculated the number of cooling terms
-  printlnlog("[info] read_atomicdata: number of coolingterms {}", ncoolingterms);
+  printlnlog("[info] setup_coolinglist: number of coolingterms {}", ncoolingterms);
   coolinglist_type = std::move(temp_coolinglist_type);
   coolinglist_level = std::move(temp_coolinglist_level);
   coolinglist_upperlevel = std::move(temp_coolinglist_upperlevel);

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -457,8 +457,7 @@ DEVICE_FUNC void do_kpkt(Packet& pkt, const double t2, const int nts) {
 
   if (rndcoolingtype == CoolingType::FREEFREE) {
     // The k-packet converts directly into a r-packet by free-free emission.
-    // Need to select the r-packets frequency and a random direction in the
-    // co-moving frame.
+    // Need to select the r-packets frequency and a random direction in the co-moving frame.
 
     // Sample the packets comoving frame frequency according to paperII 5.4.3 eq.41
 

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -59,7 +59,7 @@ THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
   const auto partfunc_ion = get_ion_partfunct(nonemptymgi, element, ion);
   const auto partfunc_upperion = get_ion_partfunct(nonemptymgi, element, ion + 1);
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const double ionpot = epsilon(element, ion + 1, 0) - epsilon(element, ion, 0);
   const double partfunct_ratio = partfunc_ion / partfunc_upperion;
   return partfunct_ratio * SAHACONST * pow(T_e, -1.5) * exp(ionpot / KB / T_e);
@@ -80,7 +80,7 @@ THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
   const int uniqueionindex = get_uniqueionindex(element, ion);
   const auto partfunc_ion = get_ion_partfunct(nonemptymgi, element, ion);
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   // photoionisation plus collisional ionisation rate coefficient per ground level pop
   const auto groundcontindex = get_groundcontindex(element, ion);
@@ -374,7 +374,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
             "[warning] calculate_ionfractions: cell {} timestep {}: non-finite ionfract set to zero for Z={} "
             "ionstage {} (T_e {:g} [K], T_R {:g} [K]; repeats suppressed)",
             grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, get_atomicnumber(element),
-            get_ionstage(element, ion), grid::get_Te(nonemptymgi), grid::get_TR(nonemptymgi));
+            get_ionstage(element, ion), grid::Te_allcells[nonemptymgi], grid::TR_allcells[nonemptymgi]);
       }
       ionfractions[ion] = 0;
     }
@@ -391,7 +391,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
     return nnground;
   }
 
-  const auto T_exc = LTEPOP_EXCITATION_USE_TJ ? grid::get_TJ(nonemptymgi) : grid::get_Te(nonemptymgi);
+  const auto T_exc = LTEPOP_EXCITATION_USE_TJ ? grid::TJ_allcells[nonemptymgi] : grid::Te_allcells[nonemptymgi];
   const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
 
   const double E_aboveground = epsilon(ionuniquelevelindexstart + level) - epsilon(ionuniquelevelindexstart);

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -493,7 +493,7 @@ auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
     if (ionfract_zeroed_count > 0) {
       printlnlog(
           "[warning] calculate_ion_balance_nne: cell {} timestep {}: {} non-finite ionfract value(s) set to zero "
-          "(T_e {:g} K, T_R {:g} K; repeats suppressed)",
+          "(T_e {:g} [K], T_R {:g} [K]; repeats suppressed)",
           modelgridindex, globals::timestep, ionfract_zeroed_count, grid::get_Te(nonemptymgi),
           grid::get_TR(nonemptymgi));
     }

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -146,8 +146,8 @@ auto nne_solution_f(const double nne_assumed, const int nonemptymgi, const bool 
 }
 
 // return population and whether the population came from the nlte solver
-auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion,
-                                 const int level) -> std::tuple<double, bool> {
+auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level)
+    -> std::tuple<double, bool> {
   testmodeassert_valid_level(element, ion, level);
 
   if (level == 0) {

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -30,17 +30,29 @@
 
 namespace {
 
-// The conditions behind these warnings can persist across the many evaluations that the nne and T_e
-// root solvers make for a single cell, so they are counted here and summarised by
-// calculate_ion_balance_nne at most once per cell per timestep instead of being logged at every
-// solver evaluation.
-THREADLOCALONHOST int ionfract_zeroed_count = 0;
-THREADLOCALONHOST int nne_solver_maxit_count = 0;
-THREADLOCALONHOST int uppermost_ion_limited_count = 0;
-THREADLOCALONHOST ptrdiff_t ionbalance_warned_nonemptymgi = -1;
-THREADLOCALONHOST int ionbalance_warned_timestep = -1;
-THREADLOCALONHOST ptrdiff_t neutralcell_warned_nonemptymgi = -1;
-THREADLOCALONHOST int neutralcell_warned_timestep = -1;
+// The conditions behind the warnings below can persist across the many evaluations that the nne and
+// T_e root solvers make for a single cell, so each one is reported only on its first occurrence for
+// a given cell and timestep. The check is made at the warning site so that the warnings are still
+// reported when the NLTE solver calls into these functions itself.
+struct CellWarningMarker {
+  ptrdiff_t nonemptymgi{-1};
+  int timestep{-1};
+
+  // returns true the first time it is called for a particular cell and timestep
+  auto is_first_occurrence(const ptrdiff_t nonemptymgi_in) -> bool {
+    if (nonemptymgi_in == nonemptymgi && globals::timestep == timestep) {
+      return false;
+    }
+    nonemptymgi = nonemptymgi_in;
+    timestep = globals::timestep;
+    return true;
+  }
+};
+
+THREADLOCALONHOST CellWarningMarker neutralcell_warned;
+THREADLOCALONHOST CellWarningMarker nne_maxit_warned;
+THREADLOCALONHOST CellWarningMarker uppermost_ion_warned;
+THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
 
 // use Saha equation for LTE ionisation balance
 [[gnu::pure]] [[nodiscard]] auto phi_saha(const int element, const int ion, const int nonemptymgi) -> double {
@@ -226,9 +238,7 @@ void set_calculated_nne(const int nonemptymgi) {
 
 // Special case of only neutral ions, set nne to some finite value so that packets are not lost in kpkts
 void set_groundlevelpops_neutral(const ptrdiff_t nonemptymgi) {
-  if (nonemptymgi != neutralcell_warned_nonemptymgi || globals::timestep != neutralcell_warned_timestep) {
-    neutralcell_warned_nonemptymgi = nonemptymgi;
-    neutralcell_warned_timestep = globals::timestep;
+  if (neutralcell_warned.is_first_occurrence(nonemptymgi)) {
     printlnlog("[warning] set_groundlevelpops_neutral: only neutral ions in cell {} timestep {} (repeats suppressed)",
                grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep);
   }
@@ -273,8 +283,11 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
   const auto result =
       boost::math::tools::toms748_solve(f_nne, nne_min, nne_max, f_nne_min, f_nne_max, ftol<fractional_accuracy>, iter);
   const double nne_solution = 0.5 * (result.first + result.second);
-  if (iter >= maxit) {
-    nne_solver_maxit_count++;
+  if (iter >= maxit && nne_maxit_warned.is_first_occurrence(nonemptymgi)) {
+    printlnlog(
+        "[warning] find_converged_nne: cell {} timestep {}: nne did not converge within {} iterations "
+        "(repeats suppressed)",
+        grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, iter);
   }
 
   return static_cast<float>(std::max(MINPOP, nne_solution));
@@ -317,7 +330,12 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
     pop_ratio_ground_to_upper *= nne_hi * phifactor;
 
     if (!std::isfinite(pop_ratio_ground_to_upper)) {
-      uppermost_ion_limited_count++;
+      if (uppermost_ion_warned.is_first_occurrence(nonemptymgi)) {
+        printlnlog(
+            "[info] find_uppermost_ion: cell {} timestep {}: uppermost ion stage limited by phi factor overflow for "
+            "Z={} ionstage {} (repeats suppressed)",
+            modelgridindex, globals::timestep, get_atomicnumber(element), get_ionstage(element, ion));
+      }
       return ion;
     }
   }
@@ -351,7 +369,13 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
     ionfractions[ion] = ionfractions[ion] / normfactor;
 
     if (normfactor == 0. || !std::isfinite(ionfractions[ion])) {
-      ionfract_zeroed_count++;
+      if (ionfract_zeroed_warned.is_first_occurrence(nonemptymgi)) {
+        printlnlog(
+            "[warning] calculate_ionfractions: cell {} timestep {}: non-finite ionfract set to zero for Z={} "
+            "ionstage {} (T_e {:g} [K], T_R {:g} [K]; repeats suppressed)",
+            grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, get_atomicnumber(element),
+            get_ionstage(element, ion), grid::get_Te(nonemptymgi), grid::get_TR(nonemptymgi));
+      }
       ionfractions[ion] = 0;
     }
   }
@@ -446,10 +470,6 @@ void set_groundlevelpops(const int nonemptymgi, const int element, const float n
 // Determine the electron number density for a given cell using a root
 // solver and calculate the dependent level populations.
 auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
-  ionfract_zeroed_count = 0;
-  nne_solver_maxit_count = 0;
-  uppermost_ion_limited_count = 0;
-
   const bool force_saha = globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1;
 
   const double nne_max = grid::get_rho(nonemptymgi) / MH;
@@ -482,32 +502,4 @@ auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
   }
 
   set_calculated_nne(nonemptymgi);
-
-  const bool any_warnings =
-      (ionfract_zeroed_count > 0) || (nne_solver_maxit_count > 0) || (uppermost_ion_limited_count > 0);
-  if (any_warnings &&
-      (nonemptymgi != ionbalance_warned_nonemptymgi || globals::timestep != ionbalance_warned_timestep)) {
-    ionbalance_warned_nonemptymgi = nonemptymgi;
-    ionbalance_warned_timestep = globals::timestep;
-    const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-    if (ionfract_zeroed_count > 0) {
-      printlnlog(
-          "[warning] calculate_ion_balance_nne: cell {} timestep {}: {} non-finite ionfract value(s) set to zero "
-          "(T_e {:g} [K], T_R {:g} [K]; repeats suppressed)",
-          modelgridindex, globals::timestep, ionfract_zeroed_count, grid::get_Te(nonemptymgi),
-          grid::get_TR(nonemptymgi));
-    }
-    if (nne_solver_maxit_count > 0) {
-      printlnlog(
-          "[warning] calculate_ion_balance_nne: cell {} timestep {}: nne solver failed to converge within the "
-          "iteration limit (repeats suppressed)",
-          modelgridindex, globals::timestep);
-    }
-    if (uppermost_ion_limited_count > 0) {
-      printlnlog(
-          "[info] calculate_ion_balance_nne: cell {} timestep {}: uppermost ion stage limited by phi factor overflow "
-          "for {} element(s) (repeats suppressed)",
-          modelgridindex, globals::timestep, uppermost_ion_limited_count);
-    }
-  }
 }

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -30,6 +30,18 @@
 
 namespace {
 
+// The conditions behind these warnings can persist across the many evaluations that the nne and T_e
+// root solvers make for a single cell, so they are counted here and summarised by
+// calculate_ion_balance_nne at most once per cell per timestep instead of being logged at every
+// solver evaluation.
+THREADLOCALONHOST int ionfract_zeroed_count = 0;
+THREADLOCALONHOST int nne_solver_maxit_count = 0;
+THREADLOCALONHOST int uppermost_ion_limited_count = 0;
+THREADLOCALONHOST ptrdiff_t ionbalance_warned_nonemptymgi = -1;
+THREADLOCALONHOST int ionbalance_warned_timestep = -1;
+THREADLOCALONHOST ptrdiff_t neutralcell_warned_nonemptymgi = -1;
+THREADLOCALONHOST int neutralcell_warned_timestep = -1;
+
 // use Saha equation for LTE ionisation balance
 [[gnu::pure]] [[nodiscard]] auto phi_saha(const int element, const int ion, const int nonemptymgi) -> double {
   const auto partfunc_ion = get_ion_partfunct(nonemptymgi, element, ion);
@@ -134,8 +146,8 @@ auto nne_solution_f(const double nne_assumed, const int nonemptymgi, const bool 
 }
 
 // return population and whether the population came from the nlte solver
-auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion, const int level)
-    -> std::tuple<double, bool> {
+auto calculate_levelpop_nominpop(const int nonemptymgi, const int element, const int ion,
+                                 const int level) -> std::tuple<double, bool> {
   testmodeassert_valid_level(element, ion, level);
 
   if (level == 0) {
@@ -214,8 +226,12 @@ void set_calculated_nne(const int nonemptymgi) {
 
 // Special case of only neutral ions, set nne to some finite value so that packets are not lost in kpkts
 void set_groundlevelpops_neutral(const ptrdiff_t nonemptymgi) {
-  printlnlog("[warning] calculate_ion_balance_nne: only neutral ions in cell modelgridindex {}",
-             grid::get_mgi_of_nonemptymgi(nonemptymgi));
+  if (nonemptymgi != neutralcell_warned_nonemptymgi || globals::timestep != neutralcell_warned_timestep) {
+    neutralcell_warned_nonemptymgi = nonemptymgi;
+    neutralcell_warned_timestep = globals::timestep;
+    printlnlog("[warning] set_groundlevelpops_neutral: only neutral ions in cell {} timestep {} (repeats suppressed)",
+               grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep);
+  }
   for (int element = 0; element < get_nelements(); element++) {
     const auto nnelement = grid::get_elem_numberdens(nonemptymgi, element);
     const int nions = get_nions(element);
@@ -258,7 +274,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
       boost::math::tools::toms748_solve(f_nne, nne_min, nne_max, f_nne_min, f_nne_max, ftol<fractional_accuracy>, iter);
   const double nne_solution = 0.5 * (result.first + result.second);
   if (iter >= maxit) {
-    printlnlog("[warning] calculate_ion_balance_nne: nne did not converge within {} iterations", iter);
+    nne_solver_maxit_count++;
   }
 
   return static_cast<float>(std::max(MINPOP, nne_solution));
@@ -301,10 +317,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
     pop_ratio_ground_to_upper *= nne_hi * phifactor;
 
     if (!std::isfinite(pop_ratio_ground_to_upper)) {
-      printlnlog(
-          "[info] calculate_ion_balance_nne: uppermost_ion limited by phi factors for element Z={}, ionstage {} in "
-          "cell {}",
-          get_atomicnumber(element), get_ionstage(element, ion), modelgridindex);
+      uppermost_ion_limited_count++;
       return ion;
     }
   }
@@ -338,9 +351,7 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
     ionfractions[ion] = ionfractions[ion] / normfactor;
 
     if (normfactor == 0. || !std::isfinite(ionfractions[ion])) {
-      printlnlog("[warning] ionfract set to zero for ionstage {}, Z={} in cell {} with T_e {:g}, T_R {:g}",
-                 get_ionstage(element, ion), get_atomicnumber(element), grid::get_mgi_of_nonemptymgi(nonemptymgi),
-                 grid::get_Te(nonemptymgi), grid::get_TR(nonemptymgi));
+      ionfract_zeroed_count++;
       ionfractions[ion] = 0;
     }
   }
@@ -435,6 +446,10 @@ void set_groundlevelpops(const int nonemptymgi, const int element, const float n
 // Determine the electron number density for a given cell using a root
 // solver and calculate the dependent level populations.
 auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
+  ionfract_zeroed_count = 0;
+  nne_solver_maxit_count = 0;
+  uppermost_ion_limited_count = 0;
+
   const bool force_saha = globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1;
 
   const double nne_max = grid::get_rho(nonemptymgi) / MH;
@@ -467,4 +482,32 @@ auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
   }
 
   set_calculated_nne(nonemptymgi);
+
+  const bool any_warnings =
+      (ionfract_zeroed_count > 0) || (nne_solver_maxit_count > 0) || (uppermost_ion_limited_count > 0);
+  if (any_warnings &&
+      (nonemptymgi != ionbalance_warned_nonemptymgi || globals::timestep != ionbalance_warned_timestep)) {
+    ionbalance_warned_nonemptymgi = nonemptymgi;
+    ionbalance_warned_timestep = globals::timestep;
+    const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+    if (ionfract_zeroed_count > 0) {
+      printlnlog(
+          "[warning] calculate_ion_balance_nne: cell {} timestep {}: {} non-finite ionfract value(s) set to zero "
+          "(T_e {:g} K, T_R {:g} K; repeats suppressed)",
+          modelgridindex, globals::timestep, ionfract_zeroed_count, grid::get_Te(nonemptymgi),
+          grid::get_TR(nonemptymgi));
+    }
+    if (nne_solver_maxit_count > 0) {
+      printlnlog(
+          "[warning] calculate_ion_balance_nne: cell {} timestep {}: nne solver failed to converge within the "
+          "iteration limit (repeats suppressed)",
+          modelgridindex, globals::timestep);
+    }
+    if (uppermost_ion_limited_count > 0) {
+      printlnlog(
+          "[info] calculate_ion_balance_nne: cell {} timestep {}: uppermost ion stage limited by phi factor overflow "
+          "for {} element(s) (repeats suppressed)",
+          modelgridindex, globals::timestep, uppermost_ion_limited_count);
+    }
+  }
 }

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -1,6 +1,5 @@
 // Level populations and ionisation balance in LTE and approximate NLTE: partition functions,
-// Boltzmann/Saha level and ion populations, and the solver for a self-consistent free electron
-// density (nne).
+// Boltzmann/Saha level and ion populations, and the solver for a self-consistent free electron density (nne).
 
 #include "ltepop.h"
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -759,8 +759,7 @@ void macroatom_open_file() {
              eoverkt / exp_eoverkt * Gamma;
     }
 
-    // forbidden transitions: magnetic dipole, electric quadropole...
-    // Axelrod's approximation (thesis 1980)
+    // forbidden transitions: magnetic dipole, electric quadropole... Axelrod's approximation (thesis 1980)
 
     return clumpednne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -690,8 +690,8 @@ void macroatom_open_file() {
 // multiply by upper level population to get a rate per second
 [[gnu::pure]] [[nodiscard]] auto col_deexcitation_ratecoeff(const float T_e, const float clumpednne,
                                                             const double epsilon_trans, const double upperstatweight,
-                                                            const double lowerstatweight, const int alltransindex)
-    -> double {
+                                                            const double lowerstatweight,
+                                                            const int alltransindex) -> double {
   const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   if (coll_strength < 0) {
     if (!globals::alltrans.forbidden[alltransindex])  // alternative: (coll_strength > -1.5) i.e. to catch -1
@@ -732,8 +732,8 @@ void macroatom_open_file() {
 // multiply by lower level population to get a rate per second
 [[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(const float T_e, const float clumpednne,
                                                           const double upperstatweight, const int alltransindex,
-                                                          const double epsilon_trans, const double lowerstatweight)
-    -> double {
+                                                          const double epsilon_trans,
+                                                          const double lowerstatweight) -> double {
   const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   const double eoverkt = epsilon_trans / (KB * T_e);
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -72,7 +72,7 @@ DEVICE_FUNC void calculate_macroatom_transitionrates(std::span<double> levelrate
   const auto transblock = std::span{get_cellcache(nonemptymgi).allmacroatomictransitions};
   const auto alllevels_matransblock_start = globals::alllevels.matransblock_start[uniquelevelindex];
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
   const double epsilon_current = epsilon(uniquelevelindex);
   const double statweight = stat_weight(uniquelevelindex);
@@ -242,7 +242,7 @@ void do_macroatom_raddeexcitation(Packet& pkt, const int ionuniquelevelindexstar
 // counters
 [[nodiscard]] auto do_macroatom_radrecomb(Packet& pkt, const int nonemptymgi, const int element, const int upperion,
                                           const int upperionlevel, const double rad_recomb) -> int {
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
   const double epsilon_current = epsilon(element, upperion, upperionlevel);
   // Randomly select a continuum
@@ -284,7 +284,7 @@ void do_macroatom_raddeexcitation(Packet& pkt, const int ionuniquelevelindexstar
 [[nodiscard]] auto do_macroatom_ionisation(const int nonemptymgi, const int element, const int ion, const int level,
                                            const double epsilon_current, const double internal_up_higher,
                                            rngstate_type& rngstate) -> int {
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
 
   // Randomly select the occurring transition
@@ -333,7 +333,7 @@ DEVICE_FUNC void calculate_cellcache_macroatom_transitionrates(const int nonempt
 DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.cellindex);
   assert_testmodeonly(nonemptymgi >= 0);
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   const double t_mid = globals::timesteps[globals::timestep].mid;
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -690,8 +690,8 @@ void macroatom_open_file() {
 // multiply by upper level population to get a rate per second
 [[gnu::pure]] [[nodiscard]] auto col_deexcitation_ratecoeff(const float T_e, const float clumpednne,
                                                             const double epsilon_trans, const double upperstatweight,
-                                                            const double lowerstatweight,
-                                                            const int alltransindex) -> double {
+                                                            const double lowerstatweight, const int alltransindex)
+    -> double {
   const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   if (coll_strength < 0) {
     if (!globals::alltrans.forbidden[alltransindex])  // alternative: (coll_strength > -1.5) i.e. to catch -1
@@ -732,8 +732,8 @@ void macroatom_open_file() {
 // multiply by lower level population to get a rate per second
 [[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(const float T_e, const float clumpednne,
                                                           const double upperstatweight, const int alltransindex,
-                                                          const double epsilon_trans,
-                                                          const double lowerstatweight) -> double {
+                                                          const double epsilon_trans, const double lowerstatweight)
+    -> double {
   const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   const double eoverkt = epsilon_trans / (KB * T_e);
 

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -1,6 +1,5 @@
 // MPI setup (global and per-node communicators, rank and node identifiers) plus the logging
-// (printlog/printlnlog) and assertion (assert_always/assert_testmodeonly) facilities used
-// throughout the code.
+// (printlog/printlnlog) and assertion (assert_always/assert_testmodeonly) facilities used throughout the code.
 
 #ifndef MPI_LOGGING_H
 #define MPI_LOGGING_H

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -516,7 +516,7 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
     }
   }
 
-  printlnlog("ERROR: Could not open file '{}' for mode '{}'.", filename, mode.data());
+  printlnlog("[error] Could not open file '{}' for mode '{}'.", filename, mode.data());
   std::abort();
 }
 
@@ -527,7 +527,7 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
 
 [[nodiscard]] inline auto fstream_required(const std::string_view filename, std::ios::openmode mode) -> std::fstream {
   if (filename.empty()) {
-    printlnlog("ERROR: Cannot open file with empty filename.");
+    printlnlog("[error] Cannot open file with empty filename.");
     std::abort();
   }
 
@@ -548,7 +548,7 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
     }
   }
 
-  printlnlog("ERROR: Could not open file '{}'", filename);
+  printlnlog("[error] Could not open file '{}'", filename);
   std::abort();
 }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1390,7 +1390,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
   if (cell_Te == MINTEMP) {
     printlnlog(
         "Not solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} due to low "
-        "temperature Te=MINTEMP={:g} K",
+        "temperature Te=MINTEMP={:g} [K]",
         modelgridindex, timestep, nlte_iter, atomic_number, cell_Te);
     set_element_pops_lte(nonemptymgi, element);
     return;
@@ -1407,7 +1407,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
     // so this announcement is only made for the first iteration
     printlnlog(
         "Solving for NLTE populations in cell {} at timestep {} for element Z={} (mass fraction "
-        "{:.2e}, nnelement {:.2e} cm^-3)",
+        "{:.2e}, nnelement {:.2e} [cm^-3])",
         modelgridindex, timestep, atomic_number, grid::get_elem_massfrac(nonemptymgi, element), nnelement);
   }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -695,7 +695,7 @@ void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element,
       rate_matrices.autoion[(upper_index * nlte_dimension) + upper_index] -= R;
       rate_matrices.autoion[(lower_index * nlte_dimension) + upper_index] += R;
       if ((R < 0)) {
-        printlnlog("  WARNING: cell {} ts {}: negative autoionisation rate from Z={} ionstage {} level {} to level {}",
+        printlnlog("  [warning] cell {} ts {}: negative autoionisation rate from Z={} ionstage {} level {} to level {}",
                    nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), get_ionstage(element, ion),
                    level, target_level);
       }
@@ -709,7 +709,7 @@ void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element,
       rate_matrices.autoion[(lower_index * nlte_dimension) + lower_index] -= R;
       rate_matrices.autoion[(upper_index * nlte_dimension) + lower_index] += R;
       if ((R < 0)) {
-        printlnlog("  WARNING: cell {} ts {}: negative autoionisation rate from Z={} ionstage {} level {} to level {}",
+        printlnlog("  [warning] cell {} ts {}: negative autoionisation rate from Z={} ionstage {} level {} to level {}",
                    nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), get_ionstage(element, ion),
                    level, target_level);
       }
@@ -793,7 +793,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   // set_groundlevelpops uses uppermost_ion. Previously, this was set based on the NLTE phi factors. Therefore we need
   // to call find_uppermost_ion with force_saha = true so the uppermost ion used in set_groundlevelpops is changed to
   // the one based on the correct LTE phi factors instead
-  printlnlog("  WARNING: cell {} ts {}: NLTEPOP setting element Z={} level pops to LTE", nltelog.modelgridindex,
+  printlnlog("  [warning] cell {} ts {}: NLTEPOP setting element Z={} level pops to LTE", nltelog.modelgridindex,
              nltelog.timestep, get_atomicnumber(element));
   const double nne_hi = grid::get_rho(nonemptymgi) / MH;
   constexpr bool force_saha = true;
@@ -824,7 +824,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
 
         if (!std::isfinite(ltepop) || ltepop <= 0.) {
           printlnlog(
-              "  WARNING: cell {} ts {}: Boltzmann population for Z={} ionstage {} level {} is non-finite or "
+              "  [warning] cell {} ts {}: Boltzmann population for Z={} ionstage {} level {} is non-finite or "
               "non-positive ({}). Setting to MINPOP",
               nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), get_ionstage(element, ion), level,
               ltepop);
@@ -832,7 +832,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
         }
 
         printlnlog(
-            "  WARNING: cell {} ts {}: NLTE solver gave negative/non-finite population to index {} (Z={} ionstage {} "
+            "  [warning] cell {} ts {}: NLTE solver gave negative/non-finite population to index {} (Z={} ionstage {} "
             "level {}), pop = {:g}. Replacing with LTE pop of {:g}",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population,
             ltepop);
@@ -843,7 +843,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
       const size_t index_ion_ground = get_nlte_vector_index(element, ion, 0, first_ion_used);
       if (index == index_ion_ground && population < MINPOP) {
         printlnlog(
-            "  WARNING: cell {} ts {}: NLTE solver gave ground pop less than MINPOP for index {} (Z={} ionstage {} "
+            "  [warning] cell {} ts {}: NLTE solver gave ground pop less than MINPOP for index {} (Z={} ionstage {} "
             "level {}), pop = {:g}. Returning nltepop_matrix_solve fail",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         return false;
@@ -851,18 +851,19 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
 
       if (population < 0.0 || !std::isfinite(population)) {
         printlnlog(
-            "  WARNING: cell {} ts {}: NLTE solver gave negative/non-finite population for index {} (Z={} ionstage {} "
+            "  [warning] cell {} ts {}: NLTE solver gave negative/non-finite population for index {} (Z={} ionstage {} "
             "level {}), pop = {:g}",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         if (population < -MINPOP) {
           printlnlog(
-              "  WARNING: negative pop = {:g} less than -MINPOP (-{:g}) unlikely a rounding error to zero so returning "
+              "  [warning] negative pop = {:g} less than -MINPOP (-{:g}) unlikely a rounding error to zero so "
+              "returning "
               "nltepop_matrix_solve fail",
               population, MINPOP);
           return false;
         }
         printlnlog(
-            "  WARNING: negative pop = {:g} greater than -MINPOP (-{:g}) likely a rounding error to zero so continue "
+            "  [warning] negative pop = {:g} greater than -MINPOP (-{:g}) likely a rounding error to zero so continue "
             "with NLTE pops but set this level to MINPOP",
             population, MINPOP);
         popvec[index] = MINPOP;
@@ -879,7 +880,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
           if (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING) {
             const bool solve_failed = (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_SOLVER_FAIL);
             printlnlog(
-                "  WARNING: cell {} ts {}: pop inversion greater than factor {:g}: (g_pop {:g})/(e_pop {:g}) = {:g} "
+                "  [warning] cell {} ts {}: pop inversion greater than factor {:g}: (g_pop {:g})/(e_pop {:g}) = {:g} "
                 "is less than (g_sw {:g})/(e_sw {:g}) = {:g} for index {} Z={} ionstage {} level {} (factor {:g} "
                 "inversion) - {}",
                 nltelog.modelgridindex, nltelog.timestep, STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING,
@@ -902,7 +903,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
             assert_testmodeonly(ion_has_superlevel(element, ion));
             const bool solve_failed = (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_SOLVER_FAIL);
             printlnlog(
-                "  WARNING: cell {} ts {}: superlevel pop inversion greater than factor {:g}: (g_pop "
+                "  [warning] cell {} ts {}: superlevel pop inversion greater than factor {:g}: (g_pop "
                 "{:g})/(SL_first_level_pop {:g}) = {:g} is less than (g_sw {:g})/(SL_first_level_sw {:g}) = {:g} for "
                 "index {} Z={} ionstage {} level {} (factor {:g} inversion) - {}",
                 nltelog.modelgridindex, nltelog.timestep, STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING,
@@ -941,7 +942,7 @@ template <typename GetDiagElement>
     }
   }
   if (!disconnectedlist.empty()) {
-    printlnlog("  ERROR: cell {} ts {}: NLTE matrix is singular for element Z={} (disconnected:{})",
+    printlnlog("  [error] cell {} ts {}: NLTE matrix is singular for element Z={} (disconnected:{})",
                nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), disconnectedlist);
     return true;
   }
@@ -1074,7 +1075,7 @@ template <typename GetDiagElement>
   }
 
   if (!(error_best >= 0.)) {
-    printlnlog("  ERROR: cell {} ts {}: NLTE solver failed to find a solution with finite error for element Z={}",
+    printlnlog("  [error] cell {} ts {}: NLTE solver failed to find a solution with finite error for element Z={}",
                nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
     return false;
   }
@@ -1082,7 +1083,7 @@ template <typename GetDiagElement>
 
   if (error_best > 1e-8) {
     printlnlog(
-        "  WARNING: cell {} ts {}: NLTE solver matrix LU_refine: after {} iterations, best solution vector has a max "
+        "  [warning] cell {} ts {}: NLTE solver matrix LU_refine: after {} iterations, best solution vector has a max "
         "residual of {:g}",
         nltelog.modelgridindex, nltelog.timestep, iteration, error_best);
   }
@@ -1100,7 +1101,7 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
   if (nions_used <= 1) {
     // can't remove an ion if there is only one ion stage used in the NLTE matrix
     printlnlog(
-        "  WARNING: cell {} ts {}: can't remove ion stage {} from NLTE matrix for element Z={} as only one ion stage "
+        "  [warning] cell {} ts {}: can't remove ion stage {} from NLTE matrix for element Z={} as only one ion stage "
         "used",
         nltelog.modelgridindex, nltelog.timestep, get_ionstage(element, ion), get_atomicnumber(element));
     return false;
@@ -1115,7 +1116,7 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
   if (ground_pop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
     // ground pop relative to the element population must not exceed the limit
     printlnlog(
-        "  WARNING: cell {} ts {}: {} ion (Z={} ionstage {}) ground state population too large to remove ion "
+        "  [warning] cell {} ts {}: {} ion (Z={} ionstage {}) ground state population too large to remove ion "
         "(ground_pop / nnelement) = ({}/{}) = {} > {}",
         nltelog.modelgridindex, nltelog.timestep, ionname, get_atomicnumber(element), get_ionstage(element, ion),
         ground_pop, nnelement, ground_pop / nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
@@ -1132,7 +1133,7 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
     nlte_excited_pop_sum += fabs(levelpop);
     if (levelpop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
       printlnlog(
-          "  WARNING: cell {} ts {}: {} ion (Z={} ionstage {}) excited state (level {}) population too large to "
+          "  [warning] cell {} ts {}: {} ion (Z={} ionstage {}) excited state (level {}) population too large to "
           "remove ion (nlte_excited_pop_{}_ion / nnelement) = ({}/{}) > ({})",
           nltelog.modelgridindex, nltelog.timestep, ionname, get_atomicnumber(element), get_ionstage(element, ion),
           level, ionname, levelpop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
@@ -1147,7 +1148,7 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
     superlevel_pop = popvec[index_superlevel];
     if (superlevel_pop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
       printlnlog(
-          "  WARNING: cell {} ts {}: {} ion (Z={} ionstage {}) superlevel population too large to remove ion "
+          "  [warning] cell {} ts {}: {} ion (Z={} ionstage {}) superlevel population too large to remove ion "
           "(superlevel_pop_{}_ion / nnelement) = ({:g}/{:g}) > ({:g})",
           nltelog.modelgridindex, nltelog.timestep, ionname, get_atomicnumber(element), get_ionstage(element, ion),
           ionname, superlevel_pop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
@@ -1258,7 +1259,7 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
             atomic_number, get_ionstage(element, first_ion_used), get_ionstage(element, max_ion_used));
       }
     } else if (NLTE_LIMIT_ION_STAGES_AFTER_FAILURE) {
-      printlnlog("  WARNING: cell {} ts {}: NLTE matrix solution failed for element Z={} using ionstage {} to {}",
+      printlnlog("  [warning] cell {} ts {}: NLTE matrix solution failed for element Z={} using ionstage {} to {}",
                  nltelog.modelgridindex, nltelog.timestep, atomic_number, get_ionstage(element, first_ion_used),
                  get_ionstage(element, max_ion_used));
 
@@ -1273,7 +1274,7 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
         matrix_solve_required = true;
       } else {
         printlnlog(
-            "  WARNING: cell {} ts {}: can't remove top or bottom ion stage from NLTE equations, therefore unable to "
+            "  [warning] cell {} ts {}: can't remove top or bottom ion stage from NLTE equations, therefore unable to "
             "find an NLTE solution for element Z={}",
             nltelog.modelgridindex, nltelog.timestep, atomic_number);
       }
@@ -1306,7 +1307,7 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 
     if (ion < first_ion_used || ion >= (first_ion_used + nions_used)) {
       printlnlog(
-          "  WARNING: cell {} ts {}: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to "
+          "  [warning] cell {} ts {}: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to "
           "zero",
           modelgridindex, timestep, get_atomicnumber(element), get_ionstage(element, ion));
 
@@ -1343,7 +1344,7 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
   const double elem_pop_error_percent = fabs((nnelement / elem_pop_matrix) - 1) * 100;
   if (elem_pop_error_percent > 1.0) {
     printlnlog(
-        "  WARNING: timestep {} nlteiter {} Z={} element population is: {:g} (from abundance) and {:g} (from matrix "
+        "  [warning] timestep {} nlteiter {} Z={} element population is: {:g} (from abundance) and {:g} (from matrix "
         "solution), error: {:.2f}%. Forcing element pops to LTE.",
         timestep, nlte_iter, atomic_number, nnelement, elem_pop_matrix, elem_pop_error_percent);
     set_element_pops_lte(nonemptymgi, element);
@@ -1444,7 +1445,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
 
   if (!matrix_solve_success) {
     printlnlog(
-        "WARNING: Can't solve for NLTE populations in cell {} at timestep {} for element Z={} due to singular matrix, "
+        "[warning] Can't solve for NLTE populations in cell {} at timestep {} for element Z={} due to singular matrix, "
         "negative pop or large pop inversion and unable to recover solution by reducing ion range. Attempting to use "
         "LTE solution instead",
         modelgridindex, timestep, atomic_number);
@@ -1574,7 +1575,7 @@ void nltepop_read_restart_data(FILE* restart_file) {
   int total_nlte_levels_in = 0;
   assert_always(fscanf(restart_file, "%d\n", &total_nlte_levels_in) == 1);
   if (total_nlte_levels_in != globals::total_nlte_levels) {
-    printlnlog("ERROR: Expected {} NLTE levels but found {} in restart file", globals::total_nlte_levels,
+    printlnlog("[error] Expected {} NLTE levels but found {} in restart file", globals::total_nlte_levels,
                total_nlte_levels_in);
     std::abort();
   }

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -243,16 +243,17 @@ void print_level_rates_summary(const int element, const int selected_ion, const 
 
   for (int i = 0; i <= 3; i++) {
     // rates in from above, in from below, out to above, out to below
+    std::string rowprefix;
     if (i == 0) {
       const int nlevels_nlte = get_nlevels_excited_nlte(element, selected_ion);
       if (ion_has_superlevel(element, selected_ion) && (selected_level == nlevels_nlte + 1)) {
-        printlog("      superlevel ");
+        rowprefix = "      superlevel ";
       } else {
-        printlog("    level{:7} ", selected_level);
+        rowprefix = std::format("    level{:7} ", selected_level);
       }
-      printlog(" {:10.2e} ", popvec[selected_index]);
+      rowprefix += std::format(" {:10.2e} ", popvec[selected_index]);
     } else {
-      printlog("                             ");
+      rowprefix = std::string(29, ' ');
     }
 
     const bool into_level = (i <= 1);
@@ -274,21 +275,8 @@ void print_level_rates_summary(const int element, const int selected_ion, const 
     const double autoion_total =
         get_total_rate(selected_index, rate_matrices.autoion, popvec, into_level, only_levels_below, only_levels_above);
 
-    if (into_level) {
-      // into this level
-      printlog(" from ");
-    } else {
-      // out of this level
-      printlog("   to ");
-    }
-
-    if (only_levels_below) {
-      printlog("below ");
-    } else {
-      printlog("above ");
-    }
-
-    printlnlog("{:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e}", rad_bb_total, coll_bb_total,
+    printlnlog("{}{}{}{:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e}", rowprefix,
+               into_level ? " from " : "   to ", only_levels_below ? "below " : "above ", rad_bb_total, coll_bb_total,
                ntcoll_bb_total, rad_bf_total, coll_bf_total, ntcoll_bf_total, autoion_total);
   }
 }
@@ -1378,11 +1366,6 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
 
   if (grid::get_elem_massfrac(nonemptymgi, element) <= 0.) {
     // abundance of this element is zero, so do not store any NLTE populations
-    printlnlog(
-        "Not solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} due to zero "
-        "abundance",
-        modelgridindex, timestep, nlte_iter, atomic_number);
-
     nltepop_reset_element(nonemptymgi, element);
     return;
   }
@@ -1404,10 +1387,14 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
   const int nions = get_nions(element);
   const double nnelement = grid::get_elem_numberdens(nonemptymgi, element);
 
-  printlnlog(
-      "Solving for NLTE populations in cell {} at timestep {} NLTE iteration {} for element Z={} (mass fraction "
-      "{:.2e}, nnelement {:.2e} cm^-3)",
-      modelgridindex, timestep, nlte_iter, atomic_number, grid::get_elem_massfrac(nonemptymgi, element), nnelement);
+  if (nlte_iter == 0) {
+    // the per-iteration progress is summarised by the NLTE convergence messages in update_grid.cc,
+    // so this announcement is only made for the first iteration
+    printlnlog(
+        "Solving for NLTE populations in cell {} at timestep {} for element Z={} (mass fraction "
+        "{:.2e}, nnelement {:.2e} cm^-3)",
+        modelgridindex, timestep, atomic_number, grid::get_elem_massfrac(nonemptymgi, element), nnelement);
+  }
 
   const auto superlevel_partfuncs = get_element_superlevelpartfuncs(nonemptymgi, element);
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -252,17 +252,16 @@ void print_level_rates_summary(const int element, const int selected_ion, const 
 
   for (int i = 0; i <= 3; i++) {
     // rates in from above, in from below, out to above, out to below
-    std::string rowprefix;
     if (i == 0) {
       const int nlevels_nlte = get_nlevels_excited_nlte(element, selected_ion);
       if (ion_has_superlevel(element, selected_ion) && (selected_level == nlevels_nlte + 1)) {
-        rowprefix = "      superlevel ";
+        printlog("      superlevel ");
       } else {
-        rowprefix = std::format("    level{:7} ", selected_level);
+        printlog("    level{:7} ", selected_level);
       }
-      rowprefix += std::format(" {:10.2e} ", popvec[selected_index]);
+      printlog(" {:10.2e} ", popvec[selected_index]);
     } else {
-      rowprefix = std::string(29, ' ');
+      printlog("                             ");
     }
 
     const bool into_level = (i <= 1);
@@ -284,9 +283,9 @@ void print_level_rates_summary(const int element, const int selected_ion, const 
     const double autoion_total =
         get_total_rate(selected_index, rate_matrices.autoion, popvec, into_level, only_levels_below, only_levels_above);
 
-    printlnlog("{}{}{}{:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e}", rowprefix,
-               into_level ? " from " : "   to ", only_levels_below ? "below " : "above ", rad_bb_total, coll_bb_total,
-               ntcoll_bb_total, rad_bf_total, coll_bf_total, ntcoll_bf_total, autoion_total);
+    printlnlog("{}{}{:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e} {:10.2e}", into_level ? " from " : "   to ",
+               only_levels_below ? "below " : "above ", rad_bb_total, coll_bb_total, ntcoll_bb_total, rad_bf_total,
+               coll_bf_total, ntcoll_bf_total, autoion_total);
   }
 }
 
@@ -928,25 +927,28 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
 template <typename GetDiagElement>
 [[nodiscard]] auto lumatrix_is_singular(GetDiagElement getdiagelement, const size_t nlte_dimension, const int element,
                                         const int first_ion_used, const int nions_used) -> bool {
-  std::string disconnectedlist;
+  bool is_singular = false;
   for (auto i = 0ZU; i < nlte_dimension; i++) {
     // diagonal elements of LU matrix must be non-zero and finite
     const double matrixelement = getdiagelement(i);
     if (matrixelement == 0. || !std::isfinite(matrixelement)) {
+      if (!is_singular) {
+        printlog("  [error] cell {} ts {}: NLTE matrix is singular for element Z={} (disconnected:",
+                 nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+        is_singular = true;
+      }
       const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element, first_ion_used, nions_used);
       if (is_nlte(element, ion, level)) {
-        disconnectedlist += std::format(" ionstage {} level {}", get_ionstage(element, ion), level);
+        printlog(" ionstage {} level {}", get_ionstage(element, ion), level);
       } else {
-        disconnectedlist += std::format(" ionstage {} superlevel", get_ionstage(element, ion));
+        printlog(" ionstage {} superlevel", get_ionstage(element, ion));
       }
     }
   }
-  if (!disconnectedlist.empty()) {
-    printlnlog("  [error] cell {} ts {}: NLTE matrix is singular for element Z={} (disconnected:{})",
-               nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), disconnectedlist);
-    return true;
+  if (is_singular) {
+    printlnlog(")");
   }
-  return false;
+  return is_singular;
 }
 
 // solve rate_matrix * x = balance_vector, so that popvec[i] = x[i] * pop_normfactors[i]

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -306,8 +306,8 @@ void print_element_rates_summary(const int element, const int modelgridindex, co
       if (level == 0) {
         printlnlog(
             "  modelgridindex {} timestep {} NLTE iteration {} Te {:g} nne {:g}: NLTE summary for Z={} ionstage {}:",
-            modelgridindex, timestep, nlte_iter, grid::get_Te(nonemptymgi), grid::get_nne(nonemptymgi), atomic_number,
-            ionstage);
+            modelgridindex, timestep, nlte_iter, grid::Te_allcells[nonemptymgi], grid::get_nne(nonemptymgi),
+            atomic_number, ionstage);
         printlnlog(
             "                         pop       rates     bb_rad     bb_col   bb_ntcol     bf_rad     bf_col   "
             "bf_ntcol autoion");
@@ -336,7 +336,7 @@ void print_level_rates(const int nonemptymgi, const int timestep, const int elem
   printlnlog(
       "timestep {} cell {} Te {:g} nne {:g} NLTE level diagnostics for Z={} ionstage {} level {} rates into and out of "
       "this level",
-      timestep, grid::get_mgi_of_nonemptymgi(nonemptymgi), grid::get_Te(nonemptymgi), grid::get_nne(nonemptymgi),
+      timestep, grid::get_mgi_of_nonemptymgi(nonemptymgi), grid::Te_allcells[nonemptymgi], grid::get_nne(nonemptymgi),
       atomic_number, selected_ionstage, selected_level);
 
   const double rad_bb_in_total = get_total_rate_in(selected_index, rate_matrices.rad_bb, popvec);
@@ -478,7 +478,7 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
 void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, const int ion, const double t_mid,
                                    const std::span<const double> s_renorm, RateMatrices& rate_matrices,
                                    const int first_ion_used) {
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
   const int nlevels = get_nlevels(element, ion);
   const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
@@ -566,7 +566,7 @@ void nltepop_matrix_add_ionisation(const int nonemptymgi, const int element, con
                                    const std::span<const double> s_renorm_upperion, RateMatrices& rate_matrices,
                                    const int first_ion_used, const int nions_used) {
   assert_always((ion + 1) < (nions_used + first_ion_used));  // can't ionise top ion stage
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const float clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
   const int nionisinglevels = get_nlevels_ionising(element, ion);
   const int maxrecombininglevel = get_maxrecombininglevel(element, ion + 1);
@@ -666,7 +666,7 @@ void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element,
   const auto nlte_dimension = rate_matrices.used_nlte_dimension;
   const int max_ion_used = first_ion_used + nions_used - 1;
   assert_always(ion < max_ion_used);  // can't ionise top ion stage
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const float clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
   const int nlevels = get_nlevels(element, ion);
   for (int level = 0; level < nlevels; level++) {
@@ -1387,7 +1387,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
     return;
   }
 
-  const double cell_Te = grid::get_Te(nonemptymgi);
+  const double cell_Te = grid::Te_allcells[nonemptymgi];
 
   if (cell_Te == MINTEMP) {
     printlnlog(
@@ -1472,7 +1472,7 @@ DEVICE_FUNC auto superlevel_boltzmann(const int nonemptymgi, const int element, 
   // attached to the superlevel (see the comment in read_autoion_data())
   assert_testmodeonly(level_isinsuperlevel(element, ion, level) || level_isautoionising(element, ion, level));
   const int level_superlevel_start = get_nlevels_excited_nlte(element, ion) + 1;
-  const double T_exc = LTEPOP_EXCITATION_USE_TJ ? grid::get_TJ(nonemptymgi) : grid::get_Te(nonemptymgi);
+  const double T_exc = LTEPOP_EXCITATION_USE_TJ ? grid::TJ_allcells[nonemptymgi] : grid::Te_allcells[nonemptymgi];
   const double E_level = epsilon(element, ion, level);
   const double E_superlevel = epsilon(element, ion, level_superlevel_start);
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -856,8 +856,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
         if (population < -MINPOP) {
           printlnlog(
               "  [warning] negative pop = {:g} less than -MINPOP (-{:g}) unlikely a rounding error to zero so "
-              "returning "
-              "nltepop_matrix_solve fail",
+              "returning nltepop_matrix_solve fail",
               population, MINPOP);
           return false;
         }
@@ -1242,8 +1241,7 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
       }
     }
 
-    // calculate the normalisation factors and apply them to the matrix
-    // columns and balance vector elements
+    // calculate the normalisation factors and apply them to the matrix columns and balance vector elements
     THREADLOCALONHOST std::vector<double> pop_normfactors;
     pop_normfactors.reserve(max_nlte_dimension);
     pop_normfactors.resize(nlte_dimension);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -173,8 +173,8 @@ auto get_nlte_vector_index(const int element, const int ion, const int level, co
 }
 
 [[nodiscard]] auto get_ion_level_of_nlte_vector_index(const std::ptrdiff_t index, const int element,
-                                                      const int first_ion_used,
-                                                      const int nions_used) -> std::tuple<int, int> {
+                                                      const int first_ion_used, const int nions_used)
+    -> std::tuple<int, int> {
   // this could easily be optimized if need be
   for (int dion = first_ion_used; dion < first_ion_used + nions_used; dion++) {
     for (int dlevel = 0; dlevel < get_nlevels(element, dion); dlevel++) {
@@ -444,8 +444,8 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
   return superlevel_partfuncs;
 }
 
-[[nodiscard]] auto get_element_nlte_dimension(const int element, const int first_ion_used,
-                                              const int nions_used) -> int {
+[[nodiscard]] auto get_element_nlte_dimension(const int element, const int first_ion_used, const int nions_used)
+    -> int {
   assert_testmodeonly(nions_used >= 0);
   assert_testmodeonly(nions_used <= get_nions(element));
   assert_testmodeonly(first_ion_used >= 0);
@@ -1170,8 +1170,8 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
 auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemptymgi, const double t_mid,
                                              const double nnelement,
                                              const std::vector<std::vector<double>>& s_renorm_allions,
-                                             RateMatrices& rate_matrices,
-                                             std::vector<double>& popvec) -> std::tuple<bool, int, int> {
+                                             RateMatrices& rate_matrices, std::vector<double>& popvec)
+    -> std::tuple<bool, int, int> {
   const int atomic_number = get_atomicnumber(element);
   const int nions = get_nions(element);
   const auto max_nlte_dimension = get_max_nlte_dimension();
@@ -1464,8 +1464,8 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
 }
 
 // Get a Boltzman factor for a level within the super level (combined Non-LTE level)
-DEVICE_FUNC auto superlevel_boltzmann(const int nonemptymgi, const int element, const int ion,
-                                      const int level) -> double {
+DEVICE_FUNC auto superlevel_boltzmann(const int nonemptymgi, const int element, const int ion, const int level)
+    -> double {
   // autoionising levels are also allowed here: outside the NLTE solver their populations are
   // attached to the superlevel (see the comment in read_autoion_data())
   assert_testmodeonly(level_isinsuperlevel(element, ion, level) || level_isautoionising(element, ion, level));
@@ -1606,8 +1606,8 @@ void nltepop_read_restart_data(FILE* restart_file) {
   }
 }
 
-DEVICE_FUNC auto get_nlte_levelpop_over_rho(const int nonemptymgi, const int element, const int ion,
-                                            const int level) -> double {
+DEVICE_FUNC auto get_nlte_levelpop_over_rho(const int nonemptymgi, const int element, const int ion, const int level)
+    -> double {
   assert_testmodeonly(level > 0);  // ground state is stored separately
   assert_testmodeonly(level <= get_nlevels_excited_nlte(element, ion));
   return nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) +

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -164,8 +164,8 @@ auto get_nlte_vector_index(const int element, const int ion, const int level, co
 }
 
 [[nodiscard]] auto get_ion_level_of_nlte_vector_index(const std::ptrdiff_t index, const int element,
-                                                      const int first_ion_used, const int nions_used)
-    -> std::tuple<int, int> {
+                                                      const int first_ion_used,
+                                                      const int nions_used) -> std::tuple<int, int> {
   // this could easily be optimized if need be
   for (int dion = first_ion_used; dion < first_ion_used + nions_used; dion++) {
     for (int dlevel = 0; dlevel < get_nlevels(element, dion); dlevel++) {
@@ -447,8 +447,8 @@ auto get_element_superlevelpartfuncs(const int nonemptymgi, const int element) -
   return superlevel_partfuncs;
 }
 
-[[nodiscard]] auto get_element_nlte_dimension(const int element, const int first_ion_used, const int nions_used)
-    -> int {
+[[nodiscard]] auto get_element_nlte_dimension(const int element, const int first_ion_used,
+                                              const int nions_used) -> int {
   assert_testmodeonly(nions_used >= 0);
   assert_testmodeonly(nions_used <= get_nions(element));
   assert_testmodeonly(first_ion_used >= 0);
@@ -1138,8 +1138,8 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
     if (levelpop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
       printlnlog(
           "  WARNING: {} ion excited state (level {}) population too large to remove ion (nlte_excited_pop_{}_ion "
-          "/ nnelement) = ({}/{}) > ({}))",
-          ionname, ionname, level, levelpop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
+          "/ nnelement) = ({}/{}) > ({})",
+          ionname, level, ionname, levelpop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
       return false;
     }
   }
@@ -1172,8 +1172,8 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
 auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemptymgi, const double t_mid,
                                              const double nnelement,
                                              const std::vector<std::vector<double>>& s_renorm_allions,
-                                             RateMatrices& rate_matrices, std::vector<double>& popvec)
-    -> std::tuple<bool, int, int> {
+                                             RateMatrices& rate_matrices,
+                                             std::vector<double>& popvec) -> std::tuple<bool, int, int> {
   const int atomic_number = get_atomicnumber(element);
   const int nions = get_nions(element);
   const auto max_nlte_dimension = get_max_nlte_dimension();
@@ -1462,8 +1462,8 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
 }
 
 // Get a Boltzman factor for a level within the super level (combined Non-LTE level)
-DEVICE_FUNC auto superlevel_boltzmann(const int nonemptymgi, const int element, const int ion, const int level)
-    -> double {
+DEVICE_FUNC auto superlevel_boltzmann(const int nonemptymgi, const int element, const int ion,
+                                      const int level) -> double {
   // autoionising levels are also allowed here: outside the NLTE solver their populations are
   // attached to the superlevel (see the comment in read_autoion_data())
   assert_testmodeonly(level_isinsuperlevel(element, ion, level) || level_isautoionising(element, ion, level));
@@ -1604,8 +1604,8 @@ void nltepop_read_restart_data(FILE* restart_file) {
   }
 }
 
-DEVICE_FUNC auto get_nlte_levelpop_over_rho(const int nonemptymgi, const int element, const int ion, const int level)
-    -> double {
+DEVICE_FUNC auto get_nlte_levelpop_over_rho(const int nonemptymgi, const int element, const int ion,
+                                            const int level) -> double {
   assert_testmodeonly(level > 0);  // ground state is stored separately
   assert_testmodeonly(level <= get_nlevels_excited_nlte(element, ion));
   return nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) +

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -55,6 +55,15 @@ static_assert(STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING <
 namespace {
 std::fstream nlte_file;
 
+// context so that log messages from the NLTE solver helpers can identify the cell, timestep, and
+// iteration of the solve they were emitted from (set by solve_nlte_pops_element)
+struct NLTELogContext {
+  int modelgridindex = -1;
+  int timestep = -1;
+  int nlte_iter = -1;
+};
+THREADLOCALONHOST NLTELogContext nltelog{};
+
 struct RateMatrices {
   int used_nlte_dimension{0};
 
@@ -686,8 +695,9 @@ void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element,
       rate_matrices.autoion[(upper_index * nlte_dimension) + upper_index] -= R;
       rate_matrices.autoion[(lower_index * nlte_dimension) + upper_index] += R;
       if ((R < 0)) {
-        printlnlog("  WARNING: Negative autoionisation rate from ionstage {} level {} to level {}",
-                   get_ionstage(element, ion), level, target_level);
+        printlnlog("  WARNING: cell {} ts {}: negative autoionisation rate from Z={} ionstage {} level {} to level {}",
+                   nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), get_ionstage(element, ion),
+                   level, target_level);
       }
 
       // capture (which is an excitation process, and the first part of di-electronic recomb).
@@ -699,8 +709,9 @@ void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element,
       rate_matrices.autoion[(lower_index * nlte_dimension) + lower_index] -= R;
       rate_matrices.autoion[(upper_index * nlte_dimension) + lower_index] += R;
       if ((R < 0)) {
-        printlnlog("  WARNING: Negative autoionisation rate from ionstage {} level {} to level {}",
-                   get_ionstage(element, ion), level, target_level);
+        printlnlog("  WARNING: cell {} ts {}: negative autoionisation rate from Z={} ionstage {} level {} to level {}",
+                   nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), get_ionstage(element, ion),
+                   level, target_level);
       }
     }
   }
@@ -782,7 +793,8 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   // set_groundlevelpops uses uppermost_ion. Previously, this was set based on the NLTE phi factors. Therefore we need
   // to call find_uppermost_ion with force_saha = true so the uppermost ion used in set_groundlevelpops is changed to
   // the one based on the correct LTE phi factors instead
-  printlnlog("  WARNING: NLTEPOP setting element Z={} level pops to LTE", get_atomicnumber(element));
+  printlnlog("  WARNING: cell {} ts {}: NLTEPOP setting element Z={} level pops to LTE", nltelog.modelgridindex,
+             nltelog.timestep, get_atomicnumber(element));
   const double nne_hi = grid::get_rho(nonemptymgi) / MH;
   constexpr bool force_saha = true;
   grid::set_elements_uppermost_ion(nonemptymgi, element, find_uppermost_ion(nonemptymgi, element, nne_hi, force_saha));
@@ -812,16 +824,18 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
 
         if (!std::isfinite(ltepop) || ltepop <= 0.) {
           printlnlog(
-              "  WARNING: Boltzmann population for Z={} ionstage {} level {} is non-finite or non-positive ({}). "
-              "Setting to MINPOP",
-              get_atomicnumber(element), get_ionstage(element, ion), level, ltepop);
+              "  WARNING: cell {} ts {}: Boltzmann population for Z={} ionstage {} level {} is non-finite or "
+              "non-positive ({}). Setting to MINPOP",
+              nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), get_ionstage(element, ion), level,
+              ltepop);
           ltepop = MINPOP;
         }
 
         printlnlog(
-            "  WARNING: NLTE solver gave negative/non-finite population to index {} (Z={} ionstage {} level {}), pop = "
-            "{:g}. Replacing with LTE pop of {:g}",
-            index, get_atomicnumber(element), ionstage, level, population, ltepop);
+            "  WARNING: cell {} ts {}: NLTE solver gave negative/non-finite population to index {} (Z={} ionstage {} "
+            "level {}), pop = {:g}. Replacing with LTE pop of {:g}",
+            nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population,
+            ltepop);
         popvec[index] = ltepop;
       }
     } else {
@@ -829,17 +843,17 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
       const size_t index_ion_ground = get_nlte_vector_index(element, ion, 0, first_ion_used);
       if (index == index_ion_ground && population < MINPOP) {
         printlnlog(
-            "  WARNING: NLTE solver gave ground pop less than MINPOP for index {} (Z={} ionstage {} level {}), pop = "
-            "{:g}. Returning nltepop_matrix_solve fail",
-            index, get_atomicnumber(element), ionstage, level, population);
+            "  WARNING: cell {} ts {}: NLTE solver gave ground pop less than MINPOP for index {} (Z={} ionstage {} "
+            "level {}), pop = {:g}. Returning nltepop_matrix_solve fail",
+            nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         return false;
       }
 
       if (population < 0.0 || !std::isfinite(population)) {
         printlnlog(
-            "  WARNING: NLTE solver gave negative/non-finite population for index {} (Z={} ionstage {} level {}), pop "
-            "= {:g}",
-            index, get_atomicnumber(element), ionstage, level, population);
+            "  WARNING: cell {} ts {}: NLTE solver gave negative/non-finite population for index {} (Z={} ionstage {} "
+            "level {}), pop = {:g}",
+            nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         if (population < -MINPOP) {
           printlnlog(
               "  WARNING: negative pop = {:g} less than -MINPOP (-{:g}) unlikely a rounding error to zero so returning "
@@ -863,18 +877,19 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
           const double inversion_factor = (population / statweight) / (ground_pop / statweight_ground);
 
           if (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING) {
-            printlog(
-                " WARNING: pop inversion greater than factor {:g}: (g_pop {:g})/(e_pop {:g}) = {:g} is less "
-                "than (g_sw {:g})/(e_sw {:g}) = {:g} for index {} Z={} ionstage {} level {} (factor {:g} inversion) - ",
-                STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING, ground_pop, population,
-                ground_pop / population, statweight_ground, statweight, statweight_ground / statweight, index,
-                get_atomicnumber(element), ionstage, level, inversion_factor);
-
-            if (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_SOLVER_FAIL) {
-              printlnlog("large pop inversion - matrix solve failed");
+            const bool solve_failed = (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_SOLVER_FAIL);
+            printlnlog(
+                "  WARNING: cell {} ts {}: pop inversion greater than factor {:g}: (g_pop {:g})/(e_pop {:g}) = {:g} "
+                "is less than (g_sw {:g})/(e_sw {:g}) = {:g} for index {} Z={} ionstage {} level {} (factor {:g} "
+                "inversion) - {}",
+                nltelog.modelgridindex, nltelog.timestep, STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING,
+                ground_pop, population, ground_pop / population, statweight_ground, statweight,
+                statweight_ground / statweight, index, get_atomicnumber(element), ionstage, level, inversion_factor,
+                solve_failed ? "large pop inversion so matrix solve failed"
+                             : "relatively small pop inversion so continue with NLTE solution");
+            if (solve_failed) {
               return false;
             }
-            printlnlog("relatively small pop inversion so continue with NLTE solution");
           }
         } else {
           // check if the first sublevel in the superlevel is inverted relative to the ground state. Only need to check
@@ -885,25 +900,52 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
           const double inversion_factor = (sublevel_pop / statweight) / (ground_pop / statweight_ground);
           if (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING) {
             assert_testmodeonly(ion_has_superlevel(element, ion));
-            printlog(
-                " WARNING: superlevel pop inversion greater than factor {:g}: (g_pop {:g})/(SL_first_level_pop "
-                "{:g}) = {:g} is less than (g_sw {:g})/(SL_first_level_sw {:g}) = {:g} for index {} Z={} ionstage {} "
-                "level {} (factor {:g} inversion) - ",
-                STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING, ground_pop, sublevel_pop,
-                ground_pop / sublevel_pop, statweight_ground, statweight, statweight_ground / statweight, index,
-                get_atomicnumber(element), ionstage, level, inversion_factor);
-
-            if (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_SOLVER_FAIL) {
-              printlnlog("large pop inversion for superlevel - matrix solve failed");
+            const bool solve_failed = (inversion_factor > STRICT_POPULATION_CHECKING_INVERSION_FACTOR_SOLVER_FAIL);
+            printlnlog(
+                "  WARNING: cell {} ts {}: superlevel pop inversion greater than factor {:g}: (g_pop "
+                "{:g})/(SL_first_level_pop {:g}) = {:g} is less than (g_sw {:g})/(SL_first_level_sw {:g}) = {:g} for "
+                "index {} Z={} ionstage {} level {} (factor {:g} inversion) - {}",
+                nltelog.modelgridindex, nltelog.timestep, STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING,
+                ground_pop, sublevel_pop, ground_pop / sublevel_pop, statweight_ground, statweight,
+                statweight_ground / statweight, index, get_atomicnumber(element), ionstage, level, inversion_factor,
+                solve_failed ? "large pop inversion so matrix solve failed"
+                             : "relatively small pop inversion so continue with NLTE solution");
+            if (solve_failed) {
               return false;
             }
-            printlnlog("relatively small pop inversion for superlevel so continue with NLTE solution");
           }
         }
       }
     }
   }
   return true;
+}
+
+// Check the diagonal of an LU decomposition for zero or non-finite elements, which indicate levels that are
+// disconnected from the rest of the NLTE rate matrix. Reports and returns true if the matrix is singular.
+// Shared between the GSL and Eigen builds so that the log messages cannot drift apart.
+template <typename GetDiagElement>
+[[nodiscard]] auto lumatrix_is_singular(GetDiagElement getdiagelement, const size_t nlte_dimension, const int element,
+                                        const int first_ion_used, const int nions_used) -> bool {
+  std::string disconnectedlist;
+  for (auto i = 0ZU; i < nlte_dimension; i++) {
+    // diagonal elements of LU matrix must be non-zero and finite
+    const double matrixelement = getdiagelement(i);
+    if (matrixelement == 0. || !std::isfinite(matrixelement)) {
+      const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element, first_ion_used, nions_used);
+      if (is_nlte(element, ion, level)) {
+        disconnectedlist += std::format(" ionstage {} level {}", get_ionstage(element, ion), level);
+      } else {
+        disconnectedlist += std::format(" ionstage {} superlevel", get_ionstage(element, ion));
+      }
+    }
+  }
+  if (!disconnectedlist.empty()) {
+    printlnlog("  ERROR: cell {} ts {}: NLTE matrix is singular for element Z={} (disconnected:{})",
+               nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), disconnectedlist);
+    return true;
+  }
+  return false;
 }
 
 // solve rate_matrix * x = balance_vector, so that popvec[i] = x[i] * pop_normfactors[i]
@@ -948,27 +990,8 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   int s = 0;  // sign of the transformation
   assert_always(gsl_linalg_LU_decomp(&gsl_rate_matrix_LU_decomp, &p, &s) == GSL_SUCCESS);
 
-  bool lumatrix_is_singular = false;
-  for (auto i = 0ZU; i < nlte_dimension; i++) {
-    // diagonal elements of LU matrix must be non-zero and finite
-    const double& matrixelement = rate_matrix_LU_decomp[(i * nlte_dimension) + i];
-    if (matrixelement == 0. || !std::isfinite(matrixelement)) {
-      const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element, first_ion_used, nions_used);
-      if (!lumatrix_is_singular) {
-        printlog("ERROR: NLTE disconnected: Z={}", get_atomicnumber(element));
-      }
-      if (is_nlte(element, ion, level)) {
-        printlog(" ionstage {} level {}", get_ionstage(element, ion), level);
-      } else {
-        printlog(" ionstage {} superlevel ", get_ionstage(element, ion));
-      }
-
-      lumatrix_is_singular = true;
-    }
-  }
-  if (lumatrix_is_singular) {
-    printlnlog("");
-    printlnlog("  ERROR: NLTE matrix is singular for element Z={}!", get_atomicnumber(element));
+  if (lumatrix_is_singular([&](const size_t i) { return rate_matrix_LU_decomp[(i * nlte_dimension) + i]; },
+                           nlte_dimension, element, first_ion_used, nions_used)) {
     return false;
   }
 
@@ -990,27 +1013,9 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
       eigen_rate_matrix_lu;
 
   eigen_rate_matrix_lu.compute(eigen_rate_matrix);
-  bool lumatrix_is_singular = false;
-  for (auto i = 0ZU; i < nlte_dimension; i++) {
-    // diagonal elements of LU matrix must be non-zero and finite
-    const double& matrixelement = eigen_rate_matrix_lu.matrixLU().diagonal()[i];
-    if (matrixelement == 0. || !std::isfinite(matrixelement)) {
-      const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element, first_ion_used, nions_used);
-      if (!lumatrix_is_singular) {
-        printlog("ERROR: NLTE disconnected: Z={}", get_atomicnumber(element));
-      }
-      if (is_nlte(element, ion, level)) {
-        printlog(" ionstage {} level {}", get_ionstage(element, ion), level);
-      } else {
-        printlog(" ionstage {} superlevel ", get_ionstage(element, ion));
-      }
-
-      lumatrix_is_singular = true;
-    }
-  }
-  if (lumatrix_is_singular) {
-    printlnlog("");
-    printlnlog("ERROR: NLTE matrix is singular for element Z={}!", get_atomicnumber(element));
+  if (lumatrix_is_singular(
+          [&](const size_t i) { return eigen_rate_matrix_lu.matrixLU().diagonal()[static_cast<ptrdiff_t>(i)]; },
+          nlte_dimension, element, first_ion_used, nions_used)) {
     return false;
   }
 
@@ -1069,17 +1074,17 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   }
 
   if (!(error_best >= 0.)) {
-    printlnlog("  ERROR: NLTE solver failed to find a solution with finite error for element Z={}",
-               get_atomicnumber(element));
+    printlnlog("  ERROR: cell {} ts {}: NLTE solver failed to find a solution with finite error for element Z={}",
+               nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
     return false;
   }
   std::ranges::copy(vec_x_best, vec_x.begin());
 
   if (error_best > 1e-8) {
     printlnlog(
-        "  NLTE solver matrix LU_refine: After {} iterations, best solution vector has a max residual of {:g} "
-        "(WARNING!)",
-        iteration, error_best);
+        "  WARNING: cell {} ts {}: NLTE solver matrix LU_refine: after {} iterations, best solution vector has a max "
+        "residual of {:g}",
+        nltelog.modelgridindex, nltelog.timestep, iteration, error_best);
   }
 
   // get the unnormalised populations from the x solution vector and the normalisation factors
@@ -1094,8 +1099,10 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
                     const double nnelement, std::span<const double> popvec) -> bool {
   if (nions_used <= 1) {
     // can't remove an ion if there is only one ion stage used in the NLTE matrix
-    printlnlog("  WARNING: can't remove ion stage {} from NLTE matrix for element Z={} as only one ion stage used",
-               get_ionstage(element, ion), get_atomicnumber(element));
+    printlnlog(
+        "  WARNING: cell {} ts {}: can't remove ion stage {} from NLTE matrix for element Z={} as only one ion stage "
+        "used",
+        nltelog.modelgridindex, nltelog.timestep, get_ionstage(element, ion), get_atomicnumber(element));
     return false;
   }
 
@@ -1108,10 +1115,10 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
   if (ground_pop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
     // ground pop relative to the element population must not exceed the limit
     printlnlog(
-        "  WARNING: {} ion ground state population too large to remove ion (ground_pop / nnelement) = ({}/{}) = {} "
-        "> {}",
-        ionname, ground_pop, nnelement, ground_pop / nnelement,
-        NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
+        "  WARNING: cell {} ts {}: {} ion (Z={} ionstage {}) ground state population too large to remove ion "
+        "(ground_pop / nnelement) = ({}/{}) = {} > {}",
+        nltelog.modelgridindex, nltelog.timestep, ionname, get_atomicnumber(element), get_ionstage(element, ion),
+        ground_pop, nnelement, ground_pop / nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
 
     return false;
   }
@@ -1125,9 +1132,10 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
     nlte_excited_pop_sum += fabs(levelpop);
     if (levelpop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
       printlnlog(
-          "  WARNING: {} ion excited state (level {}) population too large to remove ion (nlte_excited_pop_{}_ion "
-          "/ nnelement) = ({}/{}) > ({})",
-          ionname, level, ionname, levelpop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
+          "  WARNING: cell {} ts {}: {} ion (Z={} ionstage {}) excited state (level {}) population too large to "
+          "remove ion (nlte_excited_pop_{}_ion / nnelement) = ({}/{}) > ({})",
+          nltelog.modelgridindex, nltelog.timestep, ionname, get_atomicnumber(element), get_ionstage(element, ion),
+          level, ionname, levelpop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
       return false;
     }
   }
@@ -1139,9 +1147,10 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
     superlevel_pop = popvec[index_superlevel];
     if (superlevel_pop / nnelement > NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION) {
       printlnlog(
-          "  WARNING: {} ion superlevel population too large to remove ion (superlevel_pop_{}_ion / nnelement "
-          "({:g}/{:g}) > ({:g}) NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION)",
-          ionname, ionname, superlevel_pop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
+          "  WARNING: cell {} ts {}: {} ion (Z={} ionstage {}) superlevel population too large to remove ion "
+          "(superlevel_pop_{}_ion / nnelement) = ({:g}/{:g}) > ({:g})",
+          nltelog.modelgridindex, nltelog.timestep, ionname, get_atomicnumber(element), get_ionstage(element, ion),
+          ionname, superlevel_pop, nnelement, NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION);
       return false;
     }
   }
@@ -1249,8 +1258,9 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
             atomic_number, get_ionstage(element, first_ion_used), get_ionstage(element, max_ion_used));
       }
     } else if (NLTE_LIMIT_ION_STAGES_AFTER_FAILURE) {
-      printlnlog("  WARNING: NLTE matrix solution failed for element Z={} using ionstage {} to {}", atomic_number,
-                 get_ionstage(element, first_ion_used), get_ionstage(element, max_ion_used));
+      printlnlog("  WARNING: cell {} ts {}: NLTE matrix solution failed for element Z={} using ionstage {} to {}",
+                 nltelog.modelgridindex, nltelog.timestep, atomic_number, get_ionstage(element, first_ion_used),
+                 get_ionstage(element, max_ion_used));
 
       if (can_remove_ion(element, max_ion_used, first_ion_used, nions_used, nnelement, popvec)) {
         // we can remove the top ion from the solution
@@ -1263,8 +1273,9 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
         matrix_solve_required = true;
       } else {
         printlnlog(
-            "  WARNING: can't remove top or bottom ion stage from NLTE equations, therefore unable to find an NLTE "
-            "solution for this element");
+            "  WARNING: cell {} ts {}: can't remove top or bottom ion stage from NLTE equations, therefore unable to "
+            "find an NLTE solution for element Z={}",
+            nltelog.modelgridindex, nltelog.timestep, atomic_number);
       }
     }
   }
@@ -1294,8 +1305,10 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
     const int nlevels_excited_nlte = get_nlevels_excited_nlte(element, ion);
 
     if (ion < first_ion_used || ion >= (first_ion_used + nions_used)) {
-      printlnlog("  WARNING: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to zero ",
-                 get_atomicnumber(element), get_ionstage(element, ion));
+      printlnlog(
+          "  WARNING: cell {} ts {}: Z={} ionstage {} removed from NLTE rate matrix. Setting all levelpops for ion to "
+          "zero",
+          modelgridindex, timestep, get_atomicnumber(element), get_ionstage(element, ion));
 
       set_groundlevelpop(nonemptymgi, element, ion, 0.);
 
@@ -1363,6 +1376,7 @@ void solve_nlte_pops_element(const int element, const int nonemptymgi, const int
 
   const int atomic_number = get_atomicnumber(element);
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+  nltelog = {.modelgridindex = modelgridindex, .timestep = timestep, .nlte_iter = nlte_iter};
 
   if (grid::get_elem_massfrac(nonemptymgi, element) <= 0.) {
     // abundance of this element is zero, so do not store any NLTE populations

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1249,8 +1249,7 @@ void calculate_eff_ionpot_auger_rates(const int nonemptymgi, const int element, 
 
   // The ionisation rates of all shells of an ion add to make the ion's total ionisation rate,
   // i.e., Gamma_ion = Gamma_shell_a + Gamma_shell_b + ...
-  // And since the ionisation rate is inversely proportional to the effective ion potential,
-  // we solve:
+  // And since the ionisation rate is inversely proportional to the effective ion potential, we solve:
   // (eta_ion / ionpot_ion) = (eta_shell_a / ionpot_shell_a) + (eta_shell_b / ionpot_shell_b) + ...
   // where eta is the fraction of the deposition energy going into ionisation of the ion or shell
 
@@ -1961,8 +1960,7 @@ void sfmatrix_add_ionisation(std::span<double> sfmatrixuppertri, const int Z, co
         int augerstopindex = 0;
         if constexpr (SF_AUGER_CONTRIBUTION_DISTRIBUTE_EN) {
           // en_auger_ev is (if LJS understands it correctly) averaged to include some probability of zero Auger
-          // electrons so we need a boost to get the average energy of Auger electrons given that there are one or
-          // more
+          // electrons so we need a boost to get the average energy of Auger electrons given that there are one or more
           const double en_boost = 1 / (1. - collionrow.prob_num_auger[0]);
 
           augerstopindex = get_energyindex_ev_gteq(en_auger_ev * en_boost);
@@ -2357,8 +2355,7 @@ DEVICE_FUNC void do_ntlepton_deposit(Packet& pkt) {
     // instead of converting directly to k-packet (unless the heating channel is selected)
 
     double zrand = rng_uniform(get_rngstate(pkt));
-    // zrand is initially between [0, 1), but we will subtract off each
-    // component of the deposition fractions
+    // zrand is initially between [0, 1), but we will subtract off each component of the deposition fractions
     // until we end and select transition_ij when zrand < dep_frac_transition_ij
 
     // Gate on the stored ionisation fraction so that the k-packet probability below is exactly
@@ -2445,8 +2442,7 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
   } else if (get_ntlepton_deposition_rate_density(nonemptymgi) / EV < MINDEPRATE) {
     printlnlog(
         "Non-thermal deposition rate of {:g} [eV/s/cm^3] below MINDEPRATE {:g} [eV/s/cm^3] in cell {} at timestep {}. "
-        "Skipping "
-        "Spencer-Fano solution.",
+        "Skipping Spencer-Fano solution.",
         get_ntlepton_deposition_rate_density(nonemptymgi) / EV, MINDEPRATE, modelgridindex, timestep);
 
     skip_solution = true;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -623,7 +623,7 @@ void read_collion_data() {
       if (!any_data_matched) {
         const double ionpot_ev = get_ionpot(element, ion) / EV;
         printlnlog(
-            "No collisional ionisation data for Z={} ionstage {}. Using Lotz approximation with ionpot = {:g} eV", Z,
+            "No collisional ionisation data for Z={} ionstage {}. Using Lotz approximation with ionpot = {:g} [eV]", Z,
             ionstage, ionpot_ev);
 
         // get the approximate shell occupancy if we don't have the data file
@@ -1565,7 +1565,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
           } else {
             printlog("{} (Lotz)", shellnames.at(-collionrow.l));
           }
-          printlog(" I {:5.1f} eV: frac_ionisation {:10.4e}", collionrow.ionpot_ev, frac_ionisation_ion_shell);
+          printlog(" I {:5.1f} [eV]: frac_ionisation {:10.4e}", collionrow.ionpot_ev, frac_ionisation_ion_shell);
 
           if (NT_MAX_AUGER_ELECTRONS > 0) {
             printlog("  prob(n Auger elec):");
@@ -1660,9 +1660,9 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
       frac_excitation_total += frac_excitation_ion;
 
       if (verbose) {
-        printlnlog("    approxworkfn: {:9.2f} eV  (without using the Spencer-Fano solution)",
+        printlnlog("    approxworkfn: {:9.2f} [eV]  (without using the Spencer-Fano solution)",
                    (1. / get_oneoverw_approx_axelrod(element, ion, nonemptymgi)) / EV);
-        printlnlog("    eff_ionpot:   {:9.2f} eV  (always use valence potential is {})",
+        printlnlog("    eff_ionpot:   {:9.2f} [eV]  (always use valence potential is {})",
                    get_eff_ionpot(nonemptymgi, element, ion) / EV, (NT_USE_VALENCE_IONPOTENTIAL ? "true" : "false"));
 
         printlnlog("    approxworkfn Gamma:      {:9.3e}", nt_ionisation_ratecoeff_wfapprox(nonemptymgi, element, ion));
@@ -1807,10 +1807,10 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
   const double frac_sum = frac_heating_calculated + frac_excitation_total + frac_ionisation_total;
 
   if (verbose) {
-    printlnlog("  deposition:  {:9.2f} eV/s/cm^3", deposition_rate_density_ev);
-    printlnlog("  nne:         {:9.3e} e-/cm^3", nne);
-    printlnlog("  nnetot:      {:9.3e} e-/cm^3", nnetot);
-    printlnlog("  nne_nt     < {:9.3e} e-/cm^3", nne_nt_max);
+    printlnlog("  deposition:  {:9.2f} [eV/s/cm^3]", deposition_rate_density_ev);
+    printlnlog("  nne:         {:9.3e} [e-/cm^3]", nne);
+    printlnlog("  nnetot:      {:9.3e} [e-/cm^3]", nnetot);
+    printlnlog("  nne_nt     < {:9.3e} [e-/cm^3]", nne_nt_max);
     printlnlog("  nne_nt/nne < {:9.3e}", nne_nt_max / nne);
 
     printlnlog("  frac_heating_tot:    {:g}", frac_heating_calculated);
@@ -2110,8 +2110,8 @@ void init() {
   printlnlog("  NTEXCITATION_MAXNLEVELS_LOWER {}", NTEXCITATION_MAXNLEVELS_LOWER);
   printlnlog("  NTEXCITATION_MAXNLEVELS_UPPER {}", NTEXCITATION_MAXNLEVELS_UPPER);
   printlnlog("  SFPTS {}", SFPTS);
-  printlnlog("  SF_EMIN {:g} eV", SF_EMIN);
-  printlnlog("  SF_EMAX {:g} eV", SF_EMAX);
+  printlnlog("  SF_EMIN {:g} [eV]", SF_EMIN);
+  printlnlog("  SF_EMAX {:g} [eV]", SF_EMAX);
   printlnlog("  NT_USE_VALENCE_IONPOTENTIAL {}", NT_USE_VALENCE_IONPOTENTIAL ? "on" : "off");
   printlnlog("  NT_MAX_AUGER_ELECTRONS {}", NT_MAX_AUGER_ELECTRONS);
   printlnlog("  SF_AUGER_CONTRIBUTION {}", SF_AUGER_CONTRIBUTION_ON ? "on" : "off");
@@ -2119,7 +2119,7 @@ void init() {
 
   if (NT_EXCITATION_ON) {
     nt_excitations_stored = std::min(MAX_NT_EXCITATIONS_STORED, get_possible_nt_excitation_count());
-    printlnlog("[info] mem_usage: storing {} non-thermal excitations for non-empty cells occupies {:.3f} MB",
+    printlnlog("[info] mem_usage: storing {} non-thermal excitations for non-empty cells occupies {:.3f} [MB]",
                nt_excitations_stored,
                nonempty_npts_model * sizeof(NonThermalExcitation) * nt_excitations_stored / 1024. / 1024.);
 
@@ -2150,7 +2150,7 @@ void init() {
   const double sourceintegral = std::ranges::fold_left(
       std::views::iota(0, SFPTS), 0.0, [](double sum, int s) { return sum + (sourcevec(s) * DELTA_E); });
 
-  printlnlog("E_init: {:14.7e} eV/s/cm3", E_init_ev);
+  printlnlog("E_init: {:14.7e} [eV/s/cm^3]", E_init_ev);
   printlnlog("source function integral: {:14.7e}", sourceintegral);
 
   read_collion_data();
@@ -2445,7 +2445,8 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
     skip_solution = true;
   } else if (get_ntlepton_deposition_rate_density(nonemptymgi) / EV < MINDEPRATE) {
     printlnlog(
-        "Non-thermal deposition rate of {:g} eV/s/cm^3 below MINDEPRATE {:g} in cell {} at timestep {}. Skipping "
+        "Non-thermal deposition rate of {:g} [eV/s/cm^3] below MINDEPRATE {:g} [eV/s/cm^3] in cell {} at timestep {}. "
+        "Skipping "
         "Spencer-Fano solution.",
         get_ntlepton_deposition_rate_density(nonemptymgi) / EV, MINDEPRATE, modelgridindex, timestep);
 
@@ -2490,8 +2491,8 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
     return;
   }
   printlnlog(
-      "Setting up Spencer-Fano equation with {} energy points from {:g} eV to {:g} eV in cell {} at timestep {} "
-      "iteration {} (nne={:g} e-/cm^3)",
+      "Setting up Spencer-Fano equation with {} energy points from {:g} [eV] to {:g} [eV] in cell {} at timestep {} "
+      "iteration {} (nne={:g} [e-/cm^3])",
       SFPTS, SF_EMIN, SF_EMAX, modelgridindex, timestep, iteration, nne);
 
   nt_solution[nonemptymgi].nneperion_when_solved = static_cast<float>(nne_per_ion);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2118,7 +2118,7 @@ void init() {
 
   if (NT_EXCITATION_ON) {
     nt_excitations_stored = std::min(MAX_NT_EXCITATIONS_STORED, get_possible_nt_excitation_count());
-    printlnlog("[info] mem_usage: storing {} non-thermal excitations for non-empty cells occupies {:.3f} [MB]",
+    printlnlog("[info] mem_usage: storing {} non-thermal excitations for non-empty cells occupies {:.3f} MB",
                nt_excitations_stored,
                nonempty_npts_model * sizeof(NonThermalExcitation) * nt_excitations_stored / 1024. / 1024.);
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -385,28 +385,27 @@ void check_auger_probabilities(const ptrdiff_t nonemptymgi) {
       }
 
       if (fabs(prob_sum - 1.0) > 0.001) {
-        std::string probliststr;
-        for (int a = 0; a <= NT_MAX_AUGER_ELECTRONS; a++) {
-          probliststr += std::format(" {}:{:g}", a, get_auger_probability(nonemptymgi, element, ion, a));
-        }
-        printlnlog(
+        printlog(
             "[error] Auger probabilities sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
-            "P(n_Auger):{}",
-            prob_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element), get_ionstage(element, ion),
-            probliststr);
+            "P(n_Auger):",
+            prob_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element), get_ionstage(element, ion));
+        for (int a = 0; a <= NT_MAX_AUGER_ELECTRONS; a++) {
+          printlog(" {}:{:g}", a, get_auger_probability(nonemptymgi, element, ion, a));
+        }
+        printlnlog("");
         problem_found = true;
       }
 
       if (fabs(ionenfrac_sum - 1.0) > 0.001) {
-        std::string enfracliststr;
-        for (int a = 0; a <= NT_MAX_AUGER_ELECTRONS; a++) {
-          enfracliststr += std::format(" {}:{:g}", a, get_ion_auger_enfrac(nonemptymgi, element, ion, a));
-        }
-        printlnlog(
+        printlog(
             "[error] Auger energy fractions sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
-            "enfrac(n_Auger):{}",
+            "enfrac(n_Auger):",
             ionenfrac_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element),
-            get_ionstage(element, ion), enfracliststr);
+            get_ionstage(element, ion));
+        for (int a = 0; a <= NT_MAX_AUGER_ELECTRONS; a++) {
+          printlog(" {}:{:g}", a, get_ion_auger_enfrac(nonemptymgi, element, ion, a));
+        }
+        printlnlog("");
         problem_found = true;
       }
     }
@@ -2510,7 +2509,6 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
     sfmatrix[uppertriangular(i, i)] += electron_loss_rate(engrid(i) * EV, nne) / EV;
   }
 
-  std::string includedionsstr;
   for (int element = 0; element < get_nelements(); element++) {
     const int Z = get_atomicnumber(element);
     const int nions = get_nions(element);
@@ -2525,11 +2523,14 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
 
       const int ionstage = get_ionstage(element, ion);
       if (first_included_ion_of_element) {
-        includedionsstr += std::format(" Z={} ionstages", Z);
+        printlog("  including Z={:2} ionstages: ", Z);
+        for (int i = 1; i < get_ionstage(element, ion); i++) {
+          printlog("  ");
+        }
         first_included_ion_of_element = false;
       }
 
-      includedionsstr += std::format(" {}", ionstage);
+      printlog("{} ", ionstage);
 
       sfmatrix_add_excitation(sfmatrix, nonemptymgi, element, ion);
 
@@ -2537,13 +2538,9 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
         sfmatrix_add_ionisation(sfmatrix, Z, ionstage, nnion);
       }
     }
-  }
-
-  // the included set rarely changes between solves, so only log it when it differs from the last report
-  THREADLOCALONHOST auto last_logged_includedionsstr = std::string();
-  if (includedionsstr != last_logged_includedionsstr) {
-    last_logged_includedionsstr = includedionsstr;
-    printlnlog("  including{} (list logged when it changes)", includedionsstr);
+    if (!first_included_ion_of_element) {
+      printlnlog("");
+    }
   }
 
   decompactify_triangular_matrix(sfmatrix);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -770,8 +770,8 @@ void zero_all_effionpot(const ptrdiff_t nonemptymgi) {
   return std::lerp(ybelow, yabove, (energy_ev - enbelow) / (enabove - enbelow));
 }
 
-constexpr auto xs_ionisation_lotz(const double en_erg, const ShellParams& colliondata_ion,
-                                  const int electronsinshell) -> double {
+constexpr auto xs_ionisation_lotz(const double en_erg, const ShellParams& colliondata_ion, const int electronsinshell)
+    -> double {
   const double ionpot = colliondata_ion.ionpot_ev * EV;
   if (en_erg < ionpot) {
     return 0.;
@@ -858,8 +858,8 @@ auto get_xs_ionisation_vector(std::array<double, SFPTS>& xs_vec, const ShellPara
 
 // distribution of secondary electron energies for primary electron with energy e_p
 // Opal, Peterson, & Beaty (1971)
-[[nodiscard]] constexpr auto Psecondary(const double e_p, const double en_epsilon, const double I,
-                                        const double J) -> double {
+[[nodiscard]] constexpr auto Psecondary(const double e_p, const double en_epsilon, const double I, const double J)
+    -> double {
   const double e_s = en_epsilon - I;
 
   if (e_p <= I || e_s < 0.) {
@@ -1166,8 +1166,8 @@ auto get_oneoverw_approx_axelrod(const int element, const int ion, const int non
 
 // the fraction of deposited energy that goes into ionising electrons in a particular shell
 auto calculate_nt_frac_ionisation_shell(const int nonemptymgi, const int element, const int ion,
-                                        const ShellParams& collionrow,
-                                        const std::array<double, SFPTS>& yfunc) -> double {
+                                        const ShellParams& collionrow, const std::array<double, SFPTS>& yfunc)
+    -> double {
   const double nnion = get_nnion(nonemptymgi, element, ion);
   const double ionpot_ev = collionrow.ionpot_ev;
 
@@ -1194,8 +1194,8 @@ auto nt_ionisation_ratecoeff_wfapprox(const int nonemptymgi, const int element, 
 // propagation, as the y vector may not be in memory! IMPORTANT: we are dividing by the shell potential, not the
 // valence potential here! To change this set assumeshellpotentialisvalence to true
 auto calculate_nt_ionisation_ratecoeff(const int nonemptymgi, const int element, const int ion,
-                                       const bool assumeshellpotentialisvalence,
-                                       const std::array<double, SFPTS>& yfunc) -> double {
+                                       const bool assumeshellpotentialisvalence, const std::array<double, SFPTS>& yfunc)
+    -> double {
   std::array<double, SFPTS> cross_section_vec{};
   std::array<double, SFPTS> cross_section_vec_allshells{};
 
@@ -1362,8 +1362,8 @@ auto nt_ionisation_ratecoeff_sf(const int nonemptymgi, const int element, const 
 // epsilon_trans is in erg
 // returns the index of the first valid cross section point (en >= epsilon_trans)
 // all elements below this index are invalid and should not be used
-auto get_xs_excitation_vector(const int alltransindex, const double statweight_lower,
-                              const double epsilon_trans) -> std::tuple<std::array<double, SFPTS>, int> {
+auto get_xs_excitation_vector(const int alltransindex, const double statweight_lower, const double epsilon_trans)
+    -> std::tuple<std::array<double, SFPTS>, int> {
   std::array<double, SFPTS> xs_excitation_vec{};
   if (epsilon_trans / EV > SF_EMAX) {
     // the excitation threshold is above the top of the energy grid, so the cross section is zero at
@@ -1425,8 +1425,8 @@ auto get_xs_excitation_vector(const int alltransindex, const double statweight_l
 // Kozma & Fransson equation 9 divided by level population and epsilon_trans
 // returns the rate coefficient in s^-1 divided by deposition rate density in erg/cm^3/s
 auto calculate_nt_excitation_ratecoeff_perdeposition(const std::array<double, SFPTS>& yvec, const int alltransindex,
-                                                     const double statweight_lower,
-                                                     const double epsilon_trans) -> double {
+                                                     const double statweight_lower, const double epsilon_trans)
+    -> double {
   const auto [xs_excitation_vec, xsstartindex] =
       get_xs_excitation_vector(alltransindex, statweight_lower, epsilon_trans);
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1732,7 +1732,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
     nt_solution[nonemptymgi].frac_excitations_list_size = static_cast<int>(std::ssize(tmp_excitation_list));
     std::ranges::copy(tmp_excitation_list, get_cell_ntexcitations(nonemptymgi).begin());
 
-    const auto T_e = grid::get_Te(nonemptymgi);
+    const auto T_e = grid::Te_allcells[nonemptymgi];
     if (verbose) {
       printlnlog("  Top non-thermal excitation fractions (total excitations = {}):",
                  nt_solution[nonemptymgi].frac_excitations_list_size);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -743,8 +743,8 @@ void zero_all_effionpot(const ptrdiff_t nonemptymgi) {
   return std::lerp(ybelow, yabove, (energy_ev - enbelow) / (enabove - enbelow));
 }
 
-constexpr auto xs_ionisation_lotz(const double en_erg, const ShellParams& colliondata_ion, const int electronsinshell)
-    -> double {
+constexpr auto xs_ionisation_lotz(const double en_erg, const ShellParams& colliondata_ion,
+                                  const int electronsinshell) -> double {
   const double ionpot = colliondata_ion.ionpot_ev * EV;
   if (en_erg < ionpot) {
     return 0.;
@@ -831,8 +831,8 @@ auto get_xs_ionisation_vector(std::array<double, SFPTS>& xs_vec, const ShellPara
 
 // distribution of secondary electron energies for primary electron with energy e_p
 // Opal, Peterson, & Beaty (1971)
-[[nodiscard]] constexpr auto Psecondary(const double e_p, const double en_epsilon, const double I, const double J)
-    -> double {
+[[nodiscard]] constexpr auto Psecondary(const double e_p, const double en_epsilon, const double I,
+                                        const double J) -> double {
   const double e_s = en_epsilon - I;
 
   if (e_p <= I || e_s < 0.) {
@@ -1138,8 +1138,8 @@ auto get_oneoverw_approx_axelrod(const int element, const int ion, const int non
 
 // the fraction of deposited energy that goes into ionising electrons in a particular shell
 auto calculate_nt_frac_ionisation_shell(const int nonemptymgi, const int element, const int ion,
-                                        const ShellParams& collionrow, const std::array<double, SFPTS>& yfunc)
-    -> double {
+                                        const ShellParams& collionrow,
+                                        const std::array<double, SFPTS>& yfunc) -> double {
   const double nnion = get_nnion(nonemptymgi, element, ion);
   const double ionpot_ev = collionrow.ionpot_ev;
 
@@ -1166,8 +1166,8 @@ auto nt_ionisation_ratecoeff_wfapprox(const int nonemptymgi, const int element, 
 // propagation, as the y vector may not be in memory! IMPORTANT: we are dividing by the shell potential, not the
 // valence potential here! To change this set assumeshellpotentialisvalence to true
 auto calculate_nt_ionisation_ratecoeff(const int nonemptymgi, const int element, const int ion,
-                                       const bool assumeshellpotentialisvalence, const std::array<double, SFPTS>& yfunc)
-    -> double {
+                                       const bool assumeshellpotentialisvalence,
+                                       const std::array<double, SFPTS>& yfunc) -> double {
   std::array<double, SFPTS> cross_section_vec{};
   std::array<double, SFPTS> cross_section_vec_allshells{};
 
@@ -1339,8 +1339,8 @@ auto nt_ionisation_ratecoeff_sf(const int nonemptymgi, const int element, const 
 // epsilon_trans is in erg
 // returns the index of the first valid cross section point (en >= epsilon_trans)
 // all elements below this index are invalid and should not be used
-auto get_xs_excitation_vector(const int alltransindex, const double statweight_lower, const double epsilon_trans)
-    -> std::tuple<std::array<double, SFPTS>, int> {
+auto get_xs_excitation_vector(const int alltransindex, const double statweight_lower,
+                              const double epsilon_trans) -> std::tuple<std::array<double, SFPTS>, int> {
   std::array<double, SFPTS> xs_excitation_vec{};
   if (epsilon_trans / EV > SF_EMAX) {
     // the excitation threshold is above the top of the energy grid, so the cross section is zero at
@@ -1402,8 +1402,8 @@ auto get_xs_excitation_vector(const int alltransindex, const double statweight_l
 // Kozma & Fransson equation 9 divided by level population and epsilon_trans
 // returns the rate coefficient in s^-1 divided by deposition rate density in erg/cm^3/s
 auto calculate_nt_excitation_ratecoeff_perdeposition(const std::array<double, SFPTS>& yvec, const int alltransindex,
-                                                     const double statweight_lower, const double epsilon_trans)
-    -> double {
+                                                     const double statweight_lower,
+                                                     const double epsilon_trans) -> double {
   const auto [xs_excitation_vec, xsstartindex] =
       get_xs_excitation_vector(alltransindex, statweight_lower, epsilon_trans);
 
@@ -2019,8 +2019,7 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
 #endif
 
   double error_best = -1.;
-  int iteration = 0;
-  for (iteration = 0; iteration < 10; iteration++) {
+  for (int iteration = 0; iteration < 10; iteration++) {
 #ifdef EIGEN_OFF
     if (iteration > 0) {
       // use gsl_vec_residual as the temporary work vector
@@ -2049,8 +2048,7 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
   std::ranges::copy(yvec_best, yvec_arr.begin());
 
   if (error_best > 1e-10) {
-    printlnlog("  SF solver LU_refine: After {} iterations, best solution vector has a max residual of {:g}", iteration,
-               error_best);
+    printlnlog("  SF solver LU_refine: best solution vector has a max residual of {:g}", error_best);
   }
 
   assert_always(std::ranges::all_of(yvec_arr, [](double y) { return y >= 0.; }));
@@ -2420,7 +2418,7 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
     skip_solution = true;
   } else if (get_ntlepton_deposition_rate_density(nonemptymgi) / EV < MINDEPRATE) {
     printlnlog(
-        "Non-thermal deposition rate of {:g} eV/cm/s/cm^3 below  MINDEPRATE {:g} in cell {} at timestep {}. Skipping "
+        "Non-thermal deposition rate of {:g} eV/s/cm^3 below MINDEPRATE {:g} in cell {} at timestep {}. Skipping "
         "Spencer-Fano solution.",
         get_ntlepton_deposition_rate_density(nonemptymgi) / EV, MINDEPRATE, modelgridindex, timestep);
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -667,6 +667,27 @@ void read_collion_data() {
     return std::tie(a.Z, a.ionstage, a.ionpot_ev, a.n, a.l) < std::tie(b.Z, b.ionstage, b.ionpot_ev, b.n, b.l);
   });
 
+  // this condition is checked here once per ion (it does not depend on the cell), so that
+  // calculate_eff_ionpot_auger_rates does not have to report it for every cell
+  for (int element = 0; element < get_nelements(); element++) {
+    const int Z = get_atomicnumber(element);
+    for (int ion = 0; ion < get_nions(element); ion++) {
+      const int ionstage = get_ionstage(element, ion);
+      if ((Z - (ionstage - 1)) <= 0) {
+        continue;  // no bound electrons, so no NT impact ionisation
+      }
+      const bool any_subshells = std::ranges::any_of(colliondata, [Z, ionstage](const ShellParams& collionrow) {
+        return collionrow.Z == Z && collionrow.ionstage == ionstage;
+      });
+      if (!any_subshells) {
+        printlnlog(
+            "[warning] no NT impact ionisation subshell data for Z={} ionstage {}: the Spencer-Fano solver will "
+            "default to the work function approximation and not account for the ionisation energy",
+            Z, ionstage);
+      }
+    }
+  }
+
   if (NT_MAX_AUGER_ELECTRONS > 0) {
     read_auger_data();
   }
@@ -1308,12 +1329,7 @@ void calculate_eff_ionpot_auger_rates(const int nonemptymgi, const int element, 
     }
     celliondata.eff_ionpot = static_cast<float>(eff_ionpot);
   } else {
-    printlnlog("WARNING! No matching subshells in NT impact ionisation cross section data for Z={} ionstage {}.",
-               get_atomicnumber(element), get_ionstage(element, ion));
-    printlnlog(
-        "-> Defaulting to work function approximation and ionisation energy is not accounted for in Spencer-Fano "
-        "solution.");
-
+    // the absence of matching subshell data is reported once at startup by read_collion_data()
     celliondata.eff_ionpot = static_cast<float>(1. / get_oneoverw_approx_axelrod(element, ion, nonemptymgi));
   }
 }
@@ -2414,7 +2430,7 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   bool skip_solution = false;
   if (timestep < globals::num_lte_timesteps + 1) {
-    printlnlog("Skipping Spencer-Fano solution for first NLTE timestep");
+    // this global condition is reported once per timestep by update_grid(), not once per cell
     skip_solution = true;
   } else if (get_ntlepton_deposition_rate_density(nonemptymgi) / EV < MINDEPRATE) {
     printlnlog(
@@ -2482,6 +2498,7 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
     sfmatrix[uppertriangular(i, i)] += electron_loss_rate(engrid(i) * EV, nne) / EV;
   }
 
+  std::string includedionsstr;
   for (int element = 0; element < get_nelements(); element++) {
     const int Z = get_atomicnumber(element);
     const int nions = get_nions(element);
@@ -2496,14 +2513,11 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
 
       const int ionstage = get_ionstage(element, ion);
       if (first_included_ion_of_element) {
-        printlog("  including Z={:2} ionstages: ", Z);
-        for (int i = 1; i < get_ionstage(element, ion); i++) {
-          printlog("  ");
-        }
+        includedionsstr += std::format(" Z={} ionstages", Z);
         first_included_ion_of_element = false;
       }
 
-      printlog("{} ", ionstage);
+      includedionsstr += std::format(" {}", ionstage);
 
       sfmatrix_add_excitation(sfmatrix, nonemptymgi, element, ion);
 
@@ -2511,9 +2525,13 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
         sfmatrix_add_ionisation(sfmatrix, Z, ionstage, nnion);
       }
     }
-    if (!first_included_ion_of_element) {
-      printlnlog("");
-    }
+  }
+
+  // the included set rarely changes between solves, so only log it when it differs from the last report
+  THREADLOCALONHOST auto last_logged_includedionsstr = std::string();
+  if (includedionsstr != last_logged_includedionsstr) {
+    last_logged_includedionsstr = includedionsstr;
+    printlnlog("  including{} (list logged when it changes)", includedionsstr);
   }
 
   decompactify_triangular_matrix(sfmatrix);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -390,7 +390,7 @@ void check_auger_probabilities(const ptrdiff_t nonemptymgi) {
           probliststr += std::format(" {}:{:g}", a, get_auger_probability(nonemptymgi, element, ion, a));
         }
         printlnlog(
-            "ERROR: Auger probabilities sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
+            "[error] Auger probabilities sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
             "P(n_Auger):{}",
             prob_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element), get_ionstage(element, ion),
             probliststr);
@@ -403,7 +403,7 @@ void check_auger_probabilities(const ptrdiff_t nonemptymgi) {
           enfracliststr += std::format(" {}:{:g}", a, get_ion_auger_enfrac(nonemptymgi, element, ion, a));
         }
         printlnlog(
-            "ERROR: Auger energy fractions sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
+            "[error] Auger energy fractions sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
             "enfrac(n_Auger):{}",
             ionenfrac_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element),
             get_ionstage(element, ion), enfracliststr);
@@ -488,7 +488,7 @@ void read_auger_data() {
       const int g = xrayg[shellnum - 1];
 
       if (!std::isfinite(en_auger_ev) || en_auger_ev < 0) {
-        printlnlog("  WARNING: Z={:2} ionstage {:2} shellnum {} en_auger_ev is {:g}. Setting to zero.", Z, ionstage,
+        printlnlog("  [warning] Z={:2} ionstage {:2} shellnum {} en_auger_ev is {:g}. Setting to zero.", Z, ionstage,
                    shellnum, en_auger_ev);
         en_auger_ev = 0.;
       }
@@ -1099,7 +1099,7 @@ auto calculate_frac_heating(const int nonemptymgi, const std::array<double, SFPT
   const auto frac_heating = static_cast<float>(frac_heating_Einit / E_init_ev);
 
   if (!std::isfinite(frac_heating) || frac_heating < 0 || frac_heating > 1.0) {
-    printlnlog("WARNING: calculate_frac_heating: cell {} ts {}: invalid result of {:g}. Setting to 1.0 instead",
+    printlnlog("[warning] calculate_frac_heating: cell {} ts {}: invalid result of {:g}. Setting to 1.0 instead",
                grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, frac_heating);
     return 1.;
   }
@@ -1646,7 +1646,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
       }
       if (frac_excitation_ion > 1. || !std::isfinite(frac_excitation_ion)) {
         printlnlog(
-            "      WARNING: cell {} ts {}: Z={} ionstage {}: invalid frac_excitation {:g}. Replacing with zero and "
+            "      [warning] cell {} ts {}: Z={} ionstage {}: invalid frac_excitation {:g}. Replacing with zero and "
             "dropping {} stored excitations for this ion",
             grid::get_mgi_of_nonemptymgi(nonemptymgi), timestep, Z, ionstage, frac_excitation_ion,
             std::ssize(tmp_excitation_list) - tmp_excitation_list_size_before_ion);
@@ -1825,7 +1825,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
       static_cast<float>(std::clamp(1. - frac_excitation_total - frac_ionisation_total, 0., 1.));
 
   if (!ftol<0.02>(frac_sum, 1.0)) {
-    printlnlog("WARNING: frac_sum is {:g}, but should be 1.0", frac_sum);
+    printlnlog("[warning] frac_sum is {:g}, but should be 1.0", frac_sum);
     printlnlog("  (replacing calculated frac_heating_tot {:g} with {:g} to make frac_sum = 1.0)",
                frac_heating_calculated, nt_solution[nonemptymgi].frac_heating);
   }
@@ -2601,9 +2601,9 @@ void read_restart_data(FILE* gridsave_file) {
   assert_always(fscanf(gridsave_file, "%d %la %la\n", &sfpts_in, &SF_EMIN_in, &SF_EMAX_in) == 3);
 
   if (sfpts_in != SFPTS || SF_EMIN_in != SF_EMIN || SF_EMAX_in != SF_EMAX) {
-    printlnlog("ERROR: gridsave file specifies {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", sfpts_in,
+    printlnlog("[error] gridsave file specifies {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", sfpts_in,
                SF_EMIN_in, SF_EMAX_in);
-    printlnlog("ERROR: This simulation has {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", SFPTS, SF_EMIN,
+    printlnlog("[error] This simulation has {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", SFPTS, SF_EMIN,
                SF_EMAX);
     std::abort();
   }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -385,22 +385,28 @@ void check_auger_probabilities(const ptrdiff_t nonemptymgi) {
       }
 
       if (fabs(prob_sum - 1.0) > 0.001) {
-        printlnlog("Problem with Auger probabilities for cell {} Z={} ionstage {} prob_sum {:g}",
-                   grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element), get_ionstage(element, ion),
-                   prob_sum);
+        std::string probliststr;
         for (int a = 0; a <= NT_MAX_AUGER_ELECTRONS; a++) {
-          printlnlog("{}: {:g}", a, get_auger_probability(nonemptymgi, element, ion, a));
+          probliststr += std::format(" {}:{:g}", a, get_auger_probability(nonemptymgi, element, ion, a));
         }
+        printlnlog(
+            "ERROR: Auger probabilities sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
+            "P(n_Auger):{}",
+            prob_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element), get_ionstage(element, ion),
+            probliststr);
         problem_found = true;
       }
 
       if (fabs(ionenfrac_sum - 1.0) > 0.001) {
-        printlnlog("Problem with Auger energy frac sum for cell {} Z={} ionstage {} ionenfrac_sum {:g}",
-                   grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element), get_ionstage(element, ion),
-                   ionenfrac_sum);
+        std::string enfracliststr;
         for (int a = 0; a <= NT_MAX_AUGER_ELECTRONS; a++) {
-          printlnlog("{}: {:g}", a, get_ion_auger_enfrac(nonemptymgi, element, ion, a));
+          enfracliststr += std::format(" {}:{:g}", a, get_ion_auger_enfrac(nonemptymgi, element, ion, a));
         }
+        printlnlog(
+            "ERROR: Auger energy fractions sum to {:g} (expected 1.0 +/- 0.001) for cell {} Z={} ionstage {}: "
+            "enfrac(n_Auger):{}",
+            ionenfrac_sum, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element),
+            get_ionstage(element, ion), enfracliststr);
         problem_found = true;
       }
     }
@@ -1093,7 +1099,8 @@ auto calculate_frac_heating(const int nonemptymgi, const std::array<double, SFPT
   const auto frac_heating = static_cast<float>(frac_heating_Einit / E_init_ev);
 
   if (!std::isfinite(frac_heating) || frac_heating < 0 || frac_heating > 1.0) {
-    printlnlog("WARNING: calculate_frac_heating: invalid result of {:g}. Setting to 1.0 instead", frac_heating);
+    printlnlog("WARNING: calculate_frac_heating: cell {} ts {}: invalid result of {:g}. Setting to 1.0 instead",
+               grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, frac_heating);
     return 1.;
   }
 
@@ -1638,7 +1645,11 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
         printlnlog("    frac_excitation: {:g}", frac_excitation_ion);
       }
       if (frac_excitation_ion > 1. || !std::isfinite(frac_excitation_ion)) {
-        printlnlog("      WARNING: invalid frac_excitation. Replacing with zero");
+        printlnlog(
+            "      WARNING: cell {} ts {}: Z={} ionstage {}: invalid frac_excitation {:g}. Replacing with zero and "
+            "dropping {} stored excitations for this ion",
+            grid::get_mgi_of_nonemptymgi(nonemptymgi), timestep, Z, ionstage, frac_excitation_ion,
+            std::ssize(tmp_excitation_list) - tmp_excitation_list_size_before_ion);
         frac_excitation_ion = 0.;
         // remove this ion's transitions from the excitation list. Otherwise their (invalid, possibly
         // huge) frac_deposition and ratecoeffperdeposition values would remain in the stored list and

--- a/packet.cc
+++ b/packet.cc
@@ -36,20 +36,14 @@ namespace {
 constexpr auto get_packets_text_header() -> std::string {
   std::string header;
   header =
-      "#number where type_id"
-      " posx posy posz"
-      " dirx diry dirz"
-      " tdecay e_cmf e_rf nu_cmf nu_rf"
-      " escape_type_id escape_time emissiontype trueemissiontype"
-      " em_posx em_posy em_posz"
-      " absorption_type absorption_freq nscatterings em_time";
+      "#number where type_id posx posy posz dirx diry dirz tdecay e_cmf e_rf nu_cmf nu_rf escape_type_id escape_time "
+      "emissiontype trueemissiontype em_posx em_posy em_posz absorption_type absorption_freq nscatterings em_time";
   if constexpr (POL_ON) {
     header += " stokes_q stokes_u";
   }
   header +=
-      " originated_from_particlenotgamma"
-      " trueem_posx trueem_posy trueem_posz trueem_time"
-      " pellet_nucindex pellet_decaytype";
+      " originated_from_particlenotgamma trueem_posx trueem_posy trueem_posz trueem_time pellet_nucindex "
+      "pellet_decaytype";
   return header;
 }
 

--- a/packet.cc
+++ b/packet.cc
@@ -209,9 +209,7 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
     ssline >> pkt.pellet_decaytype;
   }
 
-  if (std::ssize(packets) < MPKTS) {
-    printlnlog("  found {} out of a possible {} packets.", std::ssize(packets), MPKTS);
-  }
+  printlnlog("  read {} packets from {} (MPKTS {})", std::ssize(packets), filename, MPKTS);
   packets.shrink_to_fit();
   return packets;
 }
@@ -249,7 +247,6 @@ void read_temp_packetsfile(const int timestep, const int my_rank, std::vector<Pa
   // read binary packets file
   const auto filename = std::format("packets_{:04d}_ts{:d}.tmp", my_rank, timestep);
 
-  printlnlog("Reading {}", filename);
   const auto packets_file = fopen_required_uniqueptr(filename, "rb");
   std::int64_t packet_count_in_file = 0;
   assert_always(std::fread(&packet_count_in_file, sizeof(std::int64_t), 1, packets_file.get()) == 1);
@@ -258,7 +255,7 @@ void read_temp_packetsfile(const int timestep, const int my_rank, std::vector<Pa
   reserve_resize(packets, packet_count_in_file);
   assert_always(std::fread(packets.data(), sizeof(Packet), packet_count_in_file, packets_file.get()) ==
                 static_cast<size_t>(packet_count_in_file));
-  printlnlog("done");
+  printlnlog("read {} packets from {}", packet_count_in_file, filename);
 }
 
 void write_temp_packetsfile(const int timestep, const int my_rank, const std::span<const Packet> packets) {

--- a/packet.cc
+++ b/packet.cc
@@ -95,15 +95,15 @@ void packet_init(std::span<Packet> packets)
 // Subroutine that initialises the packets if we start a new simulation.
 {
   MPI_Barrier_allranks();
-  printlnlog("UNIFORM_PELLET_ENERGIES is {}", (UNIFORM_PELLET_ENERGIES ? "true" : "false"));
+  printlnlog("UNIFORM_PELLET_ENERGIES is {}", UNIFORM_PELLET_ENERGIES ? "true" : "false");
 
-  printlnlog("INITIAL_PACKETS_ON is {}", (INITIAL_PACKETS_ON ? "on" : "off"));
+  printlnlog("INITIAL_PACKETS_ON is {}", INITIAL_PACKETS_ON ? "true" : "false");
 
   // The total number of pellets that we want to start with is just
   // npkts. The total energy of the pellets is given by etot.
   const double etot_tmodel_tinf = decay::get_global_etot_tmodel_tinf();
 
-  printlnlog("etot {:g} (t_model to t_inf)", etot_tmodel_tinf);
+  printlnlog("etot {:g} erg (t_model to t_inf)", etot_tmodel_tinf);
 
   printlnlog("e_cmf per packet (t_model to t_inf) {:g} erg", etot_tmodel_tinf / MPKTS);
 
@@ -148,7 +148,8 @@ void packet_init(std::span<Packet> packets)
   double e_cmf_total =
       std::ranges::fold_left(packets, 0., [](const double sum, const Packet& p) { return sum + p.e_cmf; });
   const double e_ratio = etot_simtime / e_cmf_total;
-  printlnlog("packet energy sum {:g} should be {:g} normalisation factor: {:g}", e_cmf_total, etot_simtime, e_ratio);
+  printlnlog("packet energy sum {:g} erg should be {:g} erg, so normalisation factor is {:g}", e_cmf_total,
+             etot_simtime, e_ratio);
   assert_always(std::isfinite(e_cmf_total));
   e_cmf_total *= e_ratio;
   for (auto& pkt : packets) {
@@ -266,13 +267,12 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
   bool write_success = false;
   while (!write_success) {
     if (tries > 10) {
-      printlnlog("ERROR: Failed to write {} after {} tries. Aborting.", filename, tries);
+      printlnlog("[error] Failed to write {} after {} tries. Aborting.", filename, tries);
       std::abort();
     }
-    printlog("timestep {}: writing {}...", timestep, filename);
     FILE* packets_file = fopen(filename.c_str(), "wb");
     if (packets_file == nullptr) {
-      printlnlog("ERROR: Could not open file '{}' for mode 'wb'.", filename);
+      printlnlog("[error] Could not open file '{}' for mode 'wb'.", filename);
       write_success = false;
     } else {
       auto packet_count = static_cast<std::int64_t>(std::ssize(packets));
@@ -281,12 +281,12 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
       write_success = write_success &&
                       (std::fwrite(packets.data(), sizeof(Packet), packets.size(), packets_file) == packets.size());
       if (!write_success) {
-        printlnlog("WARNING: fwrite to {} failed on attempt {} of 10. will retry...", filename, tries + 1);
+        printlnlog("[warning] fwrite to {} failed on attempt {} of 10. will retry...", filename, tries + 1);
       }
 
       fclose(packets_file);
     }
     tries++;
   }
-  printlnlog("done");
+  printlnlog("timestep {}: wrote {} packets to {}", timestep, std::ssize(packets), filename);
 }

--- a/packet.cc
+++ b/packet.cc
@@ -248,6 +248,7 @@ void read_temp_packetsfile(const int timestep, const int my_rank, std::vector<Pa
   // read binary packets file
   const auto filename = std::format("packets_{:04d}_ts{:d}.tmp", my_rank, timestep);
 
+  printlnlog("Reading {}", filename);
   const auto packets_file = fopen_required_uniqueptr(filename, "rb");
   std::int64_t packet_count_in_file = 0;
   assert_always(std::fread(&packet_count_in_file, sizeof(std::int64_t), 1, packets_file.get()) == 1);
@@ -270,6 +271,7 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
       printlnlog("[error] Failed to write {} after {} tries. Aborting.", filename, tries);
       std::abort();
     }
+    printlog("timestep {}: writing {}...", timestep, filename);
     FILE* packets_file = fopen(filename.c_str(), "wb");
     if (packets_file == nullptr) {
       printlnlog("[error] Could not open file '{}' for mode 'wb'.", filename);
@@ -288,5 +290,5 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
     }
     tries++;
   }
-  printlnlog("timestep {}: wrote {} packets to {}", timestep, std::ssize(packets), filename);
+  printlnlog("done");
 }

--- a/packet.cc
+++ b/packet.cc
@@ -103,9 +103,9 @@ void packet_init(std::span<Packet> packets)
   // npkts. The total energy of the pellets is given by etot.
   const double etot_tmodel_tinf = decay::get_global_etot_tmodel_tinf();
 
-  printlnlog("etot {:g} erg (t_model to t_inf)", etot_tmodel_tinf);
+  printlnlog("etot {:g} [erg] (t_model to t_inf)", etot_tmodel_tinf);
 
-  printlnlog("e_cmf per packet (t_model to t_inf) {:g} erg", etot_tmodel_tinf / MPKTS);
+  printlnlog("e_cmf per packet (t_model to t_inf) {:g} [erg]", etot_tmodel_tinf / MPKTS);
 
   const auto energy_per_mass_nonemptymgi_decaypath = decay::get_energy_per_mass_nonemptymgi_decaypath();
 
@@ -131,11 +131,11 @@ void packet_init(std::span<Packet> packets)
   assert_always(etot_simtime > 0);
 
   constexpr auto strtimelow{INITIAL_PACKETS_ON ? "tmodel" : "tmin"};
-  printlnlog("etot ({} to tmax) {:g} erg", strtimelow, etot_simtime);
+  printlnlog("etot ({} to tmax) {:g} [erg]", strtimelow, etot_simtime);
 
   // So energy per pellet is:
   const double e_cmf_per_packet = etot_simtime / MPKTS;
-  printlnlog("e_cmf per packet ({} to tmax) {:g} erg", strtimelow, e_cmf_per_packet);
+  printlnlog("e_cmf per packet ({} to tmax) {:g} [erg]", strtimelow, e_cmf_per_packet);
 
   // Now place the pellets in the ejecta and decide at what time they will decay.
 
@@ -148,7 +148,7 @@ void packet_init(std::span<Packet> packets)
   double e_cmf_total =
       std::ranges::fold_left(packets, 0., [](const double sum, const Packet& p) { return sum + p.e_cmf; });
   const double e_ratio = etot_simtime / e_cmf_total;
-  printlnlog("packet energy sum {:g} erg should be {:g} erg, so normalisation factor is {:g}", e_cmf_total,
+  printlnlog("packet energy sum {:g} [erg] should be {:g} [erg], so normalisation factor is {:g}", e_cmf_total,
              etot_simtime, e_ratio);
   assert_always(std::isfinite(e_cmf_total));
   e_cmf_total *= e_ratio;
@@ -156,7 +156,7 @@ void packet_init(std::span<Packet> packets)
     pkt.e_cmf *= e_ratio;
     pkt.e_rf *= e_ratio;
   }
-  printlnlog("total energy that will be freed during simulation time: {:g} erg", e_cmf_total);
+  printlnlog("total energy that will be freed during simulation time: {:g} [erg]", e_cmf_total);
 }
 
 // read packets*.out text format file

--- a/packet.cc
+++ b/packet.cc
@@ -284,7 +284,7 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
       write_success = write_success &&
                       (std::fwrite(packets.data(), sizeof(Packet), packets.size(), packets_file) == packets.size());
       if (!write_success) {
-        printlnlog("fwrite() FAILED! will retry...");
+        printlnlog("WARNING: fwrite to {} failed on attempt {} of 10. will retry...", filename, tries + 1);
       }
 
       fclose(packets_file);

--- a/radfield.cc
+++ b/radfield.cc
@@ -363,8 +363,9 @@ auto nu_bar_planck_minus_estimator(const double T_R, const int nonemptymgi, cons
 
   if (!std::isfinite(delta_nu_bar)) {
     printlnlog(
-        "[warning] nu_bar_planck_minus_estimator: cell {} bin {}: delta_nu_bar is {:g}. T_R {:g} K nu_lower {:g} Hz "
-        "nu_upper {:g} Hz nu_bar_planck_T_R {:g} Hz nu_bar_estimator {:g} Hz",
+        "[warning] nu_bar_planck_minus_estimator: cell {} bin {}: delta_nu_bar is {:g}. T_R {:g} [K] nu_lower {:g} "
+        "[Hz] "
+        "nu_upper {:g} [Hz] nu_bar_planck_T_R {:g} [Hz] nu_bar_estimator {:g} [Hz]",
         grid::get_mgi_of_nonemptymgi(nonemptymgi), binindex, delta_nu_bar, T_R, nu_lower, nu_upper, nu_bar_planck_T_R,
         nu_bar_estimator);
   }
@@ -397,7 +398,7 @@ auto find_bin_T_R(const int nonemptymgi, const int binindex) -> float {
     if (iteration_num >= maxit) {
       printlnlog(
           "[warning] find_bin_T_R: cell {} bin {}: T_R did not converge within {} iterations. interval [{:g}, "
-          "{:g}] K",
+          "{:g}] [K]",
           grid::get_mgi_of_nonemptymgi(nonemptymgi), binindex, iteration_num, result.first, result.second);
     }
     return T_R_solution;
@@ -445,8 +446,9 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
     grid::set_W(nonemptymgi, W);
 
     printlnlog(
-        "Full-spectrum fit radfield for cell {} at timestep {}: J {:g}, lambda_bar {:5.1f} Angstrom, T_J {:g} K, T_R "
-        "{:g} K, W {:g}",
+        "Full-spectrum fit radfield for cell {} at timestep {}: J {:g}, lambda_bar {:5.1f} [Angstrom], T_J {:g} [K], "
+        "T_R "
+        "{:g} [K], W {:g}",
         modelgridindex, timestep, J[nonemptymgi], 1e8 * CLIGHT / nubar, T_J, T_R, W);
   }
 }
@@ -579,8 +581,8 @@ void init() {
     printlnlog("The multibin radiation field is being used from timestep {} onwards.", FIRST_NLTE_RADFIELD_TIMESTEP);
 
     printlnlog(
-        "Initialising multibin radiation field with {} bins from ({:.2f} eV, {:6.1f} A) to ({:.2f} eV, {:6.1f} A) and "
-        "a T_e superbin up to ({:.2f} eV, {:6.1f} A).",
+        "Initialising multibin radiation field with {} bins from ({:.2f} [eV], {:6.1f} [A]) to ({:.2f} [eV], "
+        "{:6.1f} [A]) and a T_e superbin up to ({:.2f} [eV], {:6.1f} [A]).",
         RADFIELDBINCOUNT - 1, H * RADFIELDBINS_NU_MIN / EV, 1e8 * CLIGHT / RADFIELDBINS_NU_MIN,
         H * RADFIELDBINS_NU_MAX / EV, 1e8 * CLIGHT / RADFIELDBINS_NU_MAX, H * RADFIELDBINS_T_E_SUPERBIN_NU_MAX / EV,
         1e8 * CLIGHT / RADFIELDBINS_T_E_SUPERBIN_NU_MAX);
@@ -595,7 +597,7 @@ void init() {
     const size_t mem_usage_bins = nonempty_npts_model * RADFIELDBINCOUNT * ((2 * sizeof(double)) + sizeof(int));
     radfieldbins.resize(nonempty_npts_model);
 
-    printlnlog("[info] mem_usage: radiation field bin accumulators for non-empty cells occupy {:.3f} MB",
+    printlnlog("[info] mem_usage: radiation field bin accumulators for non-empty cells occupy {:.3f} [MB]",
                mem_usage_bins / 1024. / 1024.);
 
     radfieldbin_solutions_W = MPI_shared_array<float>(nonempty_npts_model * RADFIELDBINCOUNT);
@@ -604,7 +606,7 @@ void init() {
 
     const size_t mem_usage_bin_solutions = nonempty_npts_model * RADFIELDBINCOUNT * sizeof(RadFieldBinSolution);
     printlnlog(
-        "[info] mem_usage: radiation field bin solutions for non-empty cells occupy {:.3f} MB (node shared memory)",
+        "[info] mem_usage: radiation field bin solutions for non-empty cells occupy {:.3f} [MB] (node shared memory)",
         mem_usage_bin_solutions / 1024. / 1024.);
   } else {
     printlnlog("The radiation field model is a full-spectrum fit to a single dilute blackbody TR & W.");
@@ -617,12 +619,12 @@ void init() {
       std::ranges::fill(prev_bfrate_normed, 0.);
     }
     MPI_Barrier_node();
-    printlnlog("[info] mem_usage: detailed bf estimators for non-empty cells occupy {:.3f} MB (node shared memory)",
+    printlnlog("[info] mem_usage: detailed bf estimators for non-empty cells occupy {:.3f} [MB] (node shared memory)",
                nonempty_npts_model * bfestimcount * sizeof(float) / 1024. / 1024.);
 
     reserve_resize(bfrate_raw, nonempty_npts_model * bfestimcount);
 
-    printlnlog("[info] mem_usage: detailed bf estimator acculumators for non-empty cells occupy {:.3f} MB",
+    printlnlog("[info] mem_usage: detailed bf estimator acculumators for non-empty cells occupy {:.3f} [MB]",
                nonempty_npts_model * bfestimcount * sizeof(double) / 1024. / 1024.);
   }
 
@@ -823,15 +825,15 @@ void fit_parameters(const int nonemptymgi, const int timestep) {
           W_bin = static_cast<float>(J_bin / planck_integral_result);
           if (W_bin > 1e4) {
             printlnlog(
-                "[warning] cell {} ts {} bin {}: W {:g} too high or non-finite (T_R {:7.1f} K, J_bin {:g}) and W "
-                "{:g} still too high after retry at T_R_max {:g} K. Zeroing bin (T_R set to sentinel -99)",
+                "[warning] cell {} ts {} bin {}: W {:g} too high or non-finite (T_R {:7.1f} [K], J_bin {:g}) and W "
+                "{:g} still too high after retry at T_R_max {:g} [K]. Zeroing bin (T_R set to sentinel -99)",
                 mgi, timestep, binindex, W_bin_first, T_R_bin, J_bin, W_bin, bins_T_R_max);
             T_R_bin = -99.;
             W_bin = 0.;
           } else {
             printlnlog(
-                "[warning] cell {} ts {} bin {}: W {:g} too high or non-finite (T_R {:7.1f} K, J_bin {:g}); "
-                "continuing with W {:g} at T_R_max {:g} K",
+                "[warning] cell {} ts {} bin {}: W {:g} too high or non-finite (T_R {:7.1f} [K], J_bin {:g}); "
+                "continuing with W {:g} at T_R_max {:g} [K]",
                 mgi, timestep, binindex, W_bin_first, T_R_bin, J_bin, W_bin, bins_T_R_max);
             T_R_bin = bins_T_R_max;
           }
@@ -931,13 +933,13 @@ auto get_T_J_from_J(const int nonemptymgi) -> float {
   // Make sure that T is in the allowed temperature range.
   if (T_J > MAXTEMP) {
     printlnlog(
-        "[warning] get_T_J_from_J: cell {} ts {}: T_J would be {:.1f} K > MAXTEMP. Clamping to MAXTEMP = {:.0f} K",
+        "[warning] get_T_J_from_J: cell {} ts {}: T_J would be {:.1f} [K] > MAXTEMP. Clamping to MAXTEMP = {:.0f} [K]",
         grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, T_J, MAXTEMP);
     return MAXTEMP;
   }
   if (T_J < MINTEMP) {
     printlnlog(
-        "[warning] get_T_J_from_J: cell {} ts {}: T_J would be {:.1f} K < MINTEMP. Clamping to MINTEMP = {:.0f} K",
+        "[warning] get_T_J_from_J: cell {} ts {}: T_J would be {:.1f} [K] < MINTEMP. Clamping to MINTEMP = {:.0f} [K]",
         grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, T_J, MINTEMP);
     return MINTEMP;
   }

--- a/radfield.cc
+++ b/radfield.cc
@@ -363,8 +363,10 @@ auto nu_bar_planck_minus_estimator(const double T_R, const int nonemptymgi, cons
 
   if (!std::isfinite(delta_nu_bar)) {
     printlnlog(
-        "delta_nu_bar is {:g}. T_R {:g} nu_lower {:g} nu_upper {:g} nu_bar_planck_T_R {:g} nu_bar_estimator {:g}",
-        delta_nu_bar, T_R, nu_lower, nu_upper, nu_bar_planck_T_R, nu_bar_estimator);
+        "[warning] nu_bar_planck_minus_estimator: cell {} bin {}: delta_nu_bar is {:g}. T_R {:g} K nu_lower {:g} Hz "
+        "nu_upper {:g} Hz nu_bar_planck_T_R {:g} Hz nu_bar_estimator {:g} Hz",
+        grid::get_mgi_of_nonemptymgi(nonemptymgi), binindex, delta_nu_bar, T_R, nu_lower, nu_upper, nu_bar_planck_T_R,
+        nu_bar_estimator);
   }
 
   return delta_nu_bar;
@@ -393,7 +395,10 @@ auto find_bin_T_R(const int nonemptymgi, const int binindex) -> float {
                                                           ftol<epsrel>, iteration_num);
     const auto T_R_solution = static_cast<float>(0.5 * (result.first + result.second));
     if (iteration_num >= maxit) {
-      printlnlog("[warning] find_bin_T_R: T_R did not converge within {} iterations.", iteration_num);
+      printlnlog(
+          "[warning] find_bin_T_R: cell {} bin {}: T_R did not converge within {} iterations. interval [{:g}, "
+          "{:g}] K",
+          grid::get_mgi_of_nonemptymgi(nonemptymgi), binindex, iteration_num, result.first, result.second);
     }
     return T_R_solution;
   }
@@ -813,18 +818,21 @@ void fit_parameters(const int nonemptymgi, const int timestep) {
         W_bin = static_cast<float>(J_bin / planck_integral_result);
 
         if (W_bin > 1e4 || !std::isfinite(W_bin)) {
-          printlog(
-              "bin {} T_R {:7.1f} W {:g} too high or non-finite, trying setting T_R to {:g}. J_bin {:g} "
-              "planck_integral {:g}...",
-              binindex, T_R_bin, W_bin, bins_T_R_max, J_bin, planck_integral_result);
+          const auto W_bin_first = W_bin;
           planck_integral_result = calculate_planck_integral(bins_T_R_max, nu_lower, nu_upper, false);
           W_bin = static_cast<float>(J_bin / planck_integral_result);
           if (W_bin > 1e4) {
-            printlnlog("W still very high, W={:g}. Zeroing bin...", W_bin);
+            printlnlog(
+                "[warning] cell {} ts {} bin {}: W {:g} too high or non-finite (T_R {:7.1f} K, J_bin {:g}) and W "
+                "{:g} still too high after retry at T_R_max {:g} K. Zeroing bin (T_R set to sentinel -99)",
+                mgi, timestep, binindex, W_bin_first, T_R_bin, J_bin, W_bin, bins_T_R_max);
             T_R_bin = -99.;
             W_bin = 0.;
           } else {
-            printlnlog("new W is {:g}. Continuing...", W_bin);
+            printlnlog(
+                "[warning] cell {} ts {} bin {}: W {:g} too high or non-finite (T_R {:7.1f} K, J_bin {:g}); "
+                "continuing with W {:g} at T_R_max {:g} K",
+                mgi, timestep, binindex, W_bin_first, T_R_bin, J_bin, W_bin, bins_T_R_max);
             T_R_bin = bins_T_R_max;
           }
         }
@@ -922,11 +930,15 @@ auto get_T_J_from_J(const int nonemptymgi) -> float {
   }
   // Make sure that T is in the allowed temperature range.
   if (T_J > MAXTEMP) {
-    printlnlog("[warning] get_T_J_from_J: T_J would be {:.1f} > MAXTEMP. Clamping to MAXTEMP = {:.0f} K", T_J, MAXTEMP);
+    printlnlog(
+        "[warning] get_T_J_from_J: cell {} ts {}: T_J would be {:.1f} K > MAXTEMP. Clamping to MAXTEMP = {:.0f} K",
+        grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, T_J, MAXTEMP);
     return MAXTEMP;
   }
   if (T_J < MINTEMP) {
-    printlnlog("[warning] get_T_J_from_J: T_J would be {:.1f} < MINTEMP. Clamping to MINTEMP = {:.0f} K", T_J, MINTEMP);
+    printlnlog(
+        "[warning] get_T_J_from_J: cell {} ts {}: T_J would be {:.1f} K < MINTEMP. Clamping to MINTEMP = {:.0f} K",
+        grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, T_J, MINTEMP);
     return MINTEMP;
   }
   return T_J;

--- a/radfield.cc
+++ b/radfield.cc
@@ -1107,7 +1107,7 @@ void read_restart_data(FILE* gridsave_file) {
 
     if (bincount_in != RADFIELDBINCOUNT || T_R_min_in != bins_T_R_min || T_R_max_in != bins_T_R_max ||
         nu_lower_first_ratio < 0.999 || nu_upper_last_ratio < 0.999) {
-      printlnlog("ERROR: gridsave file specifies {} bins, nu_min {} nu_max {} T_R_min {} T_R_max {}", bincount_in,
+      printlnlog("[error] gridsave file specifies {} bins, nu_min {} nu_max {} T_R_min {} T_R_max {}", bincount_in,
                  nu_min_in, nu_max_in, T_R_min_in, T_R_max_in);
       printlnlog("require {} bins, RADFIELDBINS_NU_MIN {:g} RADFIELDBINS_NU_MAX {:g} T_R_min {:g} T_R_max {:g}",
                  RADFIELDBINCOUNT, RADFIELDBINS_NU_MIN, RADFIELDBINS_NU_MAX, bins_T_R_min, bins_T_R_max);
@@ -1153,7 +1153,7 @@ void read_restart_data(FILE* gridsave_file) {
     assert_always(fscanf(gridsave_file, "%d\n", &detailed_linecount_in) == 1);
 
     if (detailed_linecount_in != detailed_linecount) {
-      printlnlog("ERROR: gridsave file specifies {} detailed lines but this simulation has {}.", detailed_linecount_in,
+      printlnlog("[error] gridsave file specifies {} detailed lines but this simulation has {}.", detailed_linecount_in,
                  detailed_linecount);
       std::abort();
     }

--- a/radfield.cc
+++ b/radfield.cc
@@ -428,7 +428,7 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
                  MINTEMP, modelgridindex);
       T_J = MINTEMP;
     }
-    grid::set_TJ(nonemptymgi, T_J);
+    grid::TJ_allcells[nonemptymgi] = T_J;
 
     auto T_R = static_cast<float>(H * nubar / KB / 3.832229494);
     if (T_R > MAXTEMP) {
@@ -440,10 +440,10 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
                  MINTEMP, modelgridindex);
       T_R = MINTEMP;
     }
-    grid::set_TR(nonemptymgi, T_R);
+    grid::TR_allcells[nonemptymgi] = T_R;
 
     const auto W = static_cast<float>(J[nonemptymgi] * PI / STEBO / pow4(T_R));
-    grid::set_W(nonemptymgi, W);
+    grid::W_allcells[nonemptymgi] = W;
 
     printlnlog(
         "Full-spectrum fit radfield for cell {} at timestep {}: J {:g}, lambda_bar {:5.1f} [Angstrom], T_J {:g} [K], "
@@ -499,8 +499,8 @@ void write_to_file(const int nonemptymgi, const int timestep) {
       } else if (binindex == -1) {  // bin -1 is the full spectrum fit
         nuJ_out = nuJ[nonemptymgi];
         J_out = J[nonemptymgi];
-        T_R = grid::get_TR(nonemptymgi);
-        W = grid::get_W(nonemptymgi);
+        T_R = grid::TR_allcells[nonemptymgi];
+        W = grid::W_allcells[nonemptymgi];
       } else {  // use binindex < -1 for detailed line Jb_lu estimators
         const int jblueindex = -2 - binindex;  // -2 is the first detailed line, -3 is the second, etc
         const int lineindex = detailed_lineindices[jblueindex];
@@ -771,7 +771,7 @@ DEVICE_FUNC auto radfield(const double nu, const int nonemptymgi) -> double {
     }
   }
   // full spectrum fit to a single dilute blackbody
-  return grid::get_W(nonemptymgi) * planck(nu, grid::get_TR(nonemptymgi));
+  return grid::W_allcells[nonemptymgi] * planck(nu, grid::TR_allcells[nonemptymgi]);
 }
 
 void fit_parameters(const int nonemptymgi, const int timestep) {
@@ -806,7 +806,7 @@ void fit_parameters(const int nonemptymgi, const int timestep) {
 
       if (J_bin > 0) {
         if (binindex == RADFIELDBINCOUNT - 1) {
-          T_R_bin = grid::get_Te(nonemptymgi);
+          T_R_bin = grid::Te_allcells[nonemptymgi];
         } else {
           T_R_bin = find_bin_T_R(nonemptymgi, binindex);
           if (T_R_bin <= bins_T_R_min) {
@@ -928,7 +928,7 @@ auto get_T_J_from_J(const int nonemptymgi) -> float {
     const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
     printlnlog("[warning] get_T_J_from_J: T_J estimator infinite in cell {}, use value of last timestep",
                modelgridindex);
-    return grid::get_TJ(nonemptymgi);
+    return grid::TJ_allcells[nonemptymgi];
   }
   // Make sure that T is in the allowed temperature range.
   if (T_J > MAXTEMP) {

--- a/radfield.cc
+++ b/radfield.cc
@@ -1,7 +1,6 @@
 // The radiation field model: accumulates Monte Carlo estimators of the radiation field
 // (full-spectrum and binned J_nu, plus detailed bound-bound Jb_lu estimators) and fits diluted
-// blackbodies (W, T_R) per cell and per frequency bin for use in the photoionisation and
-// heating rates.
+// blackbodies (W, T_R) per cell and per frequency bin for use in the photoionisation and heating rates.
 
 #include "radfield.h"
 
@@ -149,8 +148,7 @@ constexpr auto select_bin(const double nu) -> int {
   return binindex;
 }
 
-// associate a Jb_lu estimator with a particular lineindex to be used
-// instead of the general radiation field model
+// associate a Jb_lu estimator with a particular lineindex to be used instead of the general radiation field model
 void add_detailed_line(const int lineindex) {
   detailed_linecount++;
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
@@ -364,8 +362,7 @@ auto nu_bar_planck_minus_estimator(const double T_R, const int nonemptymgi, cons
   if (!std::isfinite(delta_nu_bar)) {
     printlnlog(
         "[warning] nu_bar_planck_minus_estimator: cell {} bin {}: delta_nu_bar is {:g}. T_R {:g} [K] nu_lower {:g} "
-        "[Hz] "
-        "nu_upper {:g} [Hz] nu_bar_planck_T_R {:g} [Hz] nu_bar_estimator {:g} [Hz]",
+        "[Hz] nu_upper {:g} [Hz] nu_bar_planck_T_R {:g} [Hz] nu_bar_estimator {:g} [Hz]",
         grid::get_mgi_of_nonemptymgi(nonemptymgi), binindex, delta_nu_bar, T_R, nu_lower, nu_upper, nu_bar_planck_T_R,
         nu_bar_estimator);
   }
@@ -447,8 +444,7 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
 
     printlnlog(
         "Full-spectrum fit radfield for cell {} at timestep {}: J {:g}, lambda_bar {:5.1f} [Angstrom], T_J {:g} [K], "
-        "T_R "
-        "{:g} [K], W {:g}",
+        "T_R {:g} [K], W {:g}",
         modelgridindex, timestep, J[nonemptymgi], 1e8 * CLIGHT / nubar, T_J, T_R, W);
   }
 }
@@ -960,8 +956,7 @@ void reduce_estimators() {
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {
     // reduce all ranks on each node first, then reduce the node leaders
     // then broadcast the final result to all ranks on each node
-    // this seems necessary to avoid congestion compared to a single MPI_Allreduce
-    // when using many ranks per node
+    // this seems necessary to avoid congestion compared to a single MPI_Allreduce when using many ranks per node
     MPI_Reduce_safe(bfrate_raw, MPI_SUM, 0, globals::mpi_comm_node);
     if (globals::rank_in_node == 0) {
       MPI_Allreduce_safe(bfrate_raw, MPI_SUM, globals::mpi_comm_internode);
@@ -998,8 +993,7 @@ void reduce_estimators() {
   MPI_Barrier_allranks();
 }
 
-// broadcast computed radfield results including parameters
-// from the cells belonging to root process to all processes
+// broadcast computed radfield results including parameters from the cells belonging to root process to all processes
 void do_MPI_Bcast(const ptrdiff_t nonemptymgi, const int root, const int root_node_id) {
   MPI_Bcast_safe(J_normfactor[nonemptymgi], root, MPI_COMM_WORLD);
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -597,7 +597,7 @@ void init() {
     const size_t mem_usage_bins = nonempty_npts_model * RADFIELDBINCOUNT * ((2 * sizeof(double)) + sizeof(int));
     radfieldbins.resize(nonempty_npts_model);
 
-    printlnlog("[info] mem_usage: radiation field bin accumulators for non-empty cells occupy {:.3f} [MB]",
+    printlnlog("[info] mem_usage: radiation field bin accumulators for non-empty cells occupy {:.3f} MB",
                mem_usage_bins / 1024. / 1024.);
 
     radfieldbin_solutions_W = MPI_shared_array<float>(nonempty_npts_model * RADFIELDBINCOUNT);
@@ -606,7 +606,7 @@ void init() {
 
     const size_t mem_usage_bin_solutions = nonempty_npts_model * RADFIELDBINCOUNT * sizeof(RadFieldBinSolution);
     printlnlog(
-        "[info] mem_usage: radiation field bin solutions for non-empty cells occupy {:.3f} [MB] (node shared memory)",
+        "[info] mem_usage: radiation field bin solutions for non-empty cells occupy {:.3f} MB (node shared memory)",
         mem_usage_bin_solutions / 1024. / 1024.);
   } else {
     printlnlog("The radiation field model is a full-spectrum fit to a single dilute blackbody TR & W.");
@@ -619,12 +619,12 @@ void init() {
       std::ranges::fill(prev_bfrate_normed, 0.);
     }
     MPI_Barrier_node();
-    printlnlog("[info] mem_usage: detailed bf estimators for non-empty cells occupy {:.3f} [MB] (node shared memory)",
+    printlnlog("[info] mem_usage: detailed bf estimators for non-empty cells occupy {:.3f} MB (node shared memory)",
                nonempty_npts_model * bfestimcount * sizeof(float) / 1024. / 1024.);
 
     reserve_resize(bfrate_raw, nonempty_npts_model * bfestimcount);
 
-    printlnlog("[info] mem_usage: detailed bf estimator acculumators for non-empty cells occupy {:.3f} [MB]",
+    printlnlog("[info] mem_usage: detailed bf estimator acculumators for non-empty cells occupy {:.3f} MB",
                nonempty_npts_model * bfestimcount * sizeof(double) / 1024. / 1024.);
   }
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -440,8 +440,8 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
     grid::set_W(nonemptymgi, W);
 
     printlnlog(
-        "Full-spectrum fit radfield for cell {} at timestep {}: J {:g}, nubar {:5.1f} Angstrom, T_J {:g}, T_R {:g}, W "
-        "{:g}",
+        "Full-spectrum fit radfield for cell {} at timestep {}: J {:g}, lambda_bar {:5.1f} Angstrom, T_J {:g} K, T_R "
+        "{:g} K, W {:g}",
         modelgridindex, timestep, J[nonemptymgi], 1e8 * CLIGHT / nubar, T_J, T_R, W);
   }
 }

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -458,7 +458,7 @@ auto calculate_corrphotoioncoeff_integral(const int element, const int ion, cons
   const double nu_threshold = (1. / H) * get_phixs_threshold(element, ion, level, phixstargetindex);
   const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   // stimulated recombination is negative photoionisation
   const double nnlevel = use_cellcache ? get_cellcache_levelpop(nonemptymgi, loweruniquelevelindex)
@@ -753,8 +753,8 @@ DEVICE_FUNC auto get_corrphotoioncoeff(const int element, const int ion, const i
         gammacorr =
             calculate_corrphotoioncoeff_integral(element, ion, level, phixstargetindex, nonemptymgi, use_cellcache);
       } else {
-        const double W = grid::get_W(nonemptymgi);
-        const double T_R = grid::get_TR(nonemptymgi);
+        const double W = grid::W_allcells[nonemptymgi];
+        const double T_R = grid::TR_allcells[nonemptymgi];
 
         gammacorr = W * lerp_or_last(std::span{corrphotoioncoeffs}, uniquelevelindex, phixstargetindex, T_R);
         const int index_in_groundlevelcontestimator = globals::alllevels.closestgroundlevelcont[uniquelevelindex];
@@ -787,7 +787,7 @@ auto iongamma_is_zero(const int nonemptymgi, const int element, const int ion) -
                                     groundcontindex] == 0);
   }
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
 
   for (int level = 0; level < get_nlevels(element, ion); level++) {
@@ -821,7 +821,7 @@ auto calculate_iongamma_per_gspop(const int nonemptymgi, const int element, cons
     return 0.;
   }
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const float clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
 
   const int nlevels_ionising = get_nlevels_ionising(element, ion);
@@ -866,7 +866,7 @@ auto calculate_iongamma_per_ionpop(const int nonemptymgi, const int element, con
   }
 
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   double ionisation_rate = 0.;  // rate per second
   const auto nlevels_ionising = get_nlevels_ionising(element, lowerion);

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -610,8 +610,8 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
 }
 
 // Get an ion's rate coefficient for spontaneous recombination in LTE
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_ion_spontrecombcoeff(const int uniqueionindex,
-                                                                      const float T_e) -> double {
+[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_ion_spontrecombcoeff(const int uniqueionindex, const float T_e)
+    -> double {
   const auto upperindex = get_temperature_gridupperindex(T_e);
   if (upperindex == 0) {
     return ion_alpha_sp[uniqueionindex * TABLESIZE];
@@ -630,8 +630,8 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
 
 // Return a level's rate coefficient for spontaneous recombination in LTE
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_spontrecombcoeff(const int uniquelevelindex,
-                                                                  const int phixstargetindex,
-                                                                  const float T_e) -> double {
+                                                                  const int phixstargetindex, const float T_e)
+    -> double {
   return lerp_or_last(std::span{spontrecombcoeffs}, uniquelevelindex, phixstargetindex, T_e);
 }
 
@@ -719,8 +719,8 @@ void ratecoefficients_init() {
 }
 
 // Returns the (stimulated recombination corrected) photoionisation rate coefficient.
-auto get_corrphotoioncoeff_ana(int element, const int ion, const int level, const int phixstargetindex,
-                               const float T_R) -> double {
+auto get_corrphotoioncoeff_ana(int element, const int ion, const int level, const int phixstargetindex, const float T_R)
+    -> double {
   assert_always(USE_LUT_PHOTOION);
   const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
   return lerp_or_last(std::span{corrphotoioncoeffs}, uniquelevelindex, phixstargetindex, T_R);

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -94,8 +94,7 @@ auto gammacorr_integrand(const double nu, const double nu_edge, const float temp
   const auto sigma_bf = photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu);
 
   // The correction factor for stimulated emission in gammacorr is set to its
-  // LTE value. Because the T_e dependence of gammacorr is weak, this correction
-  // correction may be evaluated at T_R!
+  // LTE value. Because the T_e dependence of gammacorr is weak, this correction correction may be evaluated at T_R!
 
   // Dependence on dilution factor W is linear. This allows to set it here to
   // 1. and scale to its actual value later on.

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <format>
 #include <ios>
 #include <span>
 #include <sstream>
@@ -133,14 +134,16 @@ void precalculate_rate_coefficient_integrals() {
   // Calculate the rate coefficients for each level of each ion of each element
   for (int element = 0; element < get_nelements(); element++) {
     const int atomic_number = get_atomicnumber(element);
-    printlog("Performing rate integrals for Z = {}: ion stages", atomic_number);
     const int nions = get_nions(element) - 1;
+    std::string ionstagelist;
+    for (int ion = 0; ion < nions; ion++) {
+      ionstagelist += std::format(" {}", get_ionstage(element, ion));
+    }
+    printlnlog("Performing rate integrals for Z = {}: ion stages{}", atomic_number, ionstagelist);
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (int ion = 0; ion < nions; ion++) {
-      const int ionstage = get_ionstage(element, ion);
-      printlog(" {}", ionstage);
       const int nlevels = get_nlevels_ionising(element, ion);
 
       for (int level = 0; level < nlevels; level++) {
@@ -207,7 +210,6 @@ void precalculate_rate_coefficient_integrals() {
         }  // phixstarget loop
       }  // level loop
     }  // ion loop
-    printlnlog("");
   }
 
   MPI_Barrier_node();
@@ -608,8 +610,8 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
 }
 
 // Get an ion's rate coefficient for spontaneous recombination in LTE
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_ion_spontrecombcoeff(const int uniqueionindex, const float T_e)
-    -> double {
+[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_ion_spontrecombcoeff(const int uniqueionindex,
+                                                                      const float T_e) -> double {
   const auto upperindex = get_temperature_gridupperindex(T_e);
   if (upperindex == 0) {
     return ion_alpha_sp[uniqueionindex * TABLESIZE];
@@ -628,8 +630,8 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
 
 // Return a level's rate coefficient for spontaneous recombination in LTE
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_spontrecombcoeff(const int uniquelevelindex,
-                                                                  const int phixstargetindex, const float T_e)
-    -> double {
+                                                                  const int phixstargetindex,
+                                                                  const float T_e) -> double {
   return lerp_or_last(std::span{spontrecombcoeffs}, uniquelevelindex, phixstargetindex, T_e);
 }
 
@@ -717,8 +719,8 @@ void ratecoefficients_init() {
 }
 
 // Returns the (stimulated recombination corrected) photoionisation rate coefficient.
-auto get_corrphotoioncoeff_ana(int element, const int ion, const int level, const int phixstargetindex, const float T_R)
-    -> double {
+auto get_corrphotoioncoeff_ana(int element, const int ion, const int level, const int phixstargetindex,
+                               const float T_R) -> double {
   assert_always(USE_LUT_PHOTOION);
   const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
   return lerp_or_last(std::span{corrphotoioncoeffs}, uniquelevelindex, phixstargetindex, T_R);

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -135,11 +135,13 @@ void precalculate_rate_coefficient_integrals() {
   for (int element = 0; element < get_nelements(); element++) {
     const int atomic_number = get_atomicnumber(element);
     const int nions = get_nions(element) - 1;
-    std::string ionstagelist;
+    // print the full list before the parallel loop below, since worker threads have their own
+    // (unopened) threadprivate output streams
+    printlog("Performing rate integrals for Z = {}: ion stages", atomic_number);
     for (int ion = 0; ion < nions; ion++) {
-      ionstagelist += std::format(" {}", get_ionstage(element, ion));
+      printlog(" {}", get_ionstage(element, ion));
     }
-    printlnlog("Performing rate integrals for Z = {}: ion stages{}", atomic_number, ionstagelist);
+    printlnlog("");
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -133,11 +133,12 @@ void precalculate_rate_coefficient_integrals() {
   // Calculate the rate coefficients for each level of each ion of each element
   for (int element = 0; element < get_nelements(); element++) {
     const int atomic_number = get_atomicnumber(element);
-    const int nions = get_nions(element) - 1;
-    // print the full list before the parallel loop below, since worker threads have their own
-    // (unopened) threadprivate output streams
+    const int nions = get_nions(element);
+    if (nions == 0) {
+      continue;
+    }
     printlog("Performing rate integrals for Z = {}: ion stages", atomic_number);
-    for (int ion = 0; ion < nions; ion++) {
+    for (int ion = 0; ion < nions - 1; ion++) {
       printlog(" {}", get_ionstage(element, ion));
     }
     printlnlog("");

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -529,7 +529,7 @@ void setup_photoion_luts() {
 
   printlnlog(
       "[info] mem_usage: lookup tables derived from photoionisation (spontrecombcoeff, bfcooling and "
-      "corrphotoioncoeff if USE_LUT_PHOTOION) occupy {:.3f} [MB]",
+      "corrphotoioncoeff if USE_LUT_PHOTOION) occupy {:.3f} MB",
       mem_usage_photoionluts / 1024. / 1024.);
 }
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -262,7 +262,7 @@ void read_recombrate_file() {
   const float Te_estimate = RECOMBCALIBRATION_T_ELEC;
   const double log_Te_estimate = log10(RECOMBCALIBRATION_T_ELEC);
 
-  printlnlog("Calibrating recombination rates for a temperature of {:.1f} K", Te_estimate);
+  printlnlog("Calibrating recombination rates for a temperature of {:.1f} [K]", Te_estimate);
 
   struct RRCRow {
     double log_Te;
@@ -331,7 +331,7 @@ void read_recombrate_file() {
 
         double rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative,
                                               false, per_groundmultipletpop);
-        printlnlog("    rrc (initial): {:10.3e} cm^3/s", rrc);
+        printlnlog("    rrc (initial): {:10.3e} [cm^3/s]", rrc);
 
         if (!(rrc > 0.)) {
           // no recombination into this ion from the atomic data (e.g. the ion below has no
@@ -355,14 +355,14 @@ void read_recombrate_file() {
 
             rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
                                            per_groundmultipletpop);
-            printlnlog("    rrc (after low-n scaling): {:10.3e} cm^3/s", rrc);
+            printlnlog("    rrc (after low-n scaling): {:10.3e} [cm^3/s]", rrc);
           }
         }
 
         // hopefully the RRC now matches the low_n value well, if it was defined
         // Next, use the superlevel recombination rates to make up the excess needed to reach the total RRC
 
-        printlnlog("  input_rrc_total: {:10.3e} cm^3/s", input_rrc_total);
+        printlnlog("  input_rrc_total: {:10.3e} [cm^3/s]", input_rrc_total);
 
         if (input_rrc_total < 0) {
           // negative means no tabulated total, in the same way that a negative rrc_low_n is ignored above
@@ -370,7 +370,7 @@ void read_recombrate_file() {
         } else if (rrc < input_rrc_total) {
           const double rrc_superlevel = calculate_ionrecombcoeff(
               -1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, true, per_groundmultipletpop);
-          printlnlog("  rrc(superlevel): {:10.3e} cm^3/s", rrc_superlevel);
+          printlnlog("  rrc(superlevel): {:10.3e} [cm^3/s]", rrc_superlevel);
 
           if (rrc_superlevel > 0) {
             const double phixs_multiplier_superlevel = 1.0 + ((input_rrc_total - rrc) / rrc_superlevel);
@@ -386,7 +386,7 @@ void read_recombrate_file() {
             scale_levels(0, phixs_multiplier);
           }
         } else {
-          printlnlog("    rrc {:10.3e} >= input_rrc_total {:10.3e} cm^3/s", rrc, input_rrc_total);
+          printlnlog("    rrc {:10.3e} >= input_rrc_total {:10.3e} [cm^3/s]", rrc, input_rrc_total);
           const double phixs_multiplier = input_rrc_total / rrc;
           printlnlog("    scaling phixs of all levels by {:.3f}", phixs_multiplier);
 
@@ -395,7 +395,7 @@ void read_recombrate_file() {
 
         rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
                                        per_groundmultipletpop);
-        printlnlog("    rrc (final): {:10.3e} cm^3/s", rrc);
+        printlnlog("    rrc (final): {:10.3e} [cm^3/s]", rrc);
       }
     }
   }
@@ -527,7 +527,7 @@ void setup_photoion_luts() {
 
   printlnlog(
       "[info] mem_usage: lookup tables derived from photoionisation (spontrecombcoeff, bfcooling and "
-      "corrphotoioncoeff if USE_LUT_PHOTOION) occupy {:.3f} MB",
+      "corrphotoioncoeff if USE_LUT_PHOTOION) occupy {:.3f} [MB]",
       mem_usage_photoionluts / 1024. / 1024.);
 }
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -331,7 +331,7 @@ void read_recombrate_file() {
 
         double rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative,
                                               false, per_groundmultipletpop);
-        printlnlog("              rrc: {:10.3e}", rrc);
+        printlnlog("    rrc (initial): {:10.3e} cm^3/s", rrc);
 
         if (!(rrc > 0.)) {
           // no recombination into this ion from the atomic data (e.g. the ion below has no
@@ -355,14 +355,14 @@ void read_recombrate_file() {
 
             rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
                                            per_groundmultipletpop);
-            printlnlog("              rrc: {:10.3e}", rrc);
+            printlnlog("    rrc (after low-n scaling): {:10.3e} cm^3/s", rrc);
           }
         }
 
         // hopefully the RRC now matches the low_n value well, if it was defined
         // Next, use the superlevel recombination rates to make up the excess needed to reach the total RRC
 
-        printlnlog("  input_rrc_total: {:10.3e}", input_rrc_total);
+        printlnlog("  input_rrc_total: {:10.3e} cm^3/s", input_rrc_total);
 
         if (input_rrc_total < 0) {
           // negative means no tabulated total, in the same way that a negative rrc_low_n is ignored above
@@ -370,7 +370,7 @@ void read_recombrate_file() {
         } else if (rrc < input_rrc_total) {
           const double rrc_superlevel = calculate_ionrecombcoeff(
               -1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, true, per_groundmultipletpop);
-          printlnlog("  rrc(superlevel): {:10.3e}", rrc_superlevel);
+          printlnlog("  rrc(superlevel): {:10.3e} cm^3/s", rrc_superlevel);
 
           if (rrc_superlevel > 0) {
             const double phixs_multiplier_superlevel = 1.0 + ((input_rrc_total - rrc) / rrc_superlevel);
@@ -386,7 +386,7 @@ void read_recombrate_file() {
             scale_levels(0, phixs_multiplier);
           }
         } else {
-          printlnlog("rrc >= input_rrc_total!");
+          printlnlog("    rrc {:10.3e} >= input_rrc_total {:10.3e} cm^3/s", rrc, input_rrc_total);
           const double phixs_multiplier = input_rrc_total / rrc;
           printlnlog("    scaling phixs of all levels by {:.3f}", phixs_multiplier);
 
@@ -395,7 +395,7 @@ void read_recombrate_file() {
 
         rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
                                        per_groundmultipletpop);
-        printlnlog("              rrc: {:10.3e}", rrc);
+        printlnlog("    rrc (final): {:10.3e} cm^3/s", rrc);
       }
     }
   }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -955,6 +955,8 @@ void calculate_expansion_opacities(const int nonemptymgi) {
   const auto sys_time_start_calc = std::chrono::steady_clock::now();
   const auto temperature = grid::get_Te(nonemptymgi);
 
+  printlog("calculating expansion opacities for cell {}...", grid::get_mgi_of_nonemptymgi(nonemptymgi));
+
   const auto t_mid = globals::timesteps[globals::timestep].mid;
 
   // find the first line with nu below the upper limit of the first bin
@@ -998,8 +1000,5 @@ void calculate_expansion_opacities(const int nonemptymgi) {
   }
   const auto expansion_opacity_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_calc).count();
-  if (expansion_opacity_duration >= 1.) {
-    printlnlog("calculating expansion opacities for cell {} timestep {} took {:.1f} seconds",
-               grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, expansion_opacity_duration);
-  }
+  printlnlog("took {:.1f} seconds", expansion_opacity_duration);
 }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -955,8 +955,6 @@ void calculate_expansion_opacities(const int nonemptymgi) {
   const auto sys_time_start_calc = std::chrono::steady_clock::now();
   const auto temperature = grid::get_Te(nonemptymgi);
 
-  printlog("calculating expansion opacities for cell {}...", grid::get_mgi_of_nonemptymgi(nonemptymgi));
-
   const auto t_mid = globals::timesteps[globals::timestep].mid;
 
   // find the first line with nu below the upper limit of the first bin
@@ -1000,5 +998,8 @@ void calculate_expansion_opacities(const int nonemptymgi) {
   }
   const auto expansion_opacity_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_calc).count();
-  printlnlog("took {:.1f} seconds", expansion_opacity_duration);
+  if (expansion_opacity_duration >= 1.) {
+    printlnlog("calculating expansion opacities for cell {} timestep {} took {:.1f} seconds",
+               grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, expansion_opacity_duration);
+  }
 }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -555,7 +555,7 @@ auto do_rpkt_step(Packet& pkt, const double t2, ContinuumOpacity& chi_rpkt_cont)
   } else if (thickcell) {
     // In the case of optically thick cells, we treat the packets in grey approximation to speed up the calculation
 
-    const double chi_grey = grid::get_kappagrey(nonemptymgi) * grid::get_rho(nonemptymgi) *
+    const double chi_grey = grid::kappagrey_allcells[nonemptymgi] * grid::get_rho(nonemptymgi) *
                             calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
 
     edist = tau_rnd / chi_grey;
@@ -675,7 +675,7 @@ auto do_rpkt_step(Packet& pkt, const double t2, ContinuumOpacity& chi_rpkt_cont)
 // = kappa(free-free) * nne
 auto calculate_chi_ffheating(const int nonemptymgi, const double nu, const bool use_cellcache) -> double {
   const auto clumpednne = grid::get_nne(nonemptymgi) * grid::get_clumpfactor(nonemptymgi);
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   assert_testmodeonly(!use_cellcache || get_cellcache(nonemptymgi).nonemptymgi == nonemptymgi);
   const auto chi_ff_nnionpart =
       use_cellcache ? get_cellcache(nonemptymgi).chi_ff_nnionpart[0] : calculate_chi_ffheat_nnionpart(nonemptymgi);
@@ -702,7 +702,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
     }
   }
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_nne(nonemptymgi) * grid::get_clumpfactor(nonemptymgi);
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   const auto& allcont_nu_edge = globals::allcont.nu_edge;
@@ -824,7 +824,7 @@ auto calculate_chi_ffheat_nnionpart(const int nonemptymgi) -> double {
       chi_ff_nnionpart += pow2(ioncharge) * g_ff * nnion;
     }
   }
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
 
   return chi_ff_nnionpart * 3.69255e8 / sqrt(T_e);
 }
@@ -953,7 +953,7 @@ void calculate_expansion_opacities(const int nonemptymgi) {
   const auto rho = grid::get_rho(nonemptymgi);
 
   const auto sys_time_start_calc = std::chrono::steady_clock::now();
-  const auto temperature = grid::get_Te(nonemptymgi);
+  const auto temperature = grid::Te_allcells[nonemptymgi];
 
   printlog("calculating expansion opacities for cell {}...", grid::get_mgi_of_nonemptymgi(nonemptymgi));
 

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -385,8 +385,7 @@ void electron_scatter_rpkt(Packet& pkt) {
   // Check unit vector
   assert_testmodeonly(fabs(vec_len(pkt.dir) - 1.) < 1.e-6);
 
-  // Finally we want to put in the rest frame energy and frequency.
-  // And record that it's now a r-pkt.
+  // Finally we want to put in the rest frame energy and frequency. And record that it's now a r-pkt.
 
   set_pkt_restframe_from_cmf(pkt);
 }
@@ -400,14 +399,12 @@ void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
   const double chi_ff = chi_rpkt_cont.chi_freefree_heat * dopplerfactor;
   const double chi_bf = chi_rpkt_cont.chi_boundfree * dopplerfactor;
 
-  // continuum process happens. select due to its probabilities sigma/chi_cont, chi_ff/chi_cont,
-  // chi_bf/chi_cont
+  // continuum process happens. select due to its probabilities sigma/chi_cont, chi_ff/chi_cont, chi_bf/chi_cont
 
   const auto chi_rnd = rng_uniform(get_rngstate(pkt)) * chi_cont;
   if (chi_rnd < chi_escatter) {
     // electron scattering occurs
-    // in this case the packet stays a R_PKT of same nu_cmf as before (coherent scattering)
-    // but with different direction
+    // in this case the packet stays a R_PKT of same nu_cmf as before (coherent scattering) but with different direction
     pkt.nscatterings++;
     stats::increment(stats::Counter::ELECTRON_SCATTERINGS);
 
@@ -418,8 +415,7 @@ void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
 
     electron_scatter_rpkt(pkt);
 
-    // Electron scattering does not modify the last emission flag
-    // but it updates the last emission position
+    // Electron scattering does not modify the last emission flag but it updates the last emission position
     pkt.em_pos = pkt.pos;
     pkt.em_time = static_cast<float>(pkt.prop_time);
 
@@ -690,8 +686,7 @@ auto calculate_chi_ffheating(const int nonemptymgi, const double nu, const bool 
 
 // sum the bound-free opacity at frequency nu over all photoionisation continua (using the
 // binary-searched frequency window of contributing edges). When USECELLHISTANDUPDATEPHIXSLIST is
-// true, also record each continuum's contribution in the phixslist and cache the running sum for
-// reuse within the cell.
+// true, also record each continuum's contribution in the phixslist and cache the running sum for reuse within the cell.
 template <bool USECELLHISTANDUPDATEPHIXSLIST>
 auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixslist& phixslist) -> double {
   double chi_bf_sum = 0.;
@@ -749,8 +744,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
     const int level = allcont_level[i];
     double sigma_contr = 0.;
 
-    // The bf process happens only if the current cell contains
-    // the involved atomic species
+    // The bf process happens only if the current cell contains the involved atomic species
     const bool should_keep_this_cont = USECELLHISTANDUPDATEPHIXSLIST
                                            ? get_cellcache(nonemptymgi).allcont_keep[i]
                                            : keep_this_cont(element, ion, level, nonemptymgi, nnetot);
@@ -887,8 +881,7 @@ DEVICE_FUNC void emit_rpkt(Packet& pkt) {
 
   pkt.dir = angle_ab(dir_cmf, vel_vec);
 
-  // Finally we want to put in the rest frame energy and frequency. And record
-  // that it's now a r-pkt.
+  // Finally we want to put in the rest frame energy and frequency. And record that it's now a r-pkt.
 
   set_pkt_restframe_from_cmf(pkt);
 

--- a/rpkt.h
+++ b/rpkt.h
@@ -124,8 +124,7 @@ auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
 
   if constexpr (USE_RELATIVISTIC_DOPPLER_SHIFT) {
     // With special relativity, the Doppler shift formula has an extra factor of 1/gamma in it,
-    // which changes the distance reach a line resonance and creates a dependence
-    // on packet position and direction
+    // which changes the distance reach a line resonance and creates a dependence on packet position and direction
 
     // use linear interpolation of frequency along the path
     return -delta_nu / dnu_on_dl;  // dnu_on_dl is negative, so this is a positive distance
@@ -161,8 +160,7 @@ auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
     return 0;
   }
   // otherwise go through the list until nu_cmf is located between two
-  // entries in the line list and get the index of the closest line
-  // to lower frequencies
+  // entries in the line list and get the index of the closest line to lower frequencies
 
   // will find the highest frequency (lowest index) line with nu_line <= nu_cmf
   // lower_bound matches the first element where the comparison function is false

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -200,7 +200,6 @@ void initialise_linestat_file() {
 void write_deposition_file() {
   const int my_rank = globals::my_rank;
   const int nts = globals::timestep;
-  printlog("Calculating and writing deposition.out...");
   const auto time_write_deposition_file_start = std::chrono::steady_clock::now();
   double mtot = 0.;
   const int nstart_nonempty = grid::get_nstart_nonempty(my_rank);
@@ -345,7 +344,7 @@ void write_deposition_file() {
 
   const auto deposition_write_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - time_write_deposition_file_start).count();
-  printlnlog("took {:.1f} seconds", deposition_write_duration);
+  printlnlog("calculating and writing deposition.out took {:.1f} seconds", deposition_write_duration);
 }
 
 void write_timestep_file() {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -144,16 +144,16 @@ void setup_cellcache() {
     }
 
     if (cellcachenum == 0) {
-      printlnlog("[info] mem_usage: cellcache coolinglist contribs for slot 0 occupies {:.3f} [MB]",
+      printlnlog("[info] mem_usage: cellcache coolinglist contribs for slot 0 occupies {:.3f} MB",
                  ncoolingterms * sizeof(double) / 1024. / 1024.);
-      printlnlog("[info] mem_usage: cellcache macroatom stats for slot 0 occupies {:.3f} [MB]",
+      printlnlog("[info] mem_usage: cellcache macroatom stats for slot 0 occupies {:.3f} MB",
                  chtransblocksize * sizeof(double) / 1024. / 1024.);
-      printlnlog("[info] mem_usage: cellcache for slot 0 occupies {:.3f} [MB]",
+      printlnlog("[info] mem_usage: cellcache for slot 0 occupies {:.3f} MB",
                  cacheslot.get_mem_usage() / 1024. / 1024.);
     }
     mem_usage_cellcache += cacheslot.get_mem_usage();
   }
-  printlnlog("[info] mem_usage: cellcache for all {} slots occupies {:.3f} [MB]", num_cellcache_slots,
+  printlnlog("[info] mem_usage: cellcache for all {} slots occupies {:.3f} MB", num_cellcache_slots,
              mem_usage_cellcache / 1024. / 1024.);
 }
 
@@ -939,7 +939,7 @@ auto main(int argc, char* argv[]) -> int {
   printlnlog("Simulation propagates {:g} packets per process (total {:g} with nprocs {})", 1. * MPKTS,
              1. * MPKTS * globals::nprocs, globals::nprocs);
 
-  printlnlog("[info] mem_usage: packets occupy {:.3f} [MB]", MPKTS * sizeof(Packet) / 1024. / 1024.);
+  printlnlog("[info] mem_usage: packets occupy {:.3f} MB", MPKTS * sizeof(Packet) / 1024. / 1024.);
 
   if (!globals::simulation_continued_from_saved) {
     std::remove("deposition.out");

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -144,16 +144,16 @@ void setup_cellcache() {
     }
 
     if (cellcachenum == 0) {
-      printlnlog("[info] mem_usage: cellcache coolinglist contribs for slot 0 occupies {:.3f} MB",
+      printlnlog("[info] mem_usage: cellcache coolinglist contribs for slot 0 occupies {:.3f} [MB]",
                  ncoolingterms * sizeof(double) / 1024. / 1024.);
-      printlnlog("[info] mem_usage: cellcache macroatom stats for slot 0 occupies {:.3f} MB",
+      printlnlog("[info] mem_usage: cellcache macroatom stats for slot 0 occupies {:.3f} [MB]",
                  chtransblocksize * sizeof(double) / 1024. / 1024.);
-      printlnlog("[info] mem_usage: cellcache for slot 0 occupies {:.3f} MB",
+      printlnlog("[info] mem_usage: cellcache for slot 0 occupies {:.3f} [MB]",
                  cacheslot.get_mem_usage() / 1024. / 1024.);
     }
     mem_usage_cellcache += cacheslot.get_mem_usage();
   }
-  printlnlog("[info] mem_usage: cellcache for all {} slots occupies {:.3f} MB", num_cellcache_slots,
+  printlnlog("[info] mem_usage: cellcache for all {} slots occupies {:.3f} [MB]", num_cellcache_slots,
              mem_usage_cellcache / 1024. / 1024.);
 }
 
@@ -734,7 +734,7 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
 
     write_partial_lightcurve_spectra(nts, packets);
 
-    printlnlog("During timestep {} on MPI process {}, {} pellets decayed and {} packets escaped. (t={:g}d)", nts,
+    printlnlog("During timestep {} on MPI process {}, {} pellets decayed and {} packets escaped. (t={:g} [d])", nts,
                globals::my_rank, globals::timesteps[nts].pellet_decays, stats::get_counter(stats::Counter::PKTESCAPES),
                globals::timesteps[nts].mid / DAY);
 
@@ -939,7 +939,7 @@ auto main(int argc, char* argv[]) -> int {
   printlnlog("Simulation propagates {:g} packets per process (total {:g} with nprocs {})", 1. * MPKTS,
              1. * MPKTS * globals::nprocs, globals::nprocs);
 
-  printlnlog("[info] mem_usage: packets occupy {:.3f} MB", MPKTS * sizeof(Packet) / 1024. / 1024.);
+  printlnlog("[info] mem_usage: packets occupy {:.3f} [MB]", MPKTS * sizeof(Packet) / 1024. / 1024.);
 
   if (!globals::simulation_continued_from_saved) {
     std::remove("deposition.out");

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -276,8 +276,7 @@ void write_deposition_file() {
       std::print(dep_file, " Qdotspfission_ana_erg/s/g");
     }
     std::print(dep_file,
-               " eps_erg/s/g Qdot_ana_erg/s/g positrondep_discrete_Lsun elecdep_discrete_Lsun "
-               "alphadep_discrete_Lsun");
+               " eps_erg/s/g Qdot_ana_erg/s/g positrondep_discrete_Lsun elecdep_discrete_Lsun alphadep_discrete_Lsun");
     if (any_fission) {
       std::print(dep_file, " spfission_dep_discrete_Lsun");
     }
@@ -699,8 +698,7 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
              communicate_grid_duration);
 
   // If this is not the 0th time step of the current job step,
-  // write out a snapshot of the grid properties for further restarts
-  // and update input.txt accordingly
+  // write out a snapshot of the grid properties for further restarts and update input.txt accordingly
   if (((nts - globals::timestep_initial) != 0)) {
     save_grid_and_packets(nts, packets);
     do_this_full_loop = walltime_sufficient_to_continue(nts, nts_prev, walltimelimitseconds);
@@ -1012,8 +1010,7 @@ auto main(int argc, char* argv[]) -> int {
 
   // The main calculation is now over. The packets now have all stored the time, place and direction
   // at which they left the grid. Also their rest frame energies and frequencies.
-  // Spectra and light curves are now extracted using exspec which is another make target of this
-  // code.
+  // Spectra and light curves are now extracted using exspec which is another make target of this code.
 
   MPI_Barrier_allranks();
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -200,6 +200,7 @@ void initialise_linestat_file() {
 void write_deposition_file() {
   const int my_rank = globals::my_rank;
   const int nts = globals::timestep;
+  printlog("Calculating and writing deposition.out...");
   const auto time_write_deposition_file_start = std::chrono::steady_clock::now();
   double mtot = 0.;
   const int nstart_nonempty = grid::get_nstart_nonempty(my_rank);
@@ -344,7 +345,7 @@ void write_deposition_file() {
 
   const auto deposition_write_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - time_write_deposition_file_start).count();
-  printlnlog("calculating and writing deposition.out took {:.1f} seconds", deposition_write_duration);
+  printlnlog("took {:.1f} seconds", deposition_write_duration);
 }
 
 void write_timestep_file() {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -822,7 +822,7 @@ auto main(int argc, char* argv[]) -> int {
   printlnlog("GPU_ON is enabled");
 #endif
 
-  printlnlog("time at start");
+  printlnlog("sn3d launched (this line marks the start time)");
 
   printlog("Integration method is: ");
 
@@ -847,11 +847,10 @@ auto main(int argc, char* argv[]) -> int {
   int opt = 0;
   while ((opt = getopt(argc, argv, "w:")) != -1) {  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
     if (opt == 'w') {
-      printlog("Command line argument specifies wall time hours '{}', setting ",
-               optarg);  // NOLINT(misc-include-cleaner)
-      const float walltimehours = strtof(optarg, nullptr);
+      const float walltimehours = strtof(optarg, nullptr);  // NOLINT(misc-include-cleaner)
       walltimelimitseconds = static_cast<int>(walltimehours * HOUR);
-      printlnlog("walltimelimitseconds = {}", walltimelimitseconds);
+      printlnlog("command line argument specifies wall time hours '{}', so setting walltimelimitseconds = {}", optarg,
+                 walltimelimitseconds);
     } else {
       std::println(stderr, "Usage: {} [-w WALLTIMELIMITHOURS]",
                    argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic,)
@@ -862,11 +861,11 @@ auto main(int argc, char* argv[]) -> int {
   std::vector<Packet> packets;
   reserve_resize(packets, MPKTS);
 
-  printlnlog("git branch {}", GIT_BRANCH);
+  printlnlog("git branch: {}", GIT_BRANCH);
 
   printlnlog("git version: {}", GIT_VERSION);
 
-  printlnlog("git status {}", GIT_STATUS);
+  printlnlog("git status: {}", GIT_STATUS);
 
   printlnlog("sn3d compiled at {} on {}", __TIME__, __DATE__);
 
@@ -881,7 +880,7 @@ auto main(int argc, char* argv[]) -> int {
              globals::node_id, globals::node_count - 1);
 #ifdef MAX_NODE_SIZE
   printlnlog(
-      "WARNING: Compiled with MAX_NODE_SIZE {}, which may mean that there are more nodes reported than physically "
+      "[warning] Compiled with MAX_NODE_SIZE {}, which may mean that there are more nodes reported than physically "
       "present",
       MAX_NODE_SIZE);
 #endif
@@ -954,12 +953,14 @@ auto main(int argc, char* argv[]) -> int {
   const int nstart = grid::get_nstart(globals::my_rank);
   const int ndo = grid::get_ndo(globals::my_rank);
   const int ndo_nonempty = grid::get_ndo_nonempty(globals::my_rank);
-  printlog("process rank {} (global max rank {}) assigned {} modelgrid cells ({} nonempty)", globals::my_rank,
-           globals::nprocs - 1, ndo, ndo_nonempty);
   if (ndo > 0) {
-    printlnlog(": cells [{}..{}] (model has max mgi {})", nstart, nstart + ndo - 1, grid::get_npts_model() - 1);
+    printlnlog(
+        "process rank {} (global max rank {}) assigned {} modelgrid cells ({} nonempty): cells [{}..{}] (model "
+        "has max mgi {})",
+        globals::my_rank, globals::nprocs - 1, ndo, ndo_nonempty, nstart, nstart + ndo - 1, grid::get_npts_model() - 1);
   } else {
-    printlnlog("");
+    printlnlog("process rank {} (global max rank {}) assigned {} modelgrid cells ({} nonempty)", globals::my_rank,
+               globals::nprocs - 1, ndo, ndo_nonempty);
   }
 
   MPI_Barrier_allranks();

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -882,7 +882,7 @@ auto main(int argc, char* argv[]) -> int {
              globals::node_id, globals::node_count - 1);
 #ifdef MAX_NODE_SIZE
   printlnlog(
-      "WARNING: Compiled with MAX_NODE_SIZE {}, which may mean mean that there are more nodes reported than physically "
+      "WARNING: Compiled with MAX_NODE_SIZE {}, which may mean that there are more nodes reported than physically "
       "present",
       MAX_NODE_SIZE);
 #endif

--- a/sn3d.h
+++ b/sn3d.h
@@ -1,6 +1,5 @@
 // Small shared helpers for the simulation executables: the already-running lock check and
-// inline numeric utilities (exact vector resize, fractional-tolerance comparison, bin-index
-// lookups).
+// inline numeric utilities (exact vector resize, fractional-tolerance comparison, bin-index lookups).
 
 #ifndef SN3D_H
 #define SN3D_H

--- a/sn3d.h
+++ b/sn3d.h
@@ -49,7 +49,7 @@ inline void check_already_running() {
       pidfile.close();
       if (is_pid_running(artispid_in) && std::filesystem::current_path().generic_string() == line) {
         std::println(stderr,
-                     "\nERROR: artis or exspec is already running in this folder with existing pid {}. Refusing to "
+                     "\n[error] artis or exspec is already running in this folder with existing pid {}. Refusing to "
                      "start. (delete artis.pid if you are sure this is incorrect)",
                      artispid_in);
         std::abort();

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -536,7 +536,7 @@ void init_spectra(Spectra& spectra, const double nu_min, const double nu_max, co
   MPI_Barrier_allranks();
 
   if (print_memusage) {
-    printlnlog("[info] mem_usage: set of spectra{} occupy {:.3f} [MB] (node shared memory)",
+    printlnlog("[info] mem_usage: set of spectra{} occupy {:.3f} MB (node shared memory)",
                do_emission_absorption ? " (with emission/absorption tracing)" : "",
                spectra.mem_usage_bytes() / 1024. / 1024.);
   }

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -84,8 +84,7 @@ void printout_tracemission_stats() {
 
       printlnlog(
           "Top line emission contributions in the range lambda [{:5.1f}, {:5.1f}] [Angstrom] time [{:5.1f}, {:5.1f}] "
-          "[d] "
-          "({:g} [erg])",
+          "[d] ({:g} [erg])",
           traceemissabs_lambdamin, traceemissabs_lambdamax, traceemissabs_timemin / DAY, traceemissabs_timemax / DAY,
           traceemission_totalenergy);
     } else {
@@ -648,8 +647,7 @@ void add_to_spec_res(const Packet& pkt, const int dirbin, Spectra& spectra_I, Sp
 }
 
 void write_partial_lightcurve_spectra(const int nts, std::span<const Packet> pkts) {
-  // this is called by sn3d (not exspec) when each rank has its own set of packets
-  // in memory
+  // this is called by sn3d (not exspec) when each rank has its own set of packets in memory
   const bool simulation_complete = (nts >= globals::timestep_finish - 1);
 
   // the emission resolved spectra are slow to generate, and require a lot of memory

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -96,7 +96,7 @@ void printout_tracemission_stats() {
           traceabsorption_totalenergy);
     }
 
-    printlnlog("{:>16} {:>4} {:>9} {:>5} {:>5} {:>8} {:>5} {:>7} {:>7} {:>7} {:>7}", "energy (frac)", "Z", "ionstage",
+    printlnlog("{:>17} {:>4} {:>9} {:>5} {:>5} {:>8} {:>5} {:>7} {:>7} {:>7} {:>7}", "energy (frac)", "Z", "ionstage",
                "upper", "lower", "coll_str", "forb", "lambda", "<v_rad>", "B_lu", "B_ul");
 
     // display the top entries of the sorted list

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -96,8 +96,8 @@ void printout_tracemission_stats() {
           traceabsorption_totalenergy);
     }
 
-    printlnlog("{:>17} {:>4} {:>9} {:>5} {:>8} {:>8} {:>4} {:>7} {:>7} {:>7} {:>7}", "energy", "Z", "ionstage", "upper",
-               "lower", "coll_str", "forb", "lambda", "<v_rad>", "B_lu", "B_ul");
+    printlnlog("{:>16} {:>4} {:>9} {:>5} {:>5} {:>8} {:>5} {:>7} {:>7} {:>7} {:>7}", "energy (frac)", "Z", "ionstage",
+               "upper", "lower", "coll_str", "forb", "lambda", "<v_rad>", "B_lu", "B_ul");
 
     // display the top entries of the sorted list
     const auto nlines_limited = std::min(std::ssize(globals::linelist.nu), maxlinesprinted);
@@ -147,7 +147,7 @@ void printout_tracemission_stats() {
         }
         assert_always(downtransid != -1);
 
-        printlnlog("{:7.2e} ({:5.1f}%) {:4} {:9} {:5} {:5} {:8.1f}  {:4} {:7.1f} {:7.1f} {:7.1e} {:7.1e}", encontrib,
+        printlnlog("{:7.2e} ({:5.1f}%) {:4} {:9} {:5} {:5} {:8.1f} {:5} {:7.1f} {:7.1f} {:7.1e} {:7.1e}", encontrib,
                    100 * encontrib / totalenergy, get_atomicnumber(element), get_ionstage(element, ion), upper, lower,
                    globals::alltrans.coll_str[downtransid], static_cast<int>(globals::alltrans.forbidden[downtransid]),
                    linelambda, v_rad, B_lu, B_ul);

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -79,19 +79,21 @@ void printout_tracemission_stats() {
     if (mode == 0) {
       std::ranges::SORT_OR_STABLE_SORT(traceemissionabsorption,
                                        [](const auto& a, const auto& b) { return a.energyemitted > b.energyemitted; });
-      printlnlog("lambda [{:5.1f}, {:5.1f}] nu {:g} {:g}", traceemissabs_lambdamin, traceemissabs_lambdamax,
-                 traceemissabs_nulower, traceemissabs_nuupper);
+      printlnlog("lambda [{:5.1f}, {:5.1f}] [Angstrom] nu [{:g}, {:g}] [Hz]", traceemissabs_lambdamin,
+                 traceemissabs_lambdamax, traceemissabs_nulower, traceemissabs_nuupper);
 
       printlnlog(
-          "Top line emission contributions in the range lambda [{:5.1f}, {:5.1f}] time [{:5.1f}d, {:5.1f}d] ({:g} erg)",
+          "Top line emission contributions in the range lambda [{:5.1f}, {:5.1f}] [Angstrom] time [{:5.1f}, {:5.1f}] "
+          "[d] "
+          "({:g} [erg])",
           traceemissabs_lambdamin, traceemissabs_lambdamax, traceemissabs_timemin / DAY, traceemissabs_timemax / DAY,
           traceemission_totalenergy);
     } else {
       std::ranges::SORT_OR_STABLE_SORT(traceemissionabsorption, std::ranges::greater{},
                                        &EmissionAbsorptionContrib::energyabsorbed);
       printlnlog(
-          "Top line absorption contributions in the range lambda [{:5.1f}, {:5.1f}] time [{:5.1f}d, {:5.1f}d] ({:g} "
-          "erg)",
+          "Top line absorption contributions in the range lambda [{:5.1f}, {:5.1f}] [Angstrom] time [{:5.1f}, {:5.1f}] "
+          "[d] ({:g} [erg])",
           traceemissabs_lambdamin, traceemissabs_lambdamax, traceemissabs_timemin / DAY, traceemissabs_timemax / DAY,
           traceabsorption_totalenergy);
     }
@@ -534,7 +536,7 @@ void init_spectra(Spectra& spectra, const double nu_min, const double nu_max, co
   MPI_Barrier_allranks();
 
   if (print_memusage) {
-    printlnlog("[info] mem_usage: set of spectra{} occupy {:.3f} MB (node shared memory)",
+    printlnlog("[info] mem_usage: set of spectra{} occupy {:.3f} [MB] (node shared memory)",
                do_emission_absorption ? " (with emission/absorption tracing)" : "",
                spectra.mem_usage_bytes() / 1024. / 1024.);
   }

--- a/stats.cc
+++ b/stats.cc
@@ -74,11 +74,9 @@ void pkt_action_counters_printout(const int nts) {
   printlnlog("timestep {}: k_stat_from: ff {} bf {} earlierdecay {}", nts, get_counter(Counter::K_STAT_FROM_FF),
              get_counter(Counter::K_STAT_FROM_BF), get_counter(Counter::K_STAT_FROM_EARLIERDECAY));
 
-  if constexpr (NT_ON) {
-    printlnlog("timestep {}: nt_stat: from_gamma {} to_ionisation {} to_excitation {} to_kpkt {}", nts,
-               get_counter(Counter::NT_STAT_FROM_GAMMA), get_counter(Counter::NT_STAT_TO_IONISATION),
-               get_counter(Counter::NT_STAT_TO_EXCITATION), get_counter(Counter::NT_STAT_TO_KPKT));
-  }
+  printlnlog("timestep {}: nt_stat: from_gamma {} to_ionisation {} to_excitation {} to_kpkt {}", nts,
+             get_counter(Counter::NT_STAT_FROM_GAMMA), get_counter(Counter::NT_STAT_TO_IONISATION),
+             get_counter(Counter::NT_STAT_TO_EXCITATION), get_counter(Counter::NT_STAT_TO_KPKT));
   nonthermal::print_stats(modelvolume, deltat);
 
   printlnlog("timestep {}: electron_scatterings {} resonancescatterings {} upscatterings {} downscatterings {}", nts,

--- a/stats.cc
+++ b/stats.cc
@@ -54,45 +54,38 @@ void pkt_action_counters_printout(const int nts) {
     modelvolume += grid::get_modelcell_assocvolume_tmin(mgi) * pow3(globals::timesteps[nts].mid / globals::tmin);
   }
 
-  printlnlog("timestep {}: ma_stat_activation_collexc = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_COLLEXC));
-  printlnlog("timestep {}: ma_stat_activation_collion = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_COLLION));
-  printlnlog("timestep {}: ma_stat_activation_ntcollexc = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_NTCOLLEXC));
-  printlnlog("timestep {}: ma_stat_activation_ntcollion = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_NTCOLLION));
-  printlnlog("timestep {}: ma_stat_activation_bb = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_BB));
-  printlnlog("timestep {}: ma_stat_activation_bf = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_BF));
-  printlnlog("timestep {}: ma_stat_activation_fb = {}", nts, get_counter(Counter::MA_STAT_ACTIVATION_FB));
-  printlnlog("timestep {}: ma_stat_deactivation_colldeexc = {}", nts,
-             get_counter(Counter::MA_STAT_DEACTIVATION_COLLDEEXC));
-  printlnlog("timestep {}: ma_stat_deactivation_collrecomb = {}", nts,
-             get_counter(Counter::MA_STAT_DEACTIVATION_COLLRECOMB));
-  printlnlog("timestep {}: ma_stat_deactivation_bb = {}", nts, get_counter(Counter::MA_STAT_DEACTIVATION_BB));
-  printlnlog("timestep {}: ma_stat_deactivation_fb = {}", nts, get_counter(Counter::MA_STAT_DEACTIVATION_FB));
-  printlnlog("timestep {}: ma_stat_internaluphigher = {}", nts, get_counter(Counter::MA_STAT_INTERNALUPHIGHER));
-  printlnlog("timestep {}: ma_stat_internaluphighernt = {}", nts, get_counter(Counter::MA_STAT_INTERNALUPHIGHERNT));
-  printlnlog("timestep {}: ma_stat_internaldownlower = {}", nts, get_counter(Counter::MA_STAT_INTERNALDOWNLOWER));
+  printlnlog("timestep {}: ma_stat_activation: collexc {} collion {} ntcollexc {} ntcollion {} bb {} bf {} fb {}", nts,
+             get_counter(Counter::MA_STAT_ACTIVATION_COLLEXC), get_counter(Counter::MA_STAT_ACTIVATION_COLLION),
+             get_counter(Counter::MA_STAT_ACTIVATION_NTCOLLEXC), get_counter(Counter::MA_STAT_ACTIVATION_NTCOLLION),
+             get_counter(Counter::MA_STAT_ACTIVATION_BB), get_counter(Counter::MA_STAT_ACTIVATION_BF),
+             get_counter(Counter::MA_STAT_ACTIVATION_FB));
+  printlnlog("timestep {}: ma_stat_deactivation: colldeexc {} collrecomb {} bb {} fb {}", nts,
+             get_counter(Counter::MA_STAT_DEACTIVATION_COLLDEEXC),
+             get_counter(Counter::MA_STAT_DEACTIVATION_COLLRECOMB), get_counter(Counter::MA_STAT_DEACTIVATION_BB),
+             get_counter(Counter::MA_STAT_DEACTIVATION_FB));
+  printlnlog("timestep {}: ma_stat_internal: uphigher {} uphighernt {} downlower {}", nts,
+             get_counter(Counter::MA_STAT_INTERNALUPHIGHER), get_counter(Counter::MA_STAT_INTERNALUPHIGHERNT),
+             get_counter(Counter::MA_STAT_INTERNALDOWNLOWER));
 
-  printlnlog("timestep {}: k_stat_to_ma_collexc = {}", nts, get_counter(Counter::K_STAT_TO_MA_COLLEXC));
-  printlnlog("timestep {}: k_stat_to_ma_collion = {}", nts, get_counter(Counter::K_STAT_TO_MA_COLLION));
-  printlnlog("timestep {}: k_stat_to_r_ff = {}", nts, get_counter(Counter::K_STAT_TO_R_FF));
-  printlnlog("timestep {}: k_stat_to_r_fb = {}", nts, get_counter(Counter::K_STAT_TO_R_FB));
-  printlnlog("timestep {}: k_stat_to_r_bb = {}", nts, get_counter(Counter::K_STAT_TO_R_BB));
-  printlnlog("timestep {}: k_stat_from_ff = {}", nts, get_counter(Counter::K_STAT_FROM_FF));
-  printlnlog("timestep {}: k_stat_from_bf = {}", nts, get_counter(Counter::K_STAT_FROM_BF));
-  printlnlog("timestep {}: k_stat_from_earlierdecay = {}", nts, get_counter(Counter::K_STAT_FROM_EARLIERDECAY));
+  printlnlog("timestep {}: k_stat_to: ma_collexc {} ma_collion {} r_ff {} r_fb {} r_bb {}", nts,
+             get_counter(Counter::K_STAT_TO_MA_COLLEXC), get_counter(Counter::K_STAT_TO_MA_COLLION),
+             get_counter(Counter::K_STAT_TO_R_FF), get_counter(Counter::K_STAT_TO_R_FB),
+             get_counter(Counter::K_STAT_TO_R_BB));
+  printlnlog("timestep {}: k_stat_from: ff {} bf {} earlierdecay {}", nts, get_counter(Counter::K_STAT_FROM_FF),
+             get_counter(Counter::K_STAT_FROM_BF), get_counter(Counter::K_STAT_FROM_EARLIERDECAY));
 
-  printlnlog("timestep {}: nt_stat_from_gamma = {}", nts, get_counter(Counter::NT_STAT_FROM_GAMMA));
-  printlnlog("timestep {}: nt_stat_to_ionisation = {}", nts, get_counter(Counter::NT_STAT_TO_IONISATION));
-  printlnlog("timestep {}: nt_stat_to_excitation = {}", nts, get_counter(Counter::NT_STAT_TO_EXCITATION));
-  printlnlog("timestep {}: nt_stat_to_kpkt = {}", nts, get_counter(Counter::NT_STAT_TO_KPKT));
+  if constexpr (NT_ON) {
+    printlnlog("timestep {}: nt_stat: from_gamma {} to_ionisation {} to_excitation {} to_kpkt {}", nts,
+               get_counter(Counter::NT_STAT_FROM_GAMMA), get_counter(Counter::NT_STAT_TO_IONISATION),
+               get_counter(Counter::NT_STAT_TO_EXCITATION), get_counter(Counter::NT_STAT_TO_KPKT));
+  }
   nonthermal::print_stats(modelvolume, deltat);
 
-  printlnlog("timestep {}: electron_scatterings = {}", nts, get_counter(Counter::ELECTRON_SCATTERINGS));
-  printlnlog("timestep {}: cellcrossings = {}", nts, get_counter(Counter::CELLCROSSINGS));
-  printlnlog("timestep {}: updatecellcounter = {}", nts, get_counter(Counter::UPDATECELL));
-  printlnlog("timestep {}: resonancescatterings = {}", nts, get_counter(Counter::RESONANCESCATTERINGS));
-
-  printlnlog("timestep {}: upscatterings = {}", nts, get_counter(Counter::UPSCATTER));
-  printlnlog("timestep {}: downscatterings = {}", nts, get_counter(Counter::DOWNSCATTER));
+  printlnlog("timestep {}: electron_scatterings {} resonancescatterings {} upscatterings {} downscatterings {}", nts,
+             get_counter(Counter::ELECTRON_SCATTERINGS), get_counter(Counter::RESONANCESCATTERINGS),
+             get_counter(Counter::UPSCATTER), get_counter(Counter::DOWNSCATTER));
+  printlnlog("timestep {}: cellcrossings {} updatecellcounter {}", nts, get_counter(Counter::CELLCROSSINGS),
+             get_counter(Counter::UPDATECELL));
 }
 
 }  // namespace stats

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -250,6 +250,7 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
                      const std::span<const double> bfheatingcoeffs) {
   const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   const double T_e_old = grid::get_Te(nonemptymgi);
+  printlog("Finding T_e in cell {} at timestep {}...", modelgridindex, globals::timestep);
 
   const auto f_T_e = [&](double T_e) -> double {
     return T_e_eqn_heating_minus_cooling(T_e, nonemptymgi, t_current, heatingcoolingrates, bfheatingcoeffs);
@@ -278,13 +279,11 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
                                                     ftol<TEMPERATURE_SOLVER_ACCURACY>, iternum);
     T_e = 0.5 * (result.first + result.second);
     if (iternum >= maxit) {
-      printlnlog(
-          "[warning] call_T_e_finder: cell {} timestep {}: T_e did not converge within {} iterations. interval [{:g}, "
-          "{:g}] K",
-          modelgridindex, globals::timestep, iternum, result.first, result.second);
+      printlnlog("[warning] call_T_e_finder: T_e did not converge within {} iterations. interval [{:g}, {:g}] K",
+                 iternum, result.first, result.second);
     } else {
-      printlnlog("T_e found in cell {} at timestep {} after {} iterations: T_e = {:g} K, interval [{:g}, {:g}] K",
-                 modelgridindex, globals::timestep, iternum, T_e, result.first, result.second);
+      printlnlog("after {} iterations, T_e = {:g} K, interval [{:g}, {:g}] K", iternum, T_e, result.first,
+                 result.second);
     }
   } else if (invalid_values || f_T_max < 0) {
     // Thermal balance equation always negative ===> T_e = T_min

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -312,6 +312,15 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
 
   grid::set_Te(nonemptymgi, static_cast<float>(T_e));
 
+  // check the converged T_e only (grid::set_Te is also called with rejected intermediate solver guesses)
+  const double nu_peak = 5.879e10 * T_e;  // Wien's displacement law
+  if (nu_peak > NU_MAX_R || nu_peak < NU_MIN_R) {
+    printlnlog(
+        "[warning] cell {} timestep {}: B_planck(T_e={:g} K) peak at {:g} Hz is outside the radiation field frequency "
+        "range [{:g}, {:g}] Hz",
+        modelgridindex, globals::timestep, T_e, nu_peak, NU_MIN_R, NU_MAX_R);
+  }
+
   // this call will make sure heating/cooling rates and populations are updated for the final T_e
   // in case T_e got modified after the T_e solver finished
   f_T_e(T_e);

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -262,8 +262,7 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
   const bool invalid_values = (!std::isfinite(f_T_min) || !std::isfinite(f_T_max));
   if (invalid_values) {
     printlnlog(
-        "[warning] call_T_e_finder: non-finite results in modelcell {} (T_R={:g}, W={:g}). T_e forced to be "
-        "MINTEMP",
+        "[warning] call_T_e_finder: non-finite results in modelcell {} (T_R={:g}, W={:g}). T_e forced to be MINTEMP",
         modelgridindex, grid::TR_allcells[nonemptymgi], grid::W_allcells[nonemptymgi]);
   }
 

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -279,10 +279,10 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
                                                     ftol<TEMPERATURE_SOLVER_ACCURACY>, iternum);
     T_e = 0.5 * (result.first + result.second);
     if (iternum >= maxit) {
-      printlnlog("[warning] call_T_e_finder: T_e did not converge within {} iterations. interval [{:g}, {:g}] K",
+      printlnlog("[warning] call_T_e_finder: T_e did not converge within {} iterations. interval [{:g}, {:g}] [K]",
                  iternum, result.first, result.second);
     } else {
-      printlnlog("after {} iterations, T_e = {:g} K, interval [{:g}, {:g}] K", iternum, T_e, result.first,
+      printlnlog("after {} iterations, T_e = {:g} [K], interval [{:g}, {:g}] [K]", iternum, T_e, result.first,
                  result.second);
     }
   } else if (invalid_values || f_T_max < 0) {
@@ -305,15 +305,15 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
     const double T_e_solved = T_e;
     T_e = std::min(2 * T_e_old, MAXTEMP);
     printlnlog(
-        "T_e damping in cell {} at timestep {}: solver gave T_e {:g} K, clamping the rise from the previous value "
-        "{:g} K to {:g} K",
+        "T_e damping in cell {} at timestep {}: solver gave T_e {:g} [K], clamping the rise from the previous value "
+        "{:g} [K] to {:g} [K]",
         modelgridindex, globals::timestep, T_e_solved, T_e_old, T_e);
   } else if (T_e < 0.5 * T_e_old) {
     const double T_e_solved = T_e;
     T_e = std::max(0.5 * T_e_old, MINTEMP);
     printlnlog(
-        "T_e damping in cell {} at timestep {}: solver gave T_e {:g} K, clamping the fall from the previous value "
-        "{:g} K to {:g} K",
+        "T_e damping in cell {} at timestep {}: solver gave T_e {:g} [K], clamping the fall from the previous value "
+        "{:g} [K] to {:g} [K]",
         modelgridindex, globals::timestep, T_e_solved, T_e_old, T_e);
   }
 
@@ -323,8 +323,8 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
   const double nu_peak = 5.879e10 * T_e;  // Wien's displacement law
   if (nu_peak > NU_MAX_R || nu_peak < NU_MIN_R) {
     printlnlog(
-        "[warning] cell {} timestep {}: B_planck(T_e={:g} K) peak at {:g} Hz is outside the radiation field frequency "
-        "range [{:g}, {:g}] Hz",
+        "[warning] cell {} timestep {}: B_planck(T_e={:g} [K]) peak at {:g} [Hz] is outside the radiation field "
+        "frequency range [{:g}, {:g}] [Hz]",
         modelgridindex, globals::timestep, T_e, nu_peak, NU_MIN_R, NU_MAX_R);
   }
 

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -125,8 +125,8 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const doub
   const auto fT_e = static_cast<float>(T_e);
 
   if constexpr (!LTEPOP_EXCITATION_USE_TJ) {
-    if (std::abs((T_e / grid::get_Te(nonemptymgi)) - 1.) > 0.1) {
-      grid::set_Te(nonemptymgi, fT_e);
+    if (std::abs((T_e / grid::Te_allcells[nonemptymgi]) - 1.) > 0.1) {
+      grid::Te_allcells[nonemptymgi] = fT_e;
       for (int element = 0; element < get_nelements(); element++) {
         if (!elem_has_nlte_levels(element)) {
           // recalculate the Gammas using the current level populations
@@ -144,7 +144,7 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const doub
   }
 
   // Set new T_e guess for the current cell and update populations
-  grid::set_Te(nonemptymgi, fT_e);
+  grid::Te_allcells[nonemptymgi] = fT_e;
 
   calculate_ion_balance_nne(nonemptymgi);
   const auto nne = grid::get_nne(nonemptymgi);
@@ -196,7 +196,7 @@ auto calculate_bfheatingcoeff(const int element, const int ion, const int level,
   const double nu_threshold = (1. / H) * E_threshold;
   const double nu_max_phixs = nu_threshold * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
   const auto photoion_xs = get_phixs_table(element, ion, level);
-  const auto T_R = grid::get_TR(nonemptymgi);
+  const auto T_R = grid::TR_allcells[nonemptymgi];
   auto bfheating = integrator(
       [&](const double nu) { return integrand_bfheatingcoeff(nu, nu_threshold, nonemptymgi, T_R, photoion_xs); },
       nu_threshold, nu_max_phixs, epsrel, &error);
@@ -249,7 +249,7 @@ void calculate_bfheatingcoeffs(int nonemptymgi, std::span<double> bfheatingcoeff
 void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCoolingRates& heatingcoolingrates,
                      const std::span<const double> bfheatingcoeffs) {
   const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-  const double T_e_old = grid::get_Te(nonemptymgi);
+  const double T_e_old = grid::Te_allcells[nonemptymgi];
   printlog("Finding T_e in cell {} at timestep {}...", modelgridindex, globals::timestep);
 
   const auto f_T_e = [&](double T_e) -> double {
@@ -264,7 +264,7 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
     printlnlog(
         "[warning] call_T_e_finder: non-finite results in modelcell {} (T_R={:g}, W={:g}). T_e forced to be "
         "MINTEMP",
-        modelgridindex, grid::get_TR(nonemptymgi), grid::get_W(nonemptymgi));
+        modelgridindex, grid::TR_allcells[nonemptymgi], grid::W_allcells[nonemptymgi]);
   }
 
   double T_e{NAN};
@@ -291,14 +291,14 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
     printlnlog(
         "[warning] call_T_e_finder: cooling bigger than heating at lower T_e boundary {:g} in modelcell {} "
         "(T_R={:g},W={:g}). T_e forced to be MINTEMP",
-        MINTEMP, modelgridindex, grid::get_TR(nonemptymgi), grid::get_W(nonemptymgi));
+        MINTEMP, modelgridindex, grid::TR_allcells[nonemptymgi], grid::W_allcells[nonemptymgi]);
   } else {
     // Thermal balance equation always positive ===> T_e = T_max
     T_e = MAXTEMP;
     printlnlog(
         "[warning] call_T_e_finder: heating bigger than cooling over the whole T_e range [{:g},{:g}] in modelcell {} "
         "(T_R={:g},W={:g}). T_e forced to be MAXTEMP",
-        MINTEMP, MAXTEMP, modelgridindex, grid::get_TR(nonemptymgi), grid::get_W(nonemptymgi));
+        MINTEMP, MAXTEMP, modelgridindex, grid::TR_allcells[nonemptymgi], grid::W_allcells[nonemptymgi]);
   }
 
   if (T_e > 2 * T_e_old) {
@@ -317,7 +317,7 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
         modelgridindex, globals::timestep, T_e_solved, T_e_old, T_e);
   }
 
-  grid::set_Te(nonemptymgi, static_cast<float>(T_e));
+  grid::Te_allcells[nonemptymgi] = static_cast<float>(T_e);
 
   // this call will make sure heating/cooling rates and populations are updated for the final T_e
   // in case T_e got modified after the T_e solver finished

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -319,15 +319,6 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
 
   grid::set_Te(nonemptymgi, static_cast<float>(T_e));
 
-  // check the converged T_e only (grid::set_Te is also called with rejected intermediate solver guesses)
-  const double nu_peak = 5.879e10 * T_e;  // Wien's displacement law
-  if (nu_peak > NU_MAX_R || nu_peak < NU_MIN_R) {
-    printlnlog(
-        "[warning] cell {} timestep {}: B_planck(T_e={:g} [K]) peak at {:g} [Hz] is outside the radiation field "
-        "frequency range [{:g}, {:g}] [Hz]",
-        modelgridindex, globals::timestep, T_e, nu_peak, NU_MIN_R, NU_MAX_R);
-  }
-
   // this call will make sure heating/cooling rates and populations are updated for the final T_e
   // in case T_e got modified after the T_e solver finished
   f_T_e(T_e);

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -250,7 +250,6 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
                      const std::span<const double> bfheatingcoeffs) {
   const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   const double T_e_old = grid::get_Te(nonemptymgi);
-  printlog("Finding T_e in cell {} at timestep {}...", modelgridindex, globals::timestep);
 
   const auto f_T_e = [&](double T_e) -> double {
     return T_e_eqn_heating_minus_cooling(T_e, nonemptymgi, t_current, heatingcoolingrates, bfheatingcoeffs);
@@ -279,10 +278,13 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
                                                     ftol<TEMPERATURE_SOLVER_ACCURACY>, iternum);
     T_e = 0.5 * (result.first + result.second);
     if (iternum >= maxit) {
-      printlnlog("[warning] call_T_e_finder: T_e did not converge within {} iterations. interval [{:g}, {:g}]", iternum,
-                 result.first, result.second);
+      printlnlog(
+          "[warning] call_T_e_finder: cell {} timestep {}: T_e did not converge within {} iterations. interval [{:g}, "
+          "{:g}] K",
+          modelgridindex, globals::timestep, iternum, result.first, result.second);
     } else {
-      printlnlog("after {} iterations, T_e = {:g} K, interval [{:g}, {:g}]", iternum, T_e, result.first, result.second);
+      printlnlog("T_e found in cell {} at timestep {} after {} iterations: T_e = {:g} K, interval [{:g}, {:g}] K",
+                 modelgridindex, globals::timestep, iternum, T_e, result.first, result.second);
     }
   } else if (invalid_values || f_T_max < 0) {
     // Thermal balance equation always negative ===> T_e = T_min
@@ -301,13 +303,19 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
   }
 
   if (T_e > 2 * T_e_old) {
-    T_e = 2 * T_e_old;
-    printlnlog("use T_e damping in cell {}", modelgridindex);
-    T_e = std::min(T_e, MAXTEMP);
+    const double T_e_solved = T_e;
+    T_e = std::min(2 * T_e_old, MAXTEMP);
+    printlnlog(
+        "T_e damping in cell {} at timestep {}: solver gave T_e {:g} K, clamping the rise from the previous value "
+        "{:g} K to {:g} K",
+        modelgridindex, globals::timestep, T_e_solved, T_e_old, T_e);
   } else if (T_e < 0.5 * T_e_old) {
-    T_e = 0.5 * T_e_old;
-    printlnlog("use T_e damping in cell {}", modelgridindex);
-    T_e = std::max(T_e, MINTEMP);
+    const double T_e_solved = T_e;
+    T_e = std::max(0.5 * T_e_old, MINTEMP);
+    printlnlog(
+        "T_e damping in cell {} at timestep {}: solver gave T_e {:g} K, clamping the fall from the previous value "
+        "{:g} K to {:g} K",
+        modelgridindex, globals::timestep, T_e_solved, T_e_old, T_e);
   }
 
   grid::set_Te(nonemptymgi, static_cast<float>(T_e));

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -230,8 +230,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
 
       printlnlog(
           "Grid solver cell {} timestep {}: time spent on: Spencer-Fano {:.1f}s, partfuncs/gamma {:.1f}s, T_e {:.1f}s, "
-          "populations "
-          "{:.1f}s",
+          "populations {:.1f}s",
           mgi, nts, duration_solve_spencerfano, duration_solve_partfuncs_or_gamma, duration_solve_T_e,
           duration_solve_pops);
       break;  // no iteration is needed without nlte pops
@@ -239,8 +238,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
 
     const double fracdiff_T_e = fabs((grid::Te_allcells[nonemptymgi] / prev_T_e) - 1);
     const auto sys_time_start_nltepops = std::chrono::steady_clock::now();
-    // fractional difference between previous and current iteration's (nne or max(ground state
-    // population change))
+    // fractional difference between previous and current iteration's (nne or max(ground state population change))
     for (int element = 0; element < get_nelements(); element++) {
       if (get_nions(element) > 0 && elem_has_nlte_levels(element)) {
         solve_nlte_pops_element(element, nonemptymgi, nts, nlte_iter);
@@ -306,8 +304,7 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
       // 2012-01-11. These loops should terminate here to precalculate *ALL* corrphotoionrenorm
       // values so that the values are known when required by the call to get_corrphotoioncoeff in
       // the following loops. Otherwise get_corrphotoioncoeff tries to renormalize by the closest
-      // corrphotoionrenorm in frequency space which can lead to zero contributions to the total
-      // photoionsation rate!
+      // corrphotoionrenorm in frequency space which can lead to zero contributions to the total photoionsation rate!
     }
   }
   for (int element = 0; element < get_nelements(); element++) {
@@ -398,8 +395,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     }
 
     // W == 1 indicates that this modelgrid cell was treated grey in the
-    // last timestep. Therefore it has no valid Gamma estimators and must
-    // be treated in LTE at restart.
+    // last timestep. Therefore it has no valid Gamma estimators and must be treated in LTE at restart.
     if (grid::thick_allcells[nonemptymgi] != 1 && grid::W_allcells[nonemptymgi] == 1) {
       printlnlog(
           "force modelgrid cell {} to grey/LTE thick = 1 for update grid since existing W == 1. (will not have gamma "
@@ -421,8 +417,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
     // we have to calculate the electron density
     // and all the level populations
-    // Normalise estimators and make sure that they are finite.
-    // Then update T_R and W using the estimators.
+    // Normalise estimators and make sure that they are finite. Then update T_R and W using the estimators.
     // (This could in principle also be done for empty cells)
 
     const auto sys_time_start_temperature_corrections = std::chrono::steady_clock::now();
@@ -550,8 +545,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
     printlog("calculating cooling_rates for timestep {} cell {}...", nts, mgi);
 
-    // don't pass pointer to heatingcoolingrates because current populations and rates weren't
-    // used to determine T_e
+    // don't pass pointer to heatingcoolingrates because current populations and rates weren't used to determine T_e
     kpkt::calculate_cooling_rates(nonemptymgi, nullptr);
 
     const auto calc_kpkt_rates_duration =

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -41,12 +41,13 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
 
   const auto sys_time_start_write_estimators = std::chrono::steady_clock::now();
 
-  const auto T_e = grid::get_Te(nonemptymgi);
+  const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto nne = grid::get_nne(nonemptymgi);
   const auto Y_e = grid::get_electronfrac(nonemptymgi);
 
   std::print(estimators_file, "timestep {} modelgridindex {} titeration {} TR {:g} Te {:g} W {:g} TJ {:g}", timestep,
-             mgi, titer, grid::get_TR(nonemptymgi), T_e, grid::get_W(nonemptymgi), grid::get_TJ(nonemptymgi));
+             mgi, titer, grid::TR_allcells[nonemptymgi], T_e, grid::W_allcells[nonemptymgi],
+             grid::TJ_allcells[nonemptymgi]);
   std::println(estimators_file, " grey_depth {:g} thick {} nne {:g} Ye {:g} tdays {:7.2f}",
                grid::grey_depth_allcells[nonemptymgi], grid::thick_allcells[nonemptymgi], nne, Y_e,
                globals::timesteps[timestep].mid / DAY);
@@ -212,7 +213,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
     const auto duration_solve_partfuncs_or_gamma =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_partfuncs_or_gamma).count();
 
-    const double prev_T_e = grid::get_Te(nonemptymgi);
+    const double prev_T_e = grid::Te_allcells[nonemptymgi];
     const auto sys_time_start_Te = std::chrono::steady_clock::now();
 
     // Find T_e as solution for thermal balance
@@ -236,7 +237,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
       break;  // no iteration is needed without nlte pops
     }
 
-    const double fracdiff_T_e = fabs((grid::get_Te(nonemptymgi) / prev_T_e) - 1);
+    const double fracdiff_T_e = fabs((grid::Te_allcells[nonemptymgi] / prev_T_e) - 1);
     const auto sys_time_start_nltepops = std::chrono::steady_clock::now();
     // fractional difference between previous and current iteration's (nne or max(ground state
     // population change))
@@ -259,8 +260,8 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
     printlnlog(
         "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: prev_iter nne {:e}, new nne is {:e}, "
         "fracdiff {:g}, prev T_e {:g} new T_e {:g} fracdiff {:g}",
-        mgi, nts, nlte_iter, nne_prev, grid::get_nne(nonemptymgi), fracdiff_nne, prev_T_e, grid::get_Te(nonemptymgi),
-        fracdiff_T_e);
+        mgi, nts, nlte_iter, nne_prev, grid::get_nne(nonemptymgi), fracdiff_nne, prev_T_e,
+        grid::Te_allcells[nonemptymgi], fracdiff_T_e);
     if (fracdiff_nne <= nne_reltol && fracdiff_T_e <= T_e_reltol) {
       printlnlog(
           "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: nne converged to tolerance {:g} <= {:g} "
@@ -279,8 +280,8 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
 
 void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi, const double estimator_normfactor) {
   if constexpr (USE_LUT_PHOTOION) {
-    const auto W = grid::get_W(nonemptymgi);
-    const auto T_R = grid::get_TR(nonemptymgi);
+    const auto W = grid::W_allcells[nonemptymgi];
+    const auto T_R = grid::TR_allcells[nonemptymgi];
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);
       for (int ion = 0; ion < nions - 1; ion++) {
@@ -399,7 +400,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     // W == 1 indicates that this modelgrid cell was treated grey in the
     // last timestep. Therefore it has no valid Gamma estimators and must
     // be treated in LTE at restart.
-    if (grid::thick_allcells[nonemptymgi] != 1 && grid::get_W(nonemptymgi) == 1) {
+    if (grid::thick_allcells[nonemptymgi] != 1 && grid::W_allcells[nonemptymgi] == 1) {
       printlnlog(
           "force modelgrid cell {} to grey/LTE thick = 1 for update grid since existing W == 1. (will not have gamma "
           "estimators)",
@@ -439,10 +440,10 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
       // LTE mode or grey mode (where temperature doesn't matter but is calculated anyway)
 
       const auto T_J = radfield::get_T_J_from_J(nonemptymgi);
-      grid::set_TR(nonemptymgi, T_J);
-      grid::set_Te(nonemptymgi, T_J);
-      grid::set_TJ(nonemptymgi, T_J);
-      grid::set_W(nonemptymgi, 1);
+      grid::TR_allcells[nonemptymgi] = T_J;
+      grid::Te_allcells[nonemptymgi] = T_J;
+      grid::TJ_allcells[nonemptymgi] = T_J;
+      grid::W_allcells[nonemptymgi] = 1;
 
       if constexpr (USE_LUT_PHOTOION) {
         std::ranges::fill(
@@ -487,9 +488,9 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
   }
 
   // Check the temperature that the cell has ended up with for this timestep. This is done here rather
-  // than in grid::set_Te() because that setter is also called with the intermediate guesses that the
-  // T_e solver rejects, and it would report those too.
-  const auto T_e_cell = grid::get_Te(nonemptymgi);
+  // than where T_e is stored, because the T_e solver also stores the intermediate guesses that it
+  // rejects, and those would be reported too.
+  const auto T_e_cell = grid::Te_allcells[nonemptymgi];
   if (T_e_cell > 0.) {
     const double nu_peak_planck = 5.879e10 * T_e_cell;  // Wien's displacement law
     if (nu_peak_planck > NU_MAX_R || nu_peak_planck < NU_MIN_R) {
@@ -506,15 +507,15 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
   const double compton_optical_depth_across_cell = SIGMA_T * nne * propcell_width * tratmid;
 
   if constexpr (RPKT_GREY_TYPE == RpktGreyType::JUST2022_TEMP_LANTHANIDEFRAC) {
-    grid::set_kappagrey(nonemptymgi, grid::calculate_cell_kappagrey(nonemptymgi));
+    grid::kappagrey_allcells[nonemptymgi] = grid::calculate_cell_kappagrey(nonemptymgi);
   }
   const double radial_pos = grid::get_modelcell_mean_radial_pos_tmin(mgi) * tratmid;
   const double grey_optical_depth_across_cell =
-      grid::get_kappagrey(nonemptymgi) * grid::get_rho(nonemptymgi) * propcell_width * tratmid;
+      grid::kappagrey_allcells[nonemptymgi] * grid::get_rho(nonemptymgi) * propcell_width * tratmid;
   // cube corners will have radial pos > rmax, so clamp to 0.
   const double dist_to_obs = std::max(0., (globals::rmax * tratmid) - radial_pos);
   const auto grey_optical_depth =
-      static_cast<float>(grid::get_kappagrey(nonemptymgi) * grid::get_rho(nonemptymgi) * dist_to_obs);
+      static_cast<float>(grid::kappagrey_allcells[nonemptymgi] * grid::get_rho(nonemptymgi) * dist_to_obs);
   printlnlog("modelgridindex {}, compton optical depth (/propgridcell) {:g}, grey optical depth (/propgridcell) {:g}",
              mgi, compton_optical_depth_across_cell, grey_optical_depth_across_cell);
   printlnlog("radial_pos {:g}, distance_to_obs {:g}, tau_dist {:g}", radial_pos, dist_to_obs, grey_optical_depth);
@@ -523,7 +524,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
   if ((grey_optical_depth >= globals::optical_depth_is_thick) && (nts < globals::num_grey_timesteps)) {
     printlnlog("timestep {} cell {} is treated in grey approximation (chi_grey {:g} [cm2/g], tau {:g} >= {:g})", nts,
-               mgi, grid::get_kappagrey(nonemptymgi), grey_optical_depth, globals::optical_depth_is_thick);
+               mgi, grid::kappagrey_allcells[nonemptymgi], grey_optical_depth, globals::optical_depth_is_thick);
     grid::thick_allcells[nonemptymgi] = 1;
   } else if (VPKT_ON && (grey_optical_depth > vpkt::optical_depth_is_thick_vpkt)) {
     grid::thick_allcells[nonemptymgi] = 2;

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -358,8 +358,6 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
       grid::get_modelcell_assocvolume_tmin(mgi) * pow3(globals::timesteps[nts_prev].mid / globals::tmin);
   const auto sys_time_start_update_cell = std::chrono::steady_clock::now();
 
-  printlnlog("update_grid_cell: working on mgi {} before timestep {} titeration {}...", mgi, nts, titer);
-
   // Update current mass density of cell
   const auto rho = static_cast<float>(grid::get_rho_tmin(mgi) / pow3(tratmid));
   grid::set_rho(nonemptymgi, rho);
@@ -577,7 +575,7 @@ void update_grid(std::ostream& estimators_file, const int nts, const int nts_pre
   const auto startup_elapsed_seconds =
       std::chrono::duration<double>(sys_time_start_update_grid - real_time_start).count();
   const auto tmid = globals::timesteps[nts].mid;
-  printlnlog("timestep {}: time before update grid (tstartup + {:.1f} seconds) simtime ts_mid {:g} [days]", nts,
+  printlnlog("timestep {}: time before update grid (tstart + {:.1f} seconds) simtime ts_mid {:g} [days]", nts,
              startup_elapsed_seconds, tmid / DAY);
 
   globals::lte_iteration = (nts < globals::num_lte_timesteps);

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -568,7 +568,7 @@ void update_grid(std::ostream& estimators_file, const int nts, const int nts_pre
   const auto startup_elapsed_seconds =
       std::chrono::duration<double>(sys_time_start_update_grid - real_time_start).count();
   const auto tmid = globals::timesteps[nts].mid;
-  printlnlog("timestep {}: time before update grid (tstartup + {:.1f} seconds) simtime ts_mid {:g} days", nts,
+  printlnlog("timestep {}: time before update grid (tstartup + {:.1f} seconds) simtime ts_mid {:g} [days]", nts,
              startup_elapsed_seconds, tmid / DAY);
 
   globals::lte_iteration = (nts < globals::num_lte_timesteps);

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -486,6 +486,20 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
                temperature_corrections_duration);
   }
 
+  // Check the temperature that the cell has ended up with for this timestep. This is done here rather
+  // than in grid::set_Te() because that setter is also called with the intermediate guesses that the
+  // T_e solver rejects, and it would report those too.
+  const auto T_e_cell = grid::get_Te(nonemptymgi);
+  if (T_e_cell > 0.) {
+    const double nu_peak_planck = 5.879e10 * T_e_cell;  // Wien's displacement law
+    if (nu_peak_planck > NU_MAX_R || nu_peak_planck < NU_MIN_R) {
+      printlnlog(
+          "[warning] cell {} timestep {}: B_planck(T_e={:g} [K]) peak at {:g} [Hz] is outside the radiation field "
+          "frequency range [{:g}, {:g}] [Hz]",
+          mgi, nts, T_e_cell, nu_peak_planck, NU_MIN_R, NU_MAX_R);
+    }
+  }
+
   const auto nne = grid::get_nne(nonemptymgi);
   const auto propcell_width = grid::propcell_width_tmin(
       mgi, 0);  // pass mgi here because cellindex = mgi for direct map 1D or 2D, and doesn't matter for 3D grid

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -182,7 +182,6 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
   const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   // bfheating coefficients are needed for the T_e solver, but they only depend on the radiation field, which is fixed
   // during the iterations below
-  printlog("calculate_bfheatingcoeffs for timestep {} cell {}...", nts, mgi);
   const auto sys_time_start_calculate_bfheatingcoeffs = std::chrono::steady_clock::now();
   THREADLOCALONHOST auto bfheatingcoeffs = std::vector<double>(get_includedlevels());
 
@@ -190,7 +189,9 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
   const auto bfheating_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_calculate_bfheatingcoeffs)
           .count();
-  printlnlog("took {:.1f} seconds", bfheating_duration);
+  if (bfheating_duration >= 1.) {
+    printlnlog("calculate_bfheatingcoeffs for timestep {} cell {} took {:.1f} seconds", nts, mgi, bfheating_duration);
+  }
 
   constexpr double nne_reltol = 0.04;
   constexpr double T_e_reltol = 0.04;
@@ -533,15 +534,16 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     // and ion contributions inside update grid and communicate between MPI tasks
     const auto sys_time_start_calc_kpkt_rates = std::chrono::steady_clock::now();
 
-    printlog("calculating cooling_rates for timestep {} cell {}...", nts, mgi);
-
     // don't pass pointer to heatingcoolingrates because current populations and rates weren't
     // used to determine T_e
     kpkt::calculate_cooling_rates(nonemptymgi, nullptr);
 
     const auto calc_kpkt_rates_duration =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_calc_kpkt_rates).count();
-    printlnlog("took {:.1f} seconds", calc_kpkt_rates_duration);
+    if (calc_kpkt_rates_duration >= 1.) {
+      printlnlog("calculating cooling_rates for timestep {} cell {} took {:.1f} seconds", nts, mgi,
+                 calc_kpkt_rates_duration);
+    }
   }
 
   if constexpr (RPKT_USE_EXPANSION_OPACITIES || VPKT_USE_EXPANSION_OPACITIES ||
@@ -574,6 +576,11 @@ void update_grid(std::ostream& estimators_file, const int nts, const int nts_pre
   globals::lte_iteration = (nts < globals::num_lte_timesteps);
   printlnlog("lte_iteration {}", globals::lte_iteration ? 1 : 0);
   assert_always(globals::num_lte_timesteps > 0);  // The first time step must solve the ionisation balance in LTE
+
+  if (NT_ON && NT_SOLVE_SPENCERFANO && (nts < globals::num_lte_timesteps + 1)) {
+    printlnlog("timestep {}: skipping Spencer-Fano solutions for all cells (solver starts at timestep {})", nts,
+               globals::num_lte_timesteps + 1);
+  }
 
   const double tratmid = tmid / globals::tmin;
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -182,6 +182,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
   const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   // bfheating coefficients are needed for the T_e solver, but they only depend on the radiation field, which is fixed
   // during the iterations below
+  printlog("calculate_bfheatingcoeffs for timestep {} cell {}...", nts, mgi);
   const auto sys_time_start_calculate_bfheatingcoeffs = std::chrono::steady_clock::now();
   THREADLOCALONHOST auto bfheatingcoeffs = std::vector<double>(get_includedlevels());
 
@@ -189,9 +190,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
   const auto bfheating_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_calculate_bfheatingcoeffs)
           .count();
-  if (bfheating_duration >= 1.) {
-    printlnlog("calculate_bfheatingcoeffs for timestep {} cell {} took {:.1f} seconds", nts, mgi, bfheating_duration);
-  }
+  printlnlog("took {:.1f} seconds", bfheating_duration);
 
   constexpr double nne_reltol = 0.04;
   constexpr double T_e_reltol = 0.04;
@@ -534,16 +533,15 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     // and ion contributions inside update grid and communicate between MPI tasks
     const auto sys_time_start_calc_kpkt_rates = std::chrono::steady_clock::now();
 
+    printlog("calculating cooling_rates for timestep {} cell {}...", nts, mgi);
+
     // don't pass pointer to heatingcoolingrates because current populations and rates weren't
     // used to determine T_e
     kpkt::calculate_cooling_rates(nonemptymgi, nullptr);
 
     const auto calc_kpkt_rates_duration =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_calc_kpkt_rates).count();
-    if (calc_kpkt_rates_duration >= 1.) {
-      printlnlog("calculating cooling_rates for timestep {} cell {} took {:.1f} seconds", nts, mgi,
-                 calc_kpkt_rates_duration);
-    }
+    printlnlog("took {:.1f} seconds", calc_kpkt_rates_duration);
   }
 
   if constexpr (RPKT_USE_EXPANSION_OPACITIES || VPKT_USE_EXPANSION_OPACITIES ||

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -462,7 +462,7 @@ void update_packet_cellcache_group(const int cellcache_groupid, std::span<Packet
       const auto size_mb = (static_cast<ptrdiff_t>(globals::nbfcontinua_ground) +
                             static_cast<ptrdiff_t>(globals::nbfcontinua) + std::ssize(globals::bfestim_nu_edge)) *
                            std::ssize(packetgroup) * sizeof(double) / 1024. / 1024.;
-      printlog("Resizing chi_rpkt_cont_vec from {} to {} ({:g} [MB])...", chi_rpkt_cont_vec.size(), packetgroup.size(),
+      printlog("Resizing chi_rpkt_cont_vec from {} to {} ({:g} MB)...", chi_rpkt_cont_vec.size(), packetgroup.size(),
                size_mb);
       chi_rpkt_cont_vec.resize(packetgroup.size());
       printlnlog("done.");

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -166,8 +166,7 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
 
 // Handle inactive pellets. Need to do two things (a) check if it
 // decays in this time step and if it does handle that. (b) if it doesn't decay in
-// this time step then just move the packet along with the matter for the
-// start of the next time step.
+// this time step then just move the packet along with the matter for the start of the next time step.
 void update_pellet(Packet& pkt, const int nts, const double t2) {
   assert_always(pkt.prop_time < t2);
   const double ts = pkt.prop_time;
@@ -219,8 +218,7 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
     }
   } else if ((tdecay > 0) && (nts == 0)) {
     // These are pellets whose decay times were before the first time step
-    // They will be made into r-packets with energy reduced for doing work on the
-    // ejecta following Lucy 2004.
+    // They will be made into r-packets with energy reduced for doing work on the ejecta following Lucy 2004.
     // The position is already set at globals::tmin so don't need to move it. Assume
     // that it is fixed in place from decay to globals::tmin - i.e. short mfp.
 
@@ -508,8 +506,7 @@ void update_packet_cellcache_group(const int cellcache_groupid, std::span<Packet
 void update_packets(const int nts, std::span<Packet> packets) {
   // At the start, the packets have all either just been initialised or have already been
   // processed for one or more timesteps. Those that are pellets will just be sitting in the
-  // matter. Those that are photons (or one sort or another) will already have a position and
-  // a direction.
+  // matter. Those that are photons (or one sort or another) will already have a position and a direction.
   const double ts = globals::timesteps[nts].start;
   const double tw = globals::timesteps[nts].width;
   const double ts_end = ts + tw;

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -204,7 +204,7 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
         pkt.type = TYPE_NTALPHA_FISPROD_DEPOSITED;
       } else if constexpr (TESTMODE) {
         printlnlog(
-            "ERROR: pellet marked as particle emission is for decaytype {} != any of (alpha, beta+, beta-, spfission)",
+            "[error] pellet marked as particle emission is for decaytype {} != any of (alpha, beta+, beta-, spfission)",
             pkt.pellet_decaytype);
         std::abort();
       } else {
@@ -231,7 +231,7 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
 
     pkt.prop_time = globals::tmin;
   } else if constexpr (TESTMODE) {
-    printlnlog("ERROR: Something wrong with decaying pellets. tdecay {:g} ts {:g} (ts + tw) {:g}", tdecay, ts, t2);
+    printlnlog("[error] Something wrong with decaying pellets. tdecay {:g} ts {:g} (ts + tw) {:g}", tdecay, ts, t2);
     assert_testmodeonly(false);
   } else {
     __builtin_unreachable();
@@ -291,7 +291,7 @@ void do_packet(Packet& pkt, const double t2, const int nts, ContinuumOpacity& ch
 
     default: {
       if constexpr (TESTMODE) {
-        printlnlog("ERROR: Unknown packet type {}", static_cast<int>(pkt.type));
+        printlnlog("[error] Unknown packet type {}", static_cast<int>(pkt.type));
         assert_testmodeonly(false);
       } else {
         __builtin_unreachable();
@@ -462,10 +462,9 @@ void update_packet_cellcache_group(const int cellcache_groupid, std::span<Packet
       const auto size_mb = (static_cast<ptrdiff_t>(globals::nbfcontinua_ground) +
                             static_cast<ptrdiff_t>(globals::nbfcontinua) + std::ssize(globals::bfestim_nu_edge)) *
                            std::ssize(packetgroup) * sizeof(double) / 1024. / 1024.;
-      printlog("Resizing chi_rpkt_cont_vec from {} to {} ({:g} MB)...", chi_rpkt_cont_vec.size(), packetgroup.size(),
-               size_mb);
+      const auto oldsize = chi_rpkt_cont_vec.size();
       chi_rpkt_cont_vec.resize(packetgroup.size());
-      printlnlog("done.");
+      printlnlog("resized chi_rpkt_cont_vec from {} to {} ({:g} MB)", oldsize, chi_rpkt_cont_vec.size(), size_mb);
     }
   } else if (chi_rpkt_cont_vec.empty()) {
     // we're not going to use this, but we need to pass a reference to something

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -462,9 +462,10 @@ void update_packet_cellcache_group(const int cellcache_groupid, std::span<Packet
       const auto size_mb = (static_cast<ptrdiff_t>(globals::nbfcontinua_ground) +
                             static_cast<ptrdiff_t>(globals::nbfcontinua) + std::ssize(globals::bfestim_nu_edge)) *
                            std::ssize(packetgroup) * sizeof(double) / 1024. / 1024.;
-      const auto oldsize = chi_rpkt_cont_vec.size();
+      printlog("Resizing chi_rpkt_cont_vec from {} to {} ({:g} MB)...", chi_rpkt_cont_vec.size(), packetgroup.size(),
+               size_mb);
       chi_rpkt_cont_vec.resize(packetgroup.size());
-      printlnlog("resized chi_rpkt_cont_vec from {} to {} ({:g} MB)", oldsize, chi_rpkt_cont_vec.size(), size_mb);
+      printlnlog("done.");
     }
   } else if (chi_rpkt_cont_vec.empty()) {
     // we're not going to use this, but we need to pass a reference to something

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -462,7 +462,7 @@ void update_packet_cellcache_group(const int cellcache_groupid, std::span<Packet
       const auto size_mb = (static_cast<ptrdiff_t>(globals::nbfcontinua_ground) +
                             static_cast<ptrdiff_t>(globals::nbfcontinua) + std::ssize(globals::bfestim_nu_edge)) *
                            std::ssize(packetgroup) * sizeof(double) / 1024. / 1024.;
-      printlog("Resizing chi_rpkt_cont_vec from {} to {} ({:g} MB)...", chi_rpkt_cont_vec.size(), packetgroup.size(),
+      printlog("Resizing chi_rpkt_cont_vec from {} to {} ({:g} [MB])...", chi_rpkt_cont_vec.size(), packetgroup.size(),
                size_mb);
       chi_rpkt_cont_vec.resize(packetgroup.size());
       printlnlog("done.");

--- a/vectors.h
+++ b/vectors.h
@@ -122,8 +122,7 @@ constexpr void move_pkt_withtime(Vec3d& pos_rf, const Vec3d& dir_rf, double& pro
 
   pos_rf = {pos_rf[0] + (dir_rf[0] * distance), pos_rf[1] + (dir_rf[1] * distance), pos_rf[2] + (dir_rf[2] * distance)};
 
-  // During motion, rest frame energy and frequency are conserved.
-  // But need to update the co-moving ones.
+  // During motion, rest frame energy and frequency are conserved. But need to update the co-moving ones.
   const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pos_rf, dir_rf, prop_time);
 
   // frequency should only ever decrease during packet movement with homologous expansion

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -512,6 +512,7 @@ void init_vspecpol() {
 }
 
 void write_vspecpol(const std::string& filename) {
+  printlnlog("Writing {}", filename);
   auto vspecpol_file = fstream_required(filename, std::ios::out | std::ios::trunc);
   for (int ind_comb = 0; ind_comb < (nobsdirections * nspectraperobsdir); ind_comb++) {
     std::print(vspecpol_file, "{:g}", 0.);
@@ -653,7 +654,9 @@ void remove_temp_vpkt_file(const int nts, const int my_rank) {
     // these temp files are not needed again, so deletion failures are ignored (the error_code
     // overload of remove() reports the failure here instead of throwing)
     std::error_code remove_error;
-    std::filesystem::remove(filename, remove_error);
+    if (std::filesystem::remove(filename, remove_error)) {
+      printlnlog("Deleted {}", filename);
+    }
   }
 }
 
@@ -862,6 +865,7 @@ void write_timestep(const int nts, const bool is_final) {
   if (vgrid_on) {
     const auto filename_vpktgrid = is_final ? std::format("vpkt_grid_{:04d}.out", my_rank)
                                             : std::format("vpkt_grid_{:04d}_ts{}.tmp", my_rank, nts);
+    printlnlog("Writing vpkt grid file {}", filename_vpktgrid);
     write_vpkt_grid(filename_vpktgrid);
   }
 
@@ -872,13 +876,12 @@ void write_timestep(const int nts, const bool is_final) {
                                         : std::format("vpackets_{:04d}_ts{}.tmp", my_rank, nts + 1);
 
     std::filesystem::copy_file(filename_source, filename_dest, std::filesystem::copy_options::overwrite_existing);
+    printlnlog("Copying {} to {}", filename_source, filename_dest);
 
     if (!is_final) {
       vpkt_contrib_file = std::ofstream(filename_dest, std::ios::app);
     }
   }
-
-  printlnlog("timestep {}: wrote {}vpkt output files", nts, is_final ? "final " : "temporary ");
 }
 
 void init(const int nts, const bool continued_from_saved) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -18,6 +18,7 @@
 #include <print>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <tuple>
 #include <vector>
 
@@ -511,7 +512,6 @@ void init_vspecpol() {
 }
 
 void write_vspecpol(const std::string& filename) {
-  printlnlog("Writing {}", filename);
   auto vspecpol_file = fstream_required(filename, std::ios::out | std::ios::trunc);
   for (int ind_comb = 0; ind_comb < (nobsdirections * nspectraperobsdir); ind_comb++) {
     std::print(vspecpol_file, "{:g}", 0.);
@@ -650,8 +650,11 @@ void remove_temp_vpkt_file(const int nts, const int my_rank) {
   };
 
   for (const auto& filename : filenames) {
-    if (std::filesystem::remove(filename)) {
-      printlnlog("Deleted {}", filename);
+    // deleting a temp file is routine and not logged, but a failure to delete an existing file is
+    std::error_code remove_error;
+    std::filesystem::remove(filename, remove_error);
+    if (remove_error) {
+      printlnlog("[warning] failed to delete {}: {}", filename, remove_error.message());
     }
   }
 }
@@ -856,7 +859,6 @@ void write_timestep(const int nts, const bool is_final) {
   if (vgrid_on) {
     const auto filename_vpktgrid = is_final ? std::format("vpkt_grid_{:04d}.out", my_rank)
                                             : std::format("vpkt_grid_{:04d}_ts{}.tmp", my_rank, nts);
-    printlnlog("Writing vpkt grid file {}", filename_vpktgrid);
     write_vpkt_grid(filename_vpktgrid);
   }
 
@@ -867,12 +869,13 @@ void write_timestep(const int nts, const bool is_final) {
                                         : std::format("vpackets_{:04d}_ts{}.tmp", my_rank, nts + 1);
 
     std::filesystem::copy_file(filename_source, filename_dest, std::filesystem::copy_options::overwrite_existing);
-    printlnlog("Copying {} to {}", filename_source, filename_dest);
 
     if (!is_final) {
       vpkt_contrib_file = std::ofstream(filename_dest, std::ios::app);
     }
   }
+
+  printlnlog("timestep {}: wrote {}vpkt output files", nts, is_final ? "final " : "temporary ");
 }
 
 void init(const int nts, const bool continued_from_saved) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -674,7 +674,7 @@ void read_vpktparameterfile() {
     assert_always(fscanf(input_file, "%lg", &obsdirs_costheta[i]) == 1);
 
     if (fabs(obsdirs_costheta[i]) > 1) {
-      printlnlog("ERROR: vpkt.txt observer direction {} has costheta {:g}, which is outside [-1, 1]. aborting", i,
+      printlnlog("[error] vpkt.txt observer direction {} has costheta {:g}, which is outside [-1, 1]. aborting", i,
                  obsdirs_costheta[i]);
       std::abort();
     }
@@ -693,8 +693,8 @@ void read_vpktparameterfile() {
     obsdirs_phi[i] = phi_degrees * PI / 180.;
     const double theta_degrees = std::acos(obsdirs_costheta[i]) / PI * 180.;
 
-    printlnlog("vpkt.txt:   direction {} costheta {:g} ({:.1f} degrees) phi {:g} ({:.1f} degrees)", i,
-               obsdirs_costheta[i], theta_degrees, obsdirs_phi[i], phi_degrees);
+    printlnlog("vpkt.txt:   direction {}: theta {:.1f} degrees (costheta {:g}), phi {:.1f} degrees ({:g} radians)", i,
+               theta_degrees, obsdirs_costheta[i], phi_degrees, obsdirs_phi[i]);
   }
 
   // Nspectra opacity choices (i.e. Nspectra spectra for each observer)

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -650,12 +650,10 @@ void remove_temp_vpkt_file(const int nts, const int my_rank) {
   };
 
   for (const auto& filename : filenames) {
-    // deleting a temp file is routine and not logged, but a failure to delete an existing file is
+    // these temp files are not needed again, so deletion failures are ignored (the error_code
+    // overload of remove() reports the failure here instead of throwing)
     std::error_code remove_error;
     std::filesystem::remove(filename, remove_error);
-    if (remove_error) {
-      printlnlog("[warning] failed to delete {}: {}", filename, remove_error.message());
-    }
   }
 }
 

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -674,7 +674,8 @@ void read_vpktparameterfile() {
     assert_always(fscanf(input_file, "%lg", &obsdirs_costheta[i]) == 1);
 
     if (fabs(obsdirs_costheta[i]) > 1) {
-      printlnlog("Wrong observer direction");
+      printlnlog("ERROR: vpkt.txt observer direction {} has costheta {:g}, which is outside [-1, 1]. aborting", i,
+                 obsdirs_costheta[i]);
       std::abort();
     }
     if (obsdirs_costheta[i] == 1) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -725,7 +725,7 @@ void read_vpktparameterfile() {
   double vspec_tmax_in_days = 0.;
   assert_always(fscanf(input_file, "%d %lg %lg", &override_tminmax, &vspec_tmin_in_days, &vspec_tmax_in_days) == 3);
 
-  printlnlog("vpkt: compiled with VSPEC_TIMEMIN {:.1f}d VSPEC_TIMEMAX {:1f}d VSPEC_TIMEBINS {}", VSPEC_TIMEMIN / DAY,
+  printlnlog("vpkt: compiled with VSPEC_TIMEMIN {:.1f}d VSPEC_TIMEMAX {:.1f}d VSPEC_TIMEBINS {}", VSPEC_TIMEMIN / DAY,
              VSPEC_TIMEMAX / DAY, VSPEC_TIMEBINS);
   if (override_tminmax == 1) {
     vspec_timemin_input = vspec_tmin_in_days * DAY;

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -693,8 +693,9 @@ void read_vpktparameterfile() {
     obsdirs_phi[i] = phi_degrees * PI / 180.;
     const double theta_degrees = std::acos(obsdirs_costheta[i]) / PI * 180.;
 
-    printlnlog("vpkt.txt:   direction {}: theta {:.1f} degrees (costheta {:g}), phi {:.1f} degrees ({:g} radians)", i,
-               theta_degrees, obsdirs_costheta[i], phi_degrees, obsdirs_phi[i]);
+    printlnlog(
+        "vpkt.txt:   direction {}: theta {:.1f} [degrees] (costheta {:g}), phi {:.1f} [degrees] ({:g} [radians])", i,
+        theta_degrees, obsdirs_costheta[i], phi_degrees, obsdirs_phi[i]);
   }
 
   // Nspectra opacity choices (i.e. Nspectra spectra for each observer)
@@ -729,18 +730,18 @@ void read_vpktparameterfile() {
   double vspec_tmax_in_days = 0.;
   assert_always(fscanf(input_file, "%d %lg %lg", &override_tminmax, &vspec_tmin_in_days, &vspec_tmax_in_days) == 3);
 
-  printlnlog("vpkt: compiled with VSPEC_TIMEMIN {:.1f}d VSPEC_TIMEMAX {:.1f}d VSPEC_TIMEBINS {}", VSPEC_TIMEMIN / DAY,
-             VSPEC_TIMEMAX / DAY, VSPEC_TIMEBINS);
+  printlnlog("vpkt: compiled with VSPEC_TIMEMIN {:.1f} [d] VSPEC_TIMEMAX {:.1f} [d] VSPEC_TIMEBINS {}",
+             VSPEC_TIMEMIN / DAY, VSPEC_TIMEMAX / DAY, VSPEC_TIMEBINS);
   if (override_tminmax == 1) {
     vspec_timemin_input = vspec_tmin_in_days * DAY;
     vspec_timemax_input = vspec_tmax_in_days * DAY;
-    printlnlog("vpkt.txt: VSPEC_TIMEMIN_input {:.1f}d, VSPEC_TIMEMAX_input {:.1f}d", vspec_timemin_input / DAY,
+    printlnlog("vpkt.txt: VSPEC_TIMEMIN_input {:.1f} [d], VSPEC_TIMEMAX_input {:.1f} [d]", vspec_timemin_input / DAY,
                vspec_timemax_input / DAY);
   } else {
     vspec_timemin_input = VSPEC_TIMEMIN;
     vspec_timemax_input = VSPEC_TIMEMAX;
     printlnlog(
-        "vpkt.txt: VSPEC_TIMEMIN_input {:.1f}d, VSPEC_TIMEMAX_input {:.1f}d (inherited from VSPEC_TIMEMIN and "
+        "vpkt.txt: VSPEC_TIMEMIN_input {:.1f} [d], VSPEC_TIMEMAX_input {:.1f} [d] (inherited from VSPEC_TIMEMIN and "
         "VSPEC_TIMEMAX)",
         vspec_timemin_input / DAY, vspec_timemax_input / DAY);
   }
@@ -757,8 +758,10 @@ void read_vpktparameterfile() {
 
   printlnlog("vpkt: compiled with VSPEC_NUBINS {}", VSPEC_NUBINS);
   assert_always(VSPEC_NUMAX > VSPEC_NUMIN);
-  printlnlog("vpkt: compiled with VSPEC_NUMAX {:g} lambda_min {:g} Angstroms", VSPEC_NUMAX, 1e8 * CLIGHT / VSPEC_NUMAX);
-  printlnlog("vpkt: compiled with VSPEC_NUMIN {:g} lambda_max {:g} Angstroms", VSPEC_NUMIN, 1e8 * CLIGHT / VSPEC_NUMIN);
+  printlnlog("vpkt: compiled with VSPEC_NUMAX {:g} [Hz] lambda_min {:g} [Angstroms]", VSPEC_NUMAX,
+             1e8 * CLIGHT / VSPEC_NUMAX);
+  printlnlog("vpkt: compiled with VSPEC_NUMIN {:g} [Hz] lambda_max {:g} [Angstroms]", VSPEC_NUMIN,
+             1e8 * CLIGHT / VSPEC_NUMIN);
 
   if (flag_custom_freq_ranges == 1) {
     assert_always(fscanf(input_file, "%d ", &nwavelengthranges) == 1);
@@ -788,7 +791,7 @@ void read_vpktparameterfile() {
   }
 
   for (int i = 0; i < nwavelengthranges; i++) {
-    printlnlog("vpkt.txt:   range {} lambda [{:g}, {:g}] Angstroms", i, 1e8 * CLIGHT / vspec_numax_input[i],
+    printlnlog("vpkt.txt:   range {} lambda [{:g}, {:g}] [Angstroms]", i, 1e8 * CLIGHT / vspec_numax_input[i],
                1e8 * CLIGHT / vspec_numin_input[i]);
   }
 
@@ -822,7 +825,8 @@ void read_vpktparameterfile() {
     tmin_grid = tmin_grid_in_days * DAY;
     tmax_grid = tmax_grid_in_days * DAY;
 
-    printlnlog("vpkt.txt: velocity grid time range tmin_grid {:g}d tmax_grid {:g}d", tmin_grid / DAY, tmax_grid / DAY);
+    printlnlog("vpkt.txt: velocity grid time range tmin_grid {:g} [d] tmax_grid {:g} [d]", tmin_grid / DAY,
+               tmax_grid / DAY);
 
     // Specify wavelength range: number of intervals (dum9) and limits (dum10,dum11)
     assert_always(fscanf(input_file, "%d ", &grid_nwavelengthranges) == 1);
@@ -839,7 +843,7 @@ void read_vpktparameterfile() {
       nu_grid_max[i] = CLIGHT / (range_lambda_min * 1e-8);
       nu_grid_min[i] = CLIGHT / (range_lambda_max * 1e-8);
 
-      printlnlog("vpkt.txt:   velgrid range {} lambda [{:g}, {:g}] Angstroms", i, 1e8 * CLIGHT / nu_grid_max[i],
+      printlnlog("vpkt.txt:   velgrid range {} lambda [{:g}, {:g}] [Angstroms]", i, 1e8 * CLIGHT / nu_grid_max[i],
                  1e8 * CLIGHT / nu_grid_min[i]);
     }
   }


### PR DESCRIPTION
- nltepop.cc: swapped format arguments printed the ion name in the level
  slot and the level number in the ion-name slot; also remove an
  unbalanced closing parenthesis
- nonthermal.cc: wrong units on the non-thermal deposition rate
  (eV/cm/s/cm^3 -> eV/s/cm^3) and a doubled space; drop an iteration
  count that always printed 10 (the refinement loop has no early exit)
- radfield.cc: the full-spectrum fit line labelled a wavelength as
  "nubar ... Angstrom"; rename to lambda_bar and add kelvin units
- ratecoeff.cc: printlog inside an OpenMP parallel for wrote to the
  threadprivate (unopened) output stream of worker threads, dropping and
  garbling the ion stage list; build the list first and print one line
- vpkt.cc: format spec {:1f} is width 1 (prints 6 decimals), not
  precision 1; use {:.1f}
- input.cc: the photoionisation probability-sum error now ends its line
  and identifies the level; failed input.txt renames are now detected
  and reported instead of silently ignored
- gammapkt.cc: report failures of the legacy gamma line list renames
  instead of logging success before an unchecked std::rename
- grid.cc: fix "READIN GRID SNAPSHOT" wording; sn3d.cc: fix "mean mean"
  typo

No changes to simulation results.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EijzCW3VtghGPtvT3MQjrk