### PR TITLE
Apply microclumping to the classic quasti-NLTE ionisation balance

### DIFF
--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -261,9 +261,14 @@ constexpr std::optional<double> GAMMA_USE_KAPPA_GREY;
 
 // Use microclumping, which enhances collisional (de)excitation, collisional ionisation, collisional recombination,
 // radiative recombination, collisional capture, stimulated recombination, free-free heating, free-free cooling by the clumping factor
+// (including in the photoionisation-equilibrium ionisation balance for elements without NLTE levels; the Saha LTE
+// ion balance is unaffected). Note: with USE_LUT_PHOTOION, the stimulated recombination correction inside the
+// tabulated photoionisation coefficients cannot include the per-cell clumping factor; the enhancement applies to the
+// direct bound-free integrals and the packet opacity departure ratios.
 constexpr bool USE_MICROCLUMPING;
 
 // Calculate clumping factors based on time and radial velocity
-// Will be passed globals::timesteps[nts].mid and grid::get_modelcell_mean_radial_vel(mgi, globals::tmin)
+// Will be passed globals::timesteps[nts].mid and the cell's mean radial velocity
+// (grid::get_modelcell_mean_radial_pos_tmin(mgi) / globals::tmin) [cm/s]
 constexpr float clumping_factor([[maybe_unused]] double tmid, [[maybe_unused]] double rad_vel) { return 1.; }
 ```

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -105,7 +105,11 @@ THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
   assert_always((Gamma_ion + gamma_nt) > 0);
   // numerator: recombination rate coefficient, i.e. rate per upper ion pop per nne [cm^3/s]
   // denominator: ionisation rate per lower ion pop [1/s]
-  const double phi = (Alpha_sp + Col_rec) / (Gamma_ion + gamma_nt);
+  // With microclumping, recombining ions see the in-clump electron density (clumpfactor * nne), while phi is
+  // later multiplied by the volume-mean nne, so the clumping factor is applied here. This also gives collisional
+  // (three-body) recombination its full clumpfactor^2, since calculate_ionrecombcoeff() divides its
+  // clumpednne^2-scaled rate by clumpednne, leaving one factor of clumpfactor in Col_rec.
+  const double phi = grid::get_clumpfactor(nonemptymgi) * (Alpha_sp + Col_rec) / (Gamma_ion + gamma_nt);
   assert_always(phi > 0.);
 
   return phi;

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -366,8 +366,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
   // Update clumping factors
   if constexpr (USE_MICROCLUMPING) {
-    const double rad_vel =
-        grid::get_modelcell_mean_radial_pos_tmin(grid::get_mgi_of_nonemptymgi(nonemptymgi)) / globals::tmin;
+    const double rad_vel = grid::get_modelcell_mean_radial_pos_tmin(mgi) / globals::tmin;
     const float clumpfactor = clumping_factor(tmid, rad_vel);
 
     grid::set_clumpfactor(nonemptymgi, clumpfactor);


### PR DESCRIPTION
## What changed

A review of the `USE_MICROCLUMPING` implementation (#275) found that the photoionisation-equilibrium ion balance for elements without NLTE levels never saw the clumping factor: `phi_rate_balance()` used the unclumped `Alpha_sp`, and `phi` is multiplied downstream by the volume-mean `nne`. So clumping had no direct effect on the ionisation state of these elements, even though enhanced recombination (lower ionisation) is its primary physical effect.

- **ltepop.cc**: multiply `phi` by the cell clumping factor so recombining ions see the in-clump electron density (`clumpfactor * nne`). This propagates to `calculate_ionfractions()` and `find_uppermost_ion()`, which consume `phi`.
- **artisoptions_doc.md**: document the ion-balance behaviour, note that the stimulated-recombination enhancement cannot enter the `USE_LUT_PHOTOION` tables (only the direct bf integrals and packet-opacity departure ratios), and fix a reference to the nonexistent `grid::get_modelcell_mean_radial_vel()`.
- **update_grid.cc**: drop a redundant `get_mgi_of_nonemptymgi()` lookup in the clumping block (`mgi` is already in scope).

## Why

Beyond the omission itself, the previous behaviour was inconsistent in two ways:

1. NLTE-solved elements already receive clump-enhanced recombination in their rate matrix (`nltepop.cc`), so NLTE and non-NLTE elements in the same cell responded differently to clumping.
2. With `LTEPOP_EXCITATION_USE_TJ == false`, `gammaestimator` is refreshed via `calculate_iongamma_per_gspop()`, whose collisional-ionisation part *is* clump-enhanced. That enhanced rate entered the denominator of `phi` while the recombination numerator stayed unenhanced, so clumping pushed those cells toward *higher* ionisation — the wrong direction.

The fix also gives the (currently compiled-out) collisional-recombination term its correct clumpfactor², because `calculate_ionrecombcoeff()` divides its clumpednne²-scaled rate by clumpednne, leaving one factor in `Col_rec`. The Saha LTE branch (`phi_saha`, forced-Saha elements, initial LTE timesteps) is deliberately left unchanged.

## Notes for reviewers

- **No results change with the option disabled** (all presets): `get_clumpfactor()` returns exactly 1.0f and the multiplication is an exact no-op under `FASTMATH=OFF`, so stored test checksums remain valid.
- Verification performed:
  - `make OPTIMIZE=OFF` (classic preset) and `TESTMODE=ON` compiles of clumping-enabled variants of the classic and nltenebular presets.
  - Full kilonova_1d test run with clumping factor 2 under `TESTMODE=ON` (ASan/UBSan + assertions): all timesteps completed with no errors.
  - Direction check: two classicmode runs (locally shrunken 26³ grid), factor 1 vs factor 2. The clumped run shifted Fe/Co/Ni ion-stage ratios toward lower ionisation by ~2–3.7× (e.g. Fe III/IV: 6.1e-3 → 1.9e-2), the expected enhanced-recombination effect.
- The rest of the microclumping implementation was checked and found correct: D¹/D² factor placement across all documented processes, correctly unenhanced linear processes, the Spencer-Fano solver correctly unclumped (D cancels in the channel split), set-before-get ordering, MPI shared-memory writes/broadcast, and restart behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)