### PR TITLE
Fix review findings, add unit tests, and speed up bound-free estimator lookups

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -347,7 +347,8 @@ jobs:
                   apt-get install -y --no-install-recommends software-properties-common
                   add-apt-repository -y ppa:ubuntu-toolchain-r/test
                   apt-get update
-                  apt-get install -y --no-install-recommends gcc-14 g++-14
+                  # gfortran-14 completes the toolchain that nvc++ validates when passed --gcc-toolchain
+                  apt-get install -y --no-install-recommends gcc-14 g++-14 gfortran-14
                   update-alternatives \
                        --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
                        --slave /usr/bin/g++ g++ /usr/bin/g++-14

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -349,7 +349,7 @@ jobs:
               uses: fortran-lang/setup-fortran@v1.9.2
               with:
                   compiler: nvidia-hpc
-                  version: 26.1
+                  version: 26.5
 
             - name: Set nvc++ as compiler
               run: |

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -333,9 +333,12 @@ jobs:
         runs-on: ubuntu-26.04
         # NVIDIA's container registry serves the SDK preinstalled, avoiding the apt repository on
         # developer.download.nvidia.com, which (as of 2026-07) returns 404 for the SDK debs when
-        # fetched from GitHub's runner network (same approach as the AMD ROCm job above)
+        # fetched from GitHub's runner network (same approach as the AMD ROCm job above).
+        # 26.1 is the previously-validated SDK version: 26.5's bundled stdexec headers fail to
+        # compile with its own frontend in -stdpar=gpu mode ("operator= has already been declared"
+        # in include-stdexec/stdexec/__detail/__any.hpp)
         container:
-            image: nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu24.04
+            image: nvcr.io/nvidia/nvhpc:26.1-devel-cuda13.1-ubuntu24.04
         steps:
             - uses: actions/checkout@v7
               with:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -331,34 +331,39 @@ jobs:
     nvidia-nvhpc:
         name: NVIDIA NVHPC nvc++
         runs-on: ubuntu-26.04
+        # NVIDIA's container registry serves the SDK preinstalled, avoiding the apt repository on
+        # developer.download.nvidia.com, which (as of 2026-07) returns 404 for the SDK debs when
+        # fetched from GitHub's runner network (same approach as the AMD ROCm job above)
+        container:
+            image: nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu24.04
         steps:
             - uses: actions/checkout@v7
+              with:
+                    fetch-depth: 0
 
             - name: Install gcc
               run: |
-                  sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends software-properties-common
-                  sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-                  sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends gcc-14 g++-14
-                  sudo update-alternatives \
+                  apt-get update
+                  apt-get install -y --no-install-recommends software-properties-common
+                  add-apt-repository -y ppa:ubuntu-toolchain-r/test
+                  apt-get update
+                  apt-get install -y --no-install-recommends gcc-14 g++-14
+                  update-alternatives \
                        --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \
                        --slave /usr/bin/g++ g++ /usr/bin/g++-14
 
-            - name: Install nvc++
-              uses: fortran-lang/setup-fortran@v1.9.2
-              with:
-                  compiler: nvidia-hpc
-                  version: 26.5
-
             - name: Set nvc++ as compiler
               run: |
+                  nvc++ --version
                   echo "CXX=nvc++" >> $GITHUB_ENV
                   echo "OMPI_CXX=nvc++" >> $GITHUB_ENV
+                  # make nvc++ use the gcc-14 toolchain (the image's preconfigured system gcc is older)
+                  echo "GCCTOOLCHAIN=$(which g++-14)" >> $GITHUB_ENV
 
-            - name: Install Open MPI
+            - name: Install Open MPI and git
               run: |
-                  sudo apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev
+                  apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev git
+                  git config --global --add safe.directory /__w/artis/artis
 
             - name: Compile classic mode STDPAR=ON GPU=ON
               run: |

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -141,6 +141,11 @@ jobs:
                   make clean
                   make -j$(nproc) sn3d exspec
 
+            - name: Build and run unit tests (classic mode)
+              run: |
+                  make -j$(nproc) unittests
+                  ./unittests
+
             - name: Compile classic mode OPENMP=ON
               run: |
                   make clean
@@ -157,6 +162,11 @@ jobs:
                   cp -v -p artisoptions_nltenebular.h artisoptions.h
                   make clean
                   make -j$(nproc) sn3d exspec
+
+            - name: Build and run unit tests (nebular mode)
+              run: |
+                  make -j$(nproc) unittests
+                  ./unittests
 
             - name: Compile nebular mode EIGEN=OFF
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,59 @@ jobs:
                   name: test-${{ matrix.testname }}-output-pdf
                   path: tests/*.pdf
 
+    # Runs one small model with OpenMP threading to exercise the mutex/atomic code paths that the
+    # single-threaded checksum tests never enter. No checksum comparison: multithreaded runs are not
+    # reproducible (worker threads have independently seeded generators and race on shared estimators).
+    openmp_smoke:
+        runs-on: ubuntu-26.04-arm
+        timeout-minutes: ${{ inputs.testmode == 'ON' && 360 || 40 }}
+        name: kilonova_1d_openmp_norun_checksums
+        env:
+            OMPI_MCA_memory: ${{ inputs.testmode == 'ON' && '^patcher' || '' }}
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+
+            - name: Install Open MPI and set compiler to g++-15
+              run: |
+                  echo "CXX=g++-15" >> $GITHUB_ENV
+                  echo "OMPI_CXX=g++-15" >> $GITHUB_ENV
+                  sudo apt-get update
+                  sudo apt-get install -y openmpi-bin libopenmpi-dev
+
+            - name: Cache test atomic data
+              uses: actions/cache@v6
+              id: cache-testatomicdata
+              with:
+                  path: tests/atomicdata_feconi.tar.xz
+                  key: tests/atomicdata_feconi.tar.xz
+
+            - name: Download/extract test data
+              working-directory: tests/
+              run: |
+                  source ./setup_kilonova_1d.sh
+
+            - name: Compile
+              run: |
+                  cp tests/kilonova_1d_testrun/artisoptions.h .
+                  make OPENMP=ON TESTMODE=${{ inputs.testmode }} MAX_NODE_SIZE=2 FASTMATH=OFF -j$(nproc) sn3d exspec
+                  cp sn3d exspec tests/kilonova_1d_testrun/
+
+            - name: Run test job0 with OpenMP threads
+              working-directory: tests/kilonova_1d_testrun/
+              env:
+                  OMP_NUM_THREADS: 2
+              run: |
+                  cp input-newrun.txt input.txt
+                  touch output_0-0.txt
+                  time mpirun -np 2 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d
+
+            - name: cat output log
+              if: always()
+              working-directory: tests/kilonova_1d_testrun/
+              run: cat output_0-0.txt
+
     combine_checksums:
         needs: testmodels
         if: always() && inputs.testmode != 'ON'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ version*.h
 *.d
 sn3d
 exspec
+unittests
 tags
 browse.VC.db
 *.optrpt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,17 @@ The build uses `-Werror` with extensive warnings — new warnings break CI.
 
 ## Testing
 
-There are no unit tests. Testing is done through end-to-end regression runs
+Unit tests for the pure numeric helpers live in `unittests.cc` (built with
+`make unittests`, run as `./unittests`; CI runs them for the classic and nebular
+presets), and compile-time checks of the `constexpr` helpers are `static_assert`s
+next to their definitions. The main coverage is end-to-end regression runs
 (`.github/workflows/ci.yml`): each test in `tests/` runs a small model with
 `REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2` and compares `md5sum` checksums of
-the output files against `tests/<testname>_inputfiles/results_md5_*.txt`. To run
-one locally (downloads atomic data on first use):
+the output files against `tests/<testname>_inputfiles/results_md5_*.txt` (all
+`*.out` files are checksummed; `output_*.txt` logs are not). A separate CI job
+runs one model with `OPENMP=ON` and no checksum comparison to exercise the
+threaded code paths. To run a regression test locally (downloads atomic data on
+first use):
 
 ```sh
 cd tests

--- a/Makefile
+++ b/Makefile
@@ -290,8 +290,8 @@ ifneq ($(PGO),)
   endif
 endif
 
-# sn3d.cc and exspec.cc have main() defined
-common_files := $(filter-out sn3d.cc exspec.cc, $(wildcard *.cc))
+# sn3d.cc, exspec.cc, and unittests.cc have main() defined
+common_files := $(filter-out sn3d.cc exspec.cc unittests.cc, $(wildcard *.cc))
 
 sn3d_files = $(common_files) sn3d.cc
 sn3d_objects = $(addprefix $(BUILD_DIR)/,$(sn3d_files:.cc=.o))
@@ -300,6 +300,10 @@ sn3d_dep = $(sn3d_objects:%.o=%.d)
 exspec_files = $(common_files) exspec.cc
 exspec_objects = $(addprefix $(BUILD_DIR)/,$(exspec_files:.cc=.o))
 exspec_dep = $(exspec_objects:%.o=%.d)
+
+unittests_files = $(common_files) unittests.cc
+unittests_objects = $(addprefix $(BUILD_DIR)/,$(unittests_files:.cc=.o))
+unittests_dep = $(unittests_objects:%.o=%.d)
 
 .ONESHELL:
 define version_h
@@ -350,7 +354,14 @@ $(BUILD_DIR)/exspec: $(exspec_objects)
 exspec: $(BUILD_DIR)/exspec
 	ln -sf $(BUILD_DIR)/exspec exspec
 
-.PHONY: clean sn3d sn3dwhole exspec
+$(BUILD_DIR)/unittests: $(unittests_objects)
+	$(CXX) $(CXXFLAGS) $(unittests_objects) $(gsl_objects) $(LDFLAGS) -o $(BUILD_DIR)/unittests
+-include $(unittests_dep)
+
+unittests: $(BUILD_DIR)/unittests
+	ln -sf $(BUILD_DIR)/unittests unittests
+
+.PHONY: clean sn3d sn3dwhole exspec unittests
 
 clean:
-	rm -rf sn3d exspec build *.o *.d
+	rm -rf sn3d exspec unittests build *.o *.d

--- a/atomic.h
+++ b/atomic.h
@@ -212,7 +212,11 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
     } else if (nu == nu_edge) {
       sigma_bf = photoion_xs[0];
     } else if (nu < nu_edge * (1 + (globals::NPHIXSNUINCREMENT * globals::NPHIXSPOINTS))) {
-      const int i = static_cast<int>((nu - nu_edge) / (globals::NPHIXSNUINCREMENT * nu_edge));
+      // the range guard above and the index below are computed with different floating-point
+      // expressions, so for nu just under the bound the division can round up to exactly
+      // NPHIXSPOINTS. Clamp so that the read stays inside this level's table
+      const int i = std::min(static_cast<int>((nu - nu_edge) / (globals::NPHIXSNUINCREMENT * nu_edge)),
+                             globals::NPHIXSPOINTS - 1);
       sigma_bf = photoion_xs[i];
     } else {
       // use a parameterization of sigma_bf by the Kramers formula
@@ -517,6 +521,12 @@ inline void update_includedionslevels_maxnions() {
   const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
   const int phixstargetindex = get_phixstargetindex(uniquelevelindex, upperionlevel);
   return -1 - globals::alllevels.bflist_start[uniquelevelindex] - phixstargetindex;
+}
+
+// Inverse of get_emtype_continuum(): decode a (negative) bound-free continuum emission type into its index into
+// globals::bflist. Only valid for emission types below the ABSTYPE/EMTYPE special values, i.e. actual continua.
+[[nodiscard]] constexpr auto get_bflistindex_from_emtype_continuum(const int emissiontype) -> int {
+  return -1 - emissiontype;
 }
 
 // Return the photionisation threshold energy [erg]

--- a/atomic.h
+++ b/atomic.h
@@ -524,7 +524,9 @@ inline void update_includedionslevels_maxnions() {
 }
 
 // Inverse of get_emtype_continuum(): decode a (negative) bound-free continuum emission type into its index into
-// globals::bflist. Only valid for emission types below the ABSTYPE/EMTYPE special values, i.e. actual continua.
+// globals::bflist. Only valid for actual continuum emission types as returned by get_emtype_continuum(); the
+// caller must first exclude the EMTYPE_NOTSET and EMTYPE_FREEFREE sentinel values (large negative numbers that
+// would decode to out-of-range bflist indices).
 [[nodiscard]] constexpr auto get_bflistindex_from_emtype_continuum(const int emissiontype) -> int {
   return -1 - emissiontype;
 }

--- a/decay.cc
+++ b/decay.cc
@@ -292,6 +292,28 @@ void printout_decaypath(const int decaypathindex) {
   printlnlog("");
 }
 
+// The Bateman solution in calculate_decaychain() is singular when two nuclides in a chain have exactly
+// equal decay constants. Rather than failing an assertion deep inside packet setup, detect this
+// input-data problem up front and report the offending chain.
+void abort_if_decaypath_has_duplicate_lambdas() {
+  for (int decaypathindex = 0; decaypathindex < get_num_decaypaths(); decaypathindex++) {
+    const auto& lambdas = decaypaths[decaypathindex].lambdas;
+    for (auto i = 0Z; i < std::ssize(lambdas); i++) {
+      for (auto j = i + 1; j < std::ssize(lambdas); j++) {
+        if (lambdas[i] > 0. && lambdas[i] == lambdas[j]) {
+          printlnlog(
+              "[error] decay path contains two nuclides with identical decay constants {:g} [1/s], which makes the "
+              "Bateman solution singular. Slightly perturb one of the mean lifetimes in the decay data to break the "
+              "degeneracy.",
+              lambdas[i]);
+          printout_decaypath(decaypathindex);
+          std::abort();
+        }
+      }
+    }
+  }
+}
+
 // follow decays at the ends of the current list of decaypaths to get decaypaths from all descendants
 void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
   const auto initial_last_decaypath = localdecaypaths.back();
@@ -474,55 +496,6 @@ auto sample_decaytime(const int decaypathindex, const double tdecaymin, const do
     }
   }
   return tdecay;
-}
-
-// calculate final number abundance from multiple decays, e.g., Ni56 -> Co56 -> Fe56 (nuc[0] -> nuc[1] -> nuc[2])
-// the top nuclide initial abundance is set and the chain-end abundance is returned (all intermediates nuclides
-// are assumed to start with zero abundance)
-// note: first and last can be nuclide can be the same if num_nuclides==1, reducing to simple decay formula
-//
-// timediff:           time elapsed for decays [seconds]
-// lambdas:            array of 1/(mean lifetime) for nuc[0]..nuc[num_nuclides-1]  [seconds^-1]
-// useexpansionfactor: if true, return a modified 'abundance' at the end of the chain, with a weighting factor
-//                          accounting for adiabatic loss from expansion since the decays occurred
-//                          (This is needed to get the initial temperature)
-constexpr auto calculate_decaychain(const double firstinitabund, const std::span<const double> lambdas,
-                                    const double timediff, const bool useexpansionfactor) -> double {
-  const int num_nuclides = static_cast<int>(lambdas.size());
-  assert_testmodeonly(num_nuclides >= 1);
-
-  double lambdaproduct = 1.;
-  for (int j = 0; j < (num_nuclides - 1); j++) {
-    lambdaproduct *= lambdas[j];
-  }
-
-  double sum = 0;
-  for (int j = 0; j < num_nuclides; j++) {
-    const auto lambda_j = lambdas[j];
-    double denominator = 1.;
-    for (int p = 0; p < num_nuclides; p++) {
-      if (p != j) {
-        denominator *= (lambdas[p] - lambda_j);
-      }
-    }
-
-    // the Bateman solution is singular when two nuclides in a chain have equal decay constants
-    assert_always(std::abs(denominator) > 0.);
-    if (!useexpansionfactor) {
-      // get abundance output
-      sum += exp(-lambda_j * timediff) / denominator;
-    } else {
-      if (lambda_j > 0.) {
-        const double sumtermtop =
-            ((1 + (1 / lambda_j / timediff)) * exp(-timediff * lambda_j)) - (1. / lambda_j / timediff);
-        sum += sumtermtop / denominator;
-      }
-    }
-  }
-
-  const double lastabund = firstinitabund * lambdaproduct * sum;
-  assert_always(std::isfinite(lastabund));
-  return lastabund;
 }
 
 // Get the mass fraction of a nuclide accounting for all decays and initial abundances.
@@ -1077,6 +1050,7 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
 
   printlnlog("Number of nuclides before filtering: {}", std::ssize(nuclides));
   decaypaths = find_decaypaths(custom_zlist, custom_alist, standard_nuclides);
+  abort_if_decaypath_has_duplicate_lambdas();
   filter_unused_nuclides(custom_zlist, custom_alist, standard_nuclides);
 
   printlnlog("Number of nuclides: {}", std::ssize(nuclides));

--- a/decay.h
+++ b/decay.h
@@ -4,6 +4,7 @@
 #define DECAY_H
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <ostream>
 #include <span>
@@ -28,6 +29,56 @@ constexpr std::array all_decaytypes{
     DecayType::DECAYTYPE_ALPHA,     DecayType::DECAYTYPE_ELECTRONCAPTURE, DecayType::DECAYTYPE_BETAPLUS,
     DecayType::DECAYTYPE_BETAMINUS, DecayType::DECAYTYPE_SPONTFISSION,
 };
+
+// calculate final number abundance from multiple decays, e.g., Ni56 -> Co56 -> Fe56 (nuc[0] -> nuc[1] -> nuc[2])
+// the top nuclide initial abundance is set and the chain-end abundance is returned (all intermediates nuclides
+// are assumed to start with zero abundance)
+// note: first and last can be nuclide can be the same if num_nuclides==1, reducing to simple decay formula
+//
+// timediff:           time elapsed for decays [seconds]
+// lambdas:            array of 1/(mean lifetime) for nuc[0]..nuc[num_nuclides-1]  [seconds^-1]
+// useexpansionfactor: if true, return a modified 'abundance' at the end of the chain, with a weighting factor
+//                          accounting for adiabatic loss from expansion since the decays occurred
+//                          (This is needed to get the initial temperature)
+constexpr auto calculate_decaychain(const double firstinitabund, const std::span<const double> lambdas,
+                                    const double timediff, const bool useexpansionfactor) -> double {
+  const int num_nuclides = static_cast<int>(lambdas.size());
+  assert_testmodeonly(num_nuclides >= 1);
+
+  double lambdaproduct = 1.;
+  for (int j = 0; j < (num_nuclides - 1); j++) {
+    lambdaproduct *= lambdas[j];
+  }
+
+  double sum = 0;
+  for (int j = 0; j < num_nuclides; j++) {
+    const auto lambda_j = lambdas[j];
+    double denominator = 1.;
+    for (int p = 0; p < num_nuclides; p++) {
+      if (p != j) {
+        denominator *= (lambdas[p] - lambda_j);
+      }
+    }
+
+    // the Bateman solution is singular when two nuclides in a chain have equal decay constants
+    // (init_nuclides() rejects decay data that could trigger this)
+    assert_always(std::abs(denominator) > 0.);
+    if (!useexpansionfactor) {
+      // get abundance output
+      sum += exp(-lambda_j * timediff) / denominator;
+    } else {
+      if (lambda_j > 0.) {
+        const double sumtermtop =
+            ((1 + (1 / lambda_j / timediff)) * exp(-timediff * lambda_j)) - (1. / lambda_j / timediff);
+        sum += sumtermtop / denominator;
+      }
+    }
+  }
+
+  const double lastabund = firstinitabund * lambdaproduct * sum;
+  assert_always(std::isfinite(lastabund));
+  return lastabund;
+}
 
 void init_nuclides(std::span<const int> custom_zlist, std::span<const int> custom_alist);
 [[nodiscard]] auto decaytype_is_used(DecayType decaytype) -> bool;

--- a/exspec.cc
+++ b/exspec.cc
@@ -107,6 +107,26 @@ void do_direction_bin(const int dirbin, const std::vector<std::vector<Packet>>& 
       write_spectra("gamma_spec.out", "", "", "", gamma_spectra, globals::ntimesteps);
     }
 
+    // consistency check (log only): the frequency-integrated spectrum must reproduce the light curve, minus
+    // the packets whose frequencies fall outside the spectrum's frequency range
+    for (int nts = 0; nts < globals::ntimesteps; nts++) {
+      double lum_from_spec = 0.;
+      for (ptrdiff_t nnu = 0; nnu < MNUBINS; nnu++) {
+        lum_from_spec += rpkt_spectra_I.fluxalltimesteps[(nnu * static_cast<ptrdiff_t>(globals::ntimesteps)) + nts] *
+                         rpkt_spectra_I.delta_freq[nnu];
+      }
+      // undo the flux normalisation applied in add_to_spec_res() to get back to a luminosity
+      lum_from_spec *= 4.e12 * PI * PARSEC * PARSEC;
+      const double lum_lightcurve = rpkt_light_curve_lum[nts];
+      if (lum_lightcurve > 0. && lum_from_spec > (lum_lightcurve * 1.001)) {
+        printlnlog(
+            "[warning] consistency check failed for timestep {}: frequency-integrated spec.out luminosity {:g} "
+            "[erg/s] exceeds the light_curve.out luminosity {:g} [erg/s], but the spectrum's packets should be a "
+            "subset of the light curve's packets",
+            nts, lum_from_spec, lum_lightcurve);
+      }
+    }
+
     printlnlog("wrote the angle-averaged light curves and spectra");
   } else {
     // direction bin a

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -252,17 +252,6 @@ void init_xcom_photoion_data() {
   }
 }
 
-// The partial cross section for Compton scattering.
-// - xx: is the photon energy (in units of electron mass)
-// - f_max: is the energy loss factor up to which we wish to integrate
-[[nodiscard]] constexpr auto sigma_compton_partial(const double x, const double f_max) -> double {
-  const double term1 = ((x * x) - (2 * x) - 2) * std::log(f_max) / x / x;
-  const double term2 = (((f_max * f_max) - 1) / (f_max * f_max)) / 2;
-  const double term3 = ((f_max - 1) / x) * ((1 / x) + (2 / f_max) + (1 / (x * f_max)));
-
-  return (3 * SIGMA_T * (term1 + term2 + term3) / (8 * x));
-}
-
 // the absorption coefficient [cm^-1] for Compton scattering in the co-moving frame
 [[nodiscard]] auto get_chi_compton_cmf(const int nonemptymgi, const double nu_cmf) -> double {
   if constexpr (GAMMA_USE_KAPPA_GREY.has_value()) {
@@ -281,36 +270,6 @@ void init_xcom_photoion_data() {
   assert_testmodeonly(std::isfinite(chi_cmf));
 
   return chi_cmf;
-}
-
-// To choose the value of f to integrate to - idea is we want sigma_compton_partial(xx,f) = zrand.
-[[nodiscard]] auto choose_f(const double xx, const double zrand) -> double {
-  double f_max = 1 + (2 * xx);
-  double f_min = 1;
-
-  const double norm = zrand * sigma_compton_partial(xx, f_max);
-
-  int count = 0;
-  double err = 1e20;
-
-  double ftry = (f_max + f_min) / 2;
-  while ((err > 1.e-4) && (count < 1000)) {
-    ftry = (f_max + f_min) / 2;
-    const double sigma_try = sigma_compton_partial(xx, ftry);
-    if (sigma_try > norm) {
-      f_max = ftry;
-      err = (sigma_try - norm) / norm;
-    } else {
-      f_min = ftry;
-      err = (norm - sigma_try) / norm;
-    }
-
-    count++;
-  }
-
-  assert_testmodeonly(ftry >= 1.);
-  assert_testmodeonly(ftry <= ((2 * xx) + 1.));
-  return ftry;
 }
 
 // For Thomson scattering we can get the new angle from a random number very easily.
@@ -566,38 +525,6 @@ void compton_scatter(Packet& pkt) {
   const double chi_cmf = (chi_cmf_fe * ffegrp) + (chi_cmf_si * (1. - ffegrp));
 
   return std::max(chi_cmf, 0.);
-}
-
-// Compute the mean energy converted to non-thermal electrons times the Klein-Nishina cross section.
-constexpr auto meanf_sigma(const double x) -> double {
-  if (x < THOMSON_LIMIT) {
-    // The closed form below sums five terms of order 1/x^2 that have to cancel down to O(x), so it
-    // loses about 8 decimal digits per decade in x: the relative error is 2e-9 at x = 1e-2, 2e-6 at
-    // 1e-3, 25% at 1e-4, and the result turns negative below ~1e-6. Use the exact Taylor series of
-    // the same expression instead, which is accurate to 6e-11 at the x = THOMSON_LIMIT crossover
-    // and better below it. The leading term is the Thomson-limit mean fractional energy transfer x.
-    constexpr std::array taylor_coeffs{
-        1., -21. / 5., 147. / 10., -1616. / 35., 940. / 7., -2584. / 7., 14588. / 15., -409088. / 165.,
-    };
-    // Horner evaluation, starting from the highest-order coefficient
-    double series = taylor_coeffs.back();
-    for (int i = static_cast<int>(taylor_coeffs.size()) - 2; i >= 0; i--) {
-      series = taylor_coeffs[i] + (x * series);
-    }
-    return SIGMA_T * x * series;
-  }
-
-  const double f = 1 + (2 * x);
-
-  const double term0 = 2 / x;
-  const double term1 = (1 - (2 / x) - (3 / (x * x))) * log(f);
-  const double term2 = ((4 / x) + (3 / (x * x)) - 1) * 2 * x / f;
-  const double term3 = (1 - (2 / x) - (1 / (x * x))) * 2 * x * (1 + x) / f / f;
-  const double term4 = -2. * x * ((4 * x * x) + (6 * x) + 3) / 3 / f / f / f;
-
-  const double tot = 3 * SIGMA_T * (term0 + term1 + term2 + term3 + term4) / (8 * x);
-
-  return tot;
 }
 
 // get the comoving-frame gamma-ray absorption coefficient (with the expected energy loss fraction per interaction

--- a/gammapkt.h
+++ b/gammapkt.h
@@ -3,7 +3,11 @@
 #ifndef GAMMAPKT_H
 #define GAMMAPKT_H
 
+#include <array>
+#include <cmath>
+
 #include "constants.h"
+#include "mpi_logging.h"
 #include "packet.h"
 #include "random.h"
 
@@ -12,6 +16,79 @@ void init_gamma_data();
 DEVICE_FUNC void pellet_gamma_decay(Packet& pkt);
 DEVICE_FUNC void do_gamma(Packet& pkt, int nts, double t2);
 auto choose_gamma_ray(int nucindex, rngstate_type& rngstate) -> double;
+
+// The partial cross section for Compton scattering.
+// - xx: is the photon energy (in units of electron mass)
+// - f_max: is the energy loss factor up to which we wish to integrate
+[[nodiscard]] constexpr auto sigma_compton_partial(const double x, const double f_max) -> double {
+  const double term1 = ((x * x) - (2 * x) - 2) * std::log(f_max) / x / x;
+  const double term2 = (((f_max * f_max) - 1) / (f_max * f_max)) / 2;
+  const double term3 = ((f_max - 1) / x) * ((1 / x) + (2 / f_max) + (1 / (x * f_max)));
+
+  return (3 * SIGMA_T * (term1 + term2 + term3) / (8 * x));
+}
+
+// To choose the value of f to integrate to - idea is we want sigma_compton_partial(xx,f) = zrand.
+[[nodiscard]] inline auto choose_f(const double xx, const double zrand) -> double {
+  double f_max = 1 + (2 * xx);
+  double f_min = 1;
+
+  const double norm = zrand * sigma_compton_partial(xx, f_max);
+
+  int count = 0;
+  double err = 1e20;
+
+  double ftry = (f_max + f_min) / 2;
+  while ((err > 1.e-4) && (count < 1000)) {
+    ftry = (f_max + f_min) / 2;
+    const double sigma_try = sigma_compton_partial(xx, ftry);
+    if (sigma_try > norm) {
+      f_max = ftry;
+      err = (sigma_try - norm) / norm;
+    } else {
+      f_min = ftry;
+      err = (norm - sigma_try) / norm;
+    }
+
+    count++;
+  }
+
+  assert_testmodeonly(ftry >= 1.);
+  assert_testmodeonly(ftry <= ((2 * xx) + 1.));
+  return ftry;
+}
+
+// Compute the mean energy converted to non-thermal electrons times the Klein-Nishina cross section.
+constexpr auto meanf_sigma(const double x) -> double {
+  if (x < THOMSON_LIMIT) {
+    // The closed form below sums five terms of order 1/x^2 that have to cancel down to O(x), so it
+    // loses about 8 decimal digits per decade in x: the relative error is 2e-9 at x = 1e-2, 2e-6 at
+    // 1e-3, 25% at 1e-4, and the result turns negative below ~1e-6. Use the exact Taylor series of
+    // the same expression instead, which is accurate to 6e-11 at the x = THOMSON_LIMIT crossover
+    // and better below it. The leading term is the Thomson-limit mean fractional energy transfer x.
+    constexpr std::array taylor_coeffs{
+        1., -21. / 5., 147. / 10., -1616. / 35., 940. / 7., -2584. / 7., 14588. / 15., -409088. / 165.,
+    };
+    // Horner evaluation, starting from the highest-order coefficient
+    double series = taylor_coeffs.back();
+    for (int i = static_cast<int>(taylor_coeffs.size()) - 2; i >= 0; i--) {
+      series = taylor_coeffs[i] + (x * series);
+    }
+    return SIGMA_T * x * series;
+  }
+
+  const double f = 1 + (2 * x);
+
+  const double term0 = 2 / x;
+  const double term1 = (1 - (2 / x) - (3 / (x * x))) * log(f);
+  const double term2 = ((4 / x) + (3 / (x * x)) - 1) * 2 * x / f;
+  const double term3 = (1 - (2 / x) - (1 / (x * x))) * 2 * x * (1 + x) / f / f;
+  const double term4 = -2. * x * ((4 * x * x) + (6 * x) + 3) / 3 / f / f / f;
+
+  const double tot = 3 * SIGMA_T * (term0 + term1 + term2 + term3 + term4) / (8 * x);
+
+  return tot;
+}
 
 }  // namespace gammapkt
 

--- a/grid.cc
+++ b/grid.cc
@@ -2481,39 +2481,59 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
     // r_cyl component of velocity
     const double xyspeed = dirxylen * CLIGHT_PROP;
 
-    // make a normalised 2D direction vector in the xy plane
-    const std::array<double, 2> dirnoz = {dir[0] / dirxylen, dir[1] / dirxylen};
+    if (dirxylen > 0.) {
+      // make a normalised 2D direction vector in the xy plane
+      const std::array<double, 2> dirnoz = {dir[0] / dirxylen, dir[1] / dirxylen};
 
-    const double r_outer = cellcoordmax[0] * tstart / globals::tmin;
-    const double d_rcyl_coordmaxboundary =
-        is_boundary_overshoot_within_tolerance<BoundaryType::UPPER>(pktposgridcoord[0], pktvelgridcoord[0],
-                                                                    cellcoordmax[0], tstart)
-            ? 0.
-            : expanding_shell_intersection<BoundaryType::UPPER>(posnoz, dirnoz, xyspeed, r_outer, tstart);
-    if (d_rcyl_coordmaxboundary >= 0.) {
-      // how far did the packet travel in the z direction during this time?
-      const double d_z_coordmaxboundary = d_rcyl_coordmaxboundary / xyspeed * dir[2] * CLIGHT_PROP;
-      // distance from two perpendicular components to the r_cyl upper boundary
-      const double d_coordmaxboundary_rcyl = std::sqrt(pow2(d_rcyl_coordmaxboundary) + pow2(d_z_coordmaxboundary));
-      if ((d_coordmaxboundary_rcyl >= 0.) && (d_coordmaxboundary_rcyl < distance)) {
-        distance = d_coordmaxboundary_rcyl;
-        next_cellindex = (cellcoordidx[0] == (ncoordgrid[0] - 1)) ? -99 : cellindex + get_coordcellindexstride(0);
-      }
-    }
-
-    const double r_inner = cellcoordmin[0] * tstart / globals::tmin;
-    // don't try to calculate the intersection if the inner radius is zero
-    if (r_inner > 0) {
-      // calculate the distance in the xy plane to the inner boundary
-      const double d_rcyl_coordminboundary =
-          is_boundary_overshoot_within_tolerance<BoundaryType::LOWER>(pktposgridcoord[0], pktvelgridcoord[0],
-                                                                      cellcoordmin[0], tstart)
+      const double r_outer = cellcoordmax[0] * tstart / globals::tmin;
+      const double d_rcyl_coordmaxboundary =
+          is_boundary_overshoot_within_tolerance<BoundaryType::UPPER>(pktposgridcoord[0], pktvelgridcoord[0],
+                                                                      cellcoordmax[0], tstart)
               ? 0.
-              : expanding_shell_intersection<BoundaryType::LOWER>(posnoz, dirnoz, xyspeed, r_inner, tstart);
-      if (d_rcyl_coordminboundary >= 0.) {
-        const double d_z_coordminboundary = d_rcyl_coordminboundary / xyspeed * dir[2] * CLIGHT_PROP;
-        // distance from two perpendicular components to the r_cyl lower boundary
-        const double d_coordminboundary_rcyl = std::sqrt(pow2(d_rcyl_coordminboundary) + pow2(d_z_coordminboundary));
+              : expanding_shell_intersection<BoundaryType::UPPER>(posnoz, dirnoz, xyspeed, r_outer, tstart);
+      if (d_rcyl_coordmaxboundary >= 0.) {
+        // how far did the packet travel in the z direction during this time?
+        const double d_z_coordmaxboundary = d_rcyl_coordmaxboundary / xyspeed * dir[2] * CLIGHT_PROP;
+        // distance from two perpendicular components to the r_cyl upper boundary
+        const double d_coordmaxboundary_rcyl = std::sqrt(pow2(d_rcyl_coordmaxboundary) + pow2(d_z_coordmaxboundary));
+        if ((d_coordmaxboundary_rcyl >= 0.) && (d_coordmaxboundary_rcyl < distance)) {
+          distance = d_coordmaxboundary_rcyl;
+          next_cellindex = (cellcoordidx[0] == (ncoordgrid[0] - 1)) ? -99 : cellindex + get_coordcellindexstride(0);
+        }
+      }
+
+      const double r_inner = cellcoordmin[0] * tstart / globals::tmin;
+      // don't try to calculate the intersection if the inner radius is zero
+      if (r_inner > 0) {
+        // calculate the distance in the xy plane to the inner boundary
+        const double d_rcyl_coordminboundary =
+            is_boundary_overshoot_within_tolerance<BoundaryType::LOWER>(pktposgridcoord[0], pktvelgridcoord[0],
+                                                                        cellcoordmin[0], tstart)
+                ? 0.
+                : expanding_shell_intersection<BoundaryType::LOWER>(posnoz, dirnoz, xyspeed, r_inner, tstart);
+        if (d_rcyl_coordminboundary >= 0.) {
+          const double d_z_coordminboundary = d_rcyl_coordminboundary / xyspeed * dir[2] * CLIGHT_PROP;
+          // distance from two perpendicular components to the r_cyl lower boundary
+          const double d_coordminboundary_rcyl = std::sqrt(pow2(d_rcyl_coordminboundary) + pow2(d_z_coordminboundary));
+          if ((d_coordminboundary_rcyl >= 0.) && (d_coordminboundary_rcyl < distance)) {
+            distance = d_coordminboundary_rcyl;
+            next_cellindex = (cellcoordidx[0] == 0) ? -99 : cellindex - get_coordcellindexstride(0);
+          }
+        }
+      }
+    } else {
+      // The packet is moving exactly along the z axis (reachable when the comoving emission direction
+      // is sampled at exactly costheta = +/-1 and the local velocity is parallel to z), so the
+      // general-direction code above would divide by zero. The packet's cylindrical radius stays
+      // constant while the grid expands: the receding outer r_cyl boundary can never be crossed, and
+      // the expanding inner boundary catches up to the packet at t_cross = rcyl / (rcyl_inner_tmin / tmin)
+      const double rcyl_inner_tmin = cellcoordmin[0];
+      if (rcyl_inner_tmin > 0.) {
+        const double d_coordminboundary_rcyl =
+            is_boundary_overshoot_within_tolerance<BoundaryType::LOWER>(pktposgridcoord[0], pktvelgridcoord[0],
+                                                                        cellcoordmin[0], tstart)
+                ? 0.
+                : ((pktposgridcoord[0] * globals::tmin / rcyl_inner_tmin) - tstart) * CLIGHT_PROP;
         if ((d_coordminboundary_rcyl >= 0.) && (d_coordminboundary_rcyl < distance)) {
           distance = d_coordminboundary_rcyl;
           next_cellindex = (cellcoordidx[0] == 0) ? -99 : cellindex - get_coordcellindexstride(0);

--- a/input.cc
+++ b/input.cc
@@ -125,6 +125,15 @@ constexpr auto inputlinecomments = std::array{
     "23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc",
 };
 
+// indices of the noncomment lines of input.txt that update_parameterfile() rewrites for a restart
+// (the static_asserts tie each index to its description in inputlinecomments)
+constexpr int inputline_timestep_range = 2;
+constexpr int inputline_continue_from_saved = 16;
+constexpr int inputline_nprocs_exspec = 21;
+static_assert(std::string_view{inputlinecomments[inputline_timestep_range]}.starts_with(" 2:"));
+static_assert(std::string_view{inputlinecomments[inputline_continue_from_saved]}.starts_with("16:"));
+static_assert(std::string_view{inputlinecomments[inputline_nprocs_exspec]}.starts_with("21:"));
+
 void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_inputtable, const int element,
                            const int lowerion, const int lowerlevel, const int upperion, int upperlevel_in,
                            std::vector<float>& tmpallphixs, std::vector<PhotoionTarget>& tmpallphixstargets,
@@ -378,12 +387,6 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
   printlnlog("[info] mem_usage: photoionisation tables occupy {:.3f} MB", mem_usage_phixs / 1024. / 1024.);
 }
 
-constexpr auto downtranslevelstart(const int level) {
-  // each level index is associated with a block of size levelindex spanning all possible down transitions.
-  // so use the formula for the sum of 1 + 2 + 3 + 4 + ... + level
-  return level * (level + 1) / 2;
-}
-
 void read_ion_levels(std::istream& adata, const int element, const int ion, const int nions, const int nlevels,
                      int nlevelsmax, const double energyoffset_ev, const double ionpot_ev,
                      std::vector<TempEnergyLevel>& temp_alllevels) {
@@ -502,8 +505,6 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
                                           std::span<TempEnergyLevel> temp_alllevels) {
   const auto nlevels = get_nlevels(element, ion);
   const auto ion_levels = std::span{temp_alllevels}.subspan(get_ionuniquelevelindexstart(element, ion), nlevels);
-  THREADLOCALONHOST std::vector<int> iondowntranstmplineindices;
-  iondowntranstmplineindices.resize(downtranslevelstart(nlevels));
 
   const int nlines_initial = globals::nlines;
   ptrdiff_t ion_updowntranscount = 0;
@@ -526,7 +527,11 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
       assert_always(alltransindex < std::numeric_limits<int>::max());
     }
 
-    std::ranges::fill(iondowntranstmplineindices, -99);
+    // iontransitiontable is sorted by (lower, upper), so any duplicate transitions between the same
+    // pair of levels are adjacent. Track the previous accepted transition to detect them.
+    int prev_lower = -1;
+    int prev_upper = -1;
+    int prev_lineindex = -1;
 
     ion_updowntranscount = 0;
     for (const auto& transition : iontransitiontable) {
@@ -542,11 +547,12 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
       }
 
       // Make sure that we don't allow duplicate. In that case take only the lines first occurrence
-      int& downtranslineindex = iondowntranstmplineindices[downtranslevelstart(level) + lowerlevel];
+      const bool is_duplicate = (lowerlevel == prev_lower && level == prev_upper);
 
-      // negative means that the transition hasn't been seen yet
-      if (downtranslineindex < 0) {
-        downtranslineindex = globals::nlines++;
+      if (!is_duplicate) {
+        prev_lower = lowerlevel;
+        prev_upper = level;
+        prev_lineindex = globals::nlines++;
 
         const int nupperdowntrans = ion_levels[level].ndowntrans + 1;
         ion_levels[level].ndowntrans = nupperdowntrans;
@@ -592,22 +598,23 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
         }
 
       } else if (pass == 1) {
-        // This is a new branch to deal with lines that have different types of transition. It should trip after a
-        // transition is already known.
+        // A second transition between the same pair of levels (e.g. from a different physical process):
+        // combine it into the existing line. The duplicate immediately follows the first occurrence
+        // (the table is sorted), so the transition entries filled most recently are the ones to update.
 
-        if ((temp_linelist[downtranslineindex].elementindex != element) ||
-            (temp_linelist[downtranslineindex].ionindex != ion) ||
-            (temp_linelist[downtranslineindex].upperlevelindex != level) ||
-            (temp_linelist[downtranslineindex].lowerlevelindex != lowerlevel)) {
+        if ((temp_linelist[prev_lineindex].elementindex != element) ||
+            (temp_linelist[prev_lineindex].ionindex != ion) ||
+            (temp_linelist[prev_lineindex].upperlevelindex != level) ||
+            (temp_linelist[prev_lineindex].lowerlevelindex != lowerlevel)) {
           printlnlog("[error] Failure to identify level pair for duplicate bb-transition ... going to abort now");
           printlnlog("   element {} ion {} targetlevel {} level {}", element, ion, lowerlevel, level);
-          printlnlog("   transitions[level].to[targetlevel]=lineindex {}", downtranslineindex);
+          printlnlog("   duplicate of lineindex {}", prev_lineindex);
           printlnlog("   A_ul {:g}, coll_str {:g}", transition.A, transition.coll_str);
           printlnlog(
               "   globals::linelist[lineindex].elementindex {}, globals::linelist[lineindex].ionindex {}, "
               "globals::linelist[lineindex].upperlevelindex {}, globals::linelist[lineindex].lowerlevelindex {}",
-              temp_linelist[downtranslineindex].elementindex, temp_linelist[downtranslineindex].ionindex,
-              temp_linelist[downtranslineindex].upperlevelindex, temp_linelist[downtranslineindex].lowerlevelindex);
+              temp_linelist[prev_lineindex].elementindex, temp_linelist[prev_lineindex].ionindex,
+              temp_linelist[prev_lineindex].upperlevelindex, temp_linelist[prev_lineindex].lowerlevelindex);
           std::abort();
         }
 
@@ -627,8 +634,7 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
         const auto lowerstartup = ion_levels[lowerlevel].alltrans_startup();
         auto& uptransition = temp_alltranslist[lowerstartup + ion_levels[lowerlevel].nuptrans - 1];
 
-        // as above, the downtrans list should be searched to find the correct index instead of using the last one.
-        // assert_always(uptransition.targetlevelindex == level);
+        assert_always(uptransition.targetlevelindex == level);
 
         uptransition.einstein_A += transition.A;
         uptransition.osc_strength += f_lu;
@@ -1896,10 +1902,10 @@ void update_parameterfile(const int nts) {
 
       // overwrite particular lines to enable restarting from the current timestep
       if (nts >= 0) {
-        if (noncomment_linenum == 2) {
+        if (noncomment_linenum == inputline_timestep_range) {
           // Number of start and end time step
           line = std::format("{:03d} {:03d}", nts, globals::timestep_finish);
-        } else if (noncomment_linenum == 16) {
+        } else if (noncomment_linenum == inputline_continue_from_saved) {
           // resume from gridsave file
           line = "1";  // Force continuation
         }
@@ -1908,7 +1914,7 @@ void update_parameterfile(const int nts) {
       // only rewrite this line when updating input.txt for a restart (sn3d), where nprocs is the
       // number of packet files being written. The nts == -1 backup path may be run by exspec
       // (nprocs == 1), which must not clobber the nprocs_exspec value it just read
-      if (nts >= 0 && noncomment_linenum == 21) {
+      if (nts >= 0 && noncomment_linenum == inputline_nprocs_exspec) {
         // by default, exspec should use all available packet files
         globals::nprocs_exspec = globals::nprocs;
         line = std::format("{}", globals::nprocs_exspec);

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -372,7 +372,8 @@ class MPI_shared_array {
     return std::span<const T>{_span}.first(count);
   }
   [[nodiscard]] auto size() const -> size_t { return _span.size(); }
-  [[nodiscard]] auto ssize() const -> ptrdiff_t { return _span.ssize(); }
+  // (std::span has no ssize() member, so compute the signed size from size())
+  [[nodiscard]] auto ssize() const -> ptrdiff_t { return static_cast<ptrdiff_t>(_span.size()); }
 
   // define operator[] to allow direct indexing into the span
   auto operator[](const size_t index) noexcept -> T& { return _span[index]; }

--- a/packet.cc
+++ b/packet.cc
@@ -4,6 +4,7 @@
 #include "packet.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -16,6 +17,7 @@
 #include <span>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -264,6 +266,11 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
     if (tries > 10) {
       printlnlog("[error] Failed to write {} after {} tries. Aborting.", filename, tries);
       std::abort();
+    }
+    if (tries > 0) {
+      // give transient filesystem problems (e.g. contention on a cluster parallel filesystem) a
+      // chance to clear instead of burning through all of the retries within milliseconds
+      std::this_thread::sleep_for(std::chrono::seconds(5));
     }
     printlog("timestep {}: writing {}...", timestep, filename);
     FILE* packets_file = fopen(filename.c_str(), "wb");

--- a/radfield.cc
+++ b/radfield.cc
@@ -88,6 +88,11 @@ std::vector<std::vector<Jb_lu_estimator>> Jb_lu_raw{};  // unnormalised estimato
 MPI_shared_array<float> prev_bfrate_normed{};  // values from the previous timestep
 std::vector<double> bfrate_raw;  // unnormalised estimators for the current timestep
 
+// for DETAILED_BF_ESTIMATORS_ON: maps an index into the allphixstargets arrays (the
+// element/ion/level/phixstargetindex ordering) to the same continuum's index in the nu_edge-sorted
+// globals::allcont arrays. Built in init() as the inverse of the sort permutation from setup_phixs_list().
+MPI_shared_array<int> allcontindex_of_allphixstargetindex{};
+
 // J and nuJ are accumulated and then normalised in-place
 // i.e. be sure the normalisation has been applied (exactly once) before using the values here!
 
@@ -147,6 +152,12 @@ constexpr auto select_bin(const double nu) -> int {
 
   return binindex;
 }
+
+static_assert(get_bin_nu_lower(1) == get_bin_nu_upper(0));  // bins are contiguous
+static_assert(select_bin(RADFIELDBINS_NU_MIN / 2) == -2);  // below the lowest bin
+static_assert(select_bin(RADFIELDBINS_NU_MIN) == 0);  // bins are left-closed
+static_assert(select_bin(RADFIELDBINS_NU_MAX) == RADFIELDBINCOUNT - 1);  // start of the T_e superbin
+static_assert(select_bin(RADFIELDBINS_T_E_SUPERBIN_NU_MAX) == -1);  // at and above the superbin upper bound
 
 // associate a Jb_lu estimator with a particular lineindex to be used instead of the general radiation field model
 void add_detailed_line(const int lineindex) {
@@ -277,35 +288,6 @@ auto partial_nu_planck_integral_x_to_inf(const double x, const double epsrel) ->
     }
   }
   return sum;
-}
-
-// Computes the integral of the Planck function (or nu times the Planck function) between frequency nu=nu_low to
-// nu=nu_high. Units are ergs/s/sr/cm2 for the integral of the Planck function, and ergs/s2/sr/cm2 for the integral of
-// nu times the Planck function.
-auto calculate_planck_integral(double temperature, double nu_low, double nu_high, const bool times_nu) -> double {
-  if (temperature <= 0) {
-    return 0.0;
-  }
-
-  constexpr double epsrel = 1e-15;  // relative error for convergence of the series expansion
-
-  // integration variable x = H * nu / (KB * T_R)
-  const double x_low = (H * nu_low) / (KB * temperature);
-  const double x_high = (H * nu_high) / (KB * temperature);
-
-  if (times_nu) {
-    const double constant_factor = (2.0 * pow5(KB) * pow5(temperature)) / (pow4(H) * pow2(CLIGHT));
-    const auto low_to_inf = partial_nu_planck_integral_x_to_inf(x_low, epsrel);
-    const auto high_to_inf = partial_nu_planck_integral_x_to_inf(x_high, epsrel);
-
-    return constant_factor * (low_to_inf - high_to_inf);
-  }
-
-  const double constant_factor = (2.0 * pow4(KB) * pow4(temperature)) / (pow3(H) * pow2(CLIGHT));
-  const auto low_to_inf = partial_planck_integral_x_to_inf(x_low, epsrel);
-  const auto high_to_inf = partial_planck_integral_x_to_inf(x_high, epsrel);
-
-  return constant_factor * (low_to_inf - high_to_inf);
 }
 
 // Calculate the intensity-weighted mean frequency without allowing the common Wien-tail exponential to underflow.
@@ -450,21 +432,11 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
 }
 
 auto get_allcontindex(const int element, const int lowerion, const int lower, const int phixstargetindex) -> int {
-  // simple linear search seems to be faster than the binary search
-  // possibly because lower frequency transitions near start of list are more likely to be called?
-  int bfcontindex = 0;
-  for (; bfcontindex < globals::nbfcontinua; bfcontindex++) {
-    if ((globals::allcont.element[bfcontindex] == element) && (globals::allcont.ion[bfcontindex] == lowerion) &&
-        (globals::allcont.level[bfcontindex] == lower) &&
-        (globals::allcont.phixstargetindex[bfcontindex] == phixstargetindex)) {
-      break;
-    }
-  }
-  if (bfcontindex < globals::nbfcontinua) {
-    return bfcontindex;
-  }
-  // not found in the continua list
-  return -1;
+  // direct lookup via the precomputed inverse of the nu_edge sort permutation (built in init())
+  assert_testmodeonly(!allcontindex_of_allphixstargetindex.empty());
+  const auto allphixstargetindex =
+      get_allphixstargetindex(get_uniquelevelindex(element, lowerion, lower), phixstargetindex);
+  return allcontindex_of_allphixstargetindex[allphixstargetindex];
 }
 
 void write_to_file(const int nonemptymgi, const int timestep) {
@@ -520,6 +492,36 @@ void write_to_file(const int nonemptymgi, const int timestep) {
 }
 
 }  // anonymous namespace
+
+// Computes the integral of the Planck function (or nu times the Planck function) between frequency nu=nu_low to
+// nu=nu_high. Units are ergs/s/sr/cm2 for the integral of the Planck function, and ergs/s2/sr/cm2 for the integral of
+// nu times the Planck function.
+auto calculate_planck_integral(const double temperature, const double nu_low, const double nu_high, const bool times_nu)
+    -> double {
+  if (temperature <= 0) {
+    return 0.0;
+  }
+
+  constexpr double epsrel = 1e-15;  // relative error for convergence of the series expansion
+
+  // integration variable x = H * nu / (KB * T_R)
+  const double x_low = (H * nu_low) / (KB * temperature);
+  const double x_high = (H * nu_high) / (KB * temperature);
+
+  if (times_nu) {
+    const double constant_factor = (2.0 * pow5(KB) * pow5(temperature)) / (pow4(H) * pow2(CLIGHT));
+    const auto low_to_inf = partial_nu_planck_integral_x_to_inf(x_low, epsrel);
+    const auto high_to_inf = partial_nu_planck_integral_x_to_inf(x_high, epsrel);
+
+    return constant_factor * (low_to_inf - high_to_inf);
+  }
+
+  const double constant_factor = (2.0 * pow4(KB) * pow4(temperature)) / (pow3(H) * pow2(CLIGHT));
+  const auto low_to_inf = partial_planck_integral_x_to_inf(x_low, epsrel);
+  const auto high_to_inf = partial_planck_integral_x_to_inf(x_high, epsrel);
+
+  return constant_factor * (low_to_inf - high_to_inf);
+}
 
 void init() {
   // this should be called only after the atomic data is in memory
@@ -609,6 +611,21 @@ void init() {
   }
 
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {
+    if (globals::nbfcontinua > 0) {
+      // build the O(1) lookup used by get_allcontindex(): for each continuum in the nu_edge-sorted
+      // allcont list, record its position under the allphixstargets (element/ion/level/target) ordering
+      auto temp_allcontindex = MPI_shared_array<int>(globals::nbfcontinua, -1);
+      if (globals::rank_in_node == 0) {
+        for (int allcontindex = 0; allcontindex < globals::nbfcontinua; allcontindex++) {
+          const auto allphixstargetindex = get_allphixstargetindex(globals::allcont.uniquelevelindex[allcontindex],
+                                                                   globals::allcont.phixstargetindex[allcontindex]);
+          temp_allcontindex[allphixstargetindex] = allcontindex;
+        }
+      }
+      MPI_Barrier_node();
+      allcontindex_of_allphixstargetindex = std::move(temp_allcontindex);
+    }
+
     const auto bfestimcount = std::ssize(globals::bfestim_nu_edge);
     prev_bfrate_normed = MPI_shared_array<float>(nonempty_npts_model * bfestimcount);
     if (globals::rank_in_node == 0) {

--- a/radfield.cc
+++ b/radfield.cc
@@ -16,6 +16,7 @@
 #include <iterator>
 #include <print>
 #include <span>
+#include <utility>
 #include <vector>
 
 #pragma clang unsafe_buffer_usage begin

--- a/radfield.cc
+++ b/radfield.cc
@@ -434,9 +434,14 @@ void set_params_fullspec(const int nonemptymgi, const int timestep) {
 
 auto get_allcontindex(const int element, const int lowerion, const int lower, const int phixstargetindex) -> int {
   // direct lookup via the precomputed inverse of the nu_edge sort permutation (built in init())
-  assert_testmodeonly(!allcontindex_of_allphixstargetindex.empty());
+  if (allcontindex_of_allphixstargetindex.empty()) {
+    // there are no continua (or init() has not been called), so nothing can be found
+    return -1;
+  }
   const auto allphixstargetindex =
       get_allphixstargetindex(get_uniquelevelindex(element, lowerion, lower), phixstargetindex);
+  assert_testmodeonly(allphixstargetindex >= 0);
+  assert_testmodeonly(allphixstargetindex < allcontindex_of_allphixstargetindex.ssize());
   return allcontindex_of_allphixstargetindex[allphixstargetindex];
 }
 

--- a/radfield.h
+++ b/radfield.h
@@ -39,6 +39,12 @@ void normalise_bf_estimators(int nts, int nts_prev, int titer, double deltat);
 [[nodiscard]] DEVICE_FUNC auto get_bfrate_estimator(int element, int lowerion, int lower, int phixstargetindex,
                                                     int nonemptymgi) -> double;
 
+// Computes the integral of the Planck function (or nu times the Planck function) between frequency nu=nu_low to
+// nu=nu_high. Units are ergs/s/sr/cm2 for the integral of the Planck function, and ergs/s2/sr/cm2 for the integral of
+// nu times the Planck function.
+[[nodiscard]] auto calculate_planck_integral(double temperature, double nu_low, double nu_high, bool times_nu)
+    -> double;
+
 // get Planck function spectral radiance B_nu [ergs/s/sr/cm2/Hz] for a black body for some temperature [K]
 [[gnu::const]] [[nodiscard]] constexpr auto planck(const double nu, const double temperature) -> double {
   return 2 * H * pow3(nu) / pow2(CLIGHT) / std::expm1(HOVERKB * nu / temperature);

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -194,6 +194,11 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Continuu
         prop_time += ldist / CLIGHT_PROP;
         nu_cmf = pkt.nu_cmf + (dnu_on_dl * dist);  // should equal nu_trans;
         assert_testmodeonly(nu_cmf <= pkt.nu_cmf);
+        if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
+          // keep e_cmf consistent with the linearly-approximated nu_cmf for the line estimator below
+          // (e_cmf / nu_cmf = e_rf / nu_rf is invariant along a free path)
+          e_cmf = nu_cmf * pkt.e_rf / pkt.nu_rf;
+        }
       }
 
       if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
@@ -290,6 +295,11 @@ auto get_possible_event_expansion_opacity(const int nonemptymgi, Packet& pkt, co
       prop_time += binedgedist / CLIGHT_PROP;
       nu_cmf = pkt.nu_cmf + (dnu_on_dl * dist);  // should equal nu_trans;
       assert_testmodeonly(nu_cmf <= pkt.nu_cmf);
+      if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
+        // keep e_cmf consistent with the linearly-approximated nu_cmf, since it seeds the packet copy
+        // used for the line-by-line retrace (whose line estimator updates divide e_cmf by nu_cmf)
+        e_cmf = nu_cmf * e_rf / nu_rf;
+      }
     }
 
     if (nu_cmf <= nu_cmf_abort) {

--- a/rpkt.h
+++ b/rpkt.h
@@ -5,6 +5,7 @@
 #define RPKT_H
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -37,6 +38,10 @@ constexpr auto get_expopac_bin_nu_lower(const ptrdiff_t binindex) -> double {
   const auto lambda_upper = expopac_lambdamin + (binindexplusone_f64 * expopac_deltalambda);
   return 1e8 * CLIGHT / lambda_upper;
 }
+
+static_assert(get_expopac_bin_nu_lower(0) == get_expopac_bin_nu_upper(1));  // bins are contiguous
+static_assert(get_expopac_bin_nu_lower(0) < get_expopac_bin_nu_upper(0));
+static_assert(get_expopac_bin_nu_upper(expopac_nbins - 1) > get_expopac_bin_nu_lower(expopac_nbins - 1));
 
 // kappa in cm^2/g for each bin of each non-empty cell
 inline MPI_shared_array<float> expansionopacities{};
@@ -133,6 +138,10 @@ auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
   return CLIGHT * prop_time * delta_nu / nu_trans;
 }
 
+static_assert(get_linedistance(100., 1., 2., -0.5) == 0.);  // overshot the line resonance
+static_assert(USE_RELATIVISTIC_DOPPLER_SHIFT || get_linedistance(2., 4., 2., -1.) == (CLIGHT * 2. * 2. / 2.));
+static_assert(!USE_RELATIVISTIC_DOPPLER_SHIFT || get_linedistance(2., 4., 2., -1.) == 2.);
+
 // find the next transition lineindex redder than nu_cmf
 // for the propagation through non empty cells
 // return -1 if no transition can be reached
@@ -169,6 +178,15 @@ auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
 
   return matchindex;
 }
+
+// the linelist is sorted by descending frequency
+inline constexpr std::array<double, 4> test_closest_transition_linelist_nu{9., 7., 5., 3.};
+static_assert(closest_transition(10., -1, test_closest_transition_linelist_nu) == 0);  // bluer than the whole list
+static_assert(closest_transition(8., -1, test_closest_transition_linelist_nu) == 1);  // binary search case
+static_assert(closest_transition(5., -1, test_closest_transition_linelist_nu) == 2);  // exact frequency match
+static_assert(closest_transition(2., -1, test_closest_transition_linelist_nu) == -1);  // redder than the whole list
+static_assert(closest_transition(8., 2, test_closest_transition_linelist_nu) == 2);  // known next transition
+static_assert(closest_transition(8., 4, test_closest_transition_linelist_nu) == -1);  // no more line interactions
 
 [[gnu::pure]] [[nodiscard]] inline auto keep_this_cont(int element, const int ion, const int level,
                                                        const int nonemptymgi, const float nnetot) -> bool {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -340,6 +340,25 @@ void write_deposition_file() {
 
     std::remove("deposition.out");
     std::rename("deposition.out.tmp", "deposition.out");
+
+    // energy-conservation consistency check (log only): the cumulative deposition should not exceed the
+    // cumulative decay emission by more than the Monte Carlo noise of the trajectory estimators allows
+    double cumulative_emission = 0.;
+    double cumulative_dep = 0.;
+    for (int i = 0; i <= nts; i++) {
+      cumulative_emission += globals::timesteps[i].gamma_emission + globals::timesteps[i].positron_emission +
+                             globals::timesteps[i].electron_emission + globals::timesteps[i].alpha_emission +
+                             globals::timesteps[i].spfission_dep_discrete;
+      cumulative_dep += globals::timesteps[i].gamma_dep + globals::timesteps[i].positron_dep +
+                        globals::timesteps[i].electron_dep + globals::timesteps[i].alpha_dep +
+                        globals::timesteps[i].spfission_dep_discrete;
+    }
+    if (cumulative_emission > 0. && cumulative_dep > (1.2 * cumulative_emission)) {
+      printlnlog(
+          "[warning] energy conservation check: cumulative deposition {:g} [erg] exceeds cumulative decay emission "
+          "{:g} [erg] by more than 20 percent, which is more than Monte Carlo noise should produce",
+          cumulative_dep, cumulative_emission);
+    }
   }
 
   const auto deposition_write_duration =
@@ -846,7 +865,13 @@ auto main(int argc, char* argv[]) -> int {
   int opt = 0;
   while ((opt = getopt(argc, argv, "w:")) != -1) {  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
     if (opt == 'w') {
-      const float walltimehours = strtof(optarg, nullptr);  // NOLINT(misc-include-cleaner)
+      char* parse_end = nullptr;
+      const float walltimehours = strtof(optarg, &parse_end);  // NOLINT(misc-include-cleaner)
+      if (parse_end == optarg || *parse_end != '\0' || !std::isfinite(walltimehours) || walltimehours <= 0.) {
+        // silently accepting a bad value would disable the wall time limit instead of applying it
+        std::println(stderr, "[error] invalid wall time hours '{}' given with -w option", optarg);
+        std::abort();
+      }
       walltimelimitseconds = static_cast<int>(walltimehours * HOUR);
       printlnlog("command line argument specifies wall time hours '{}', so setting walltimelimitseconds = {}", optarg,
                  walltimelimitseconds);

--- a/sn3d.h
+++ b/sn3d.h
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <csignal>
@@ -101,6 +102,12 @@ template <typename Range, typename Value>
   return static_cast<int>(index_lowerbound(cumulative_values, target));
 }
 
+static_assert(index_upperbound(std::array{1., 2., 2., 3.}, 2.) == 3);  // skips over repeated (zero-weight) entries
+static_assert(index_upperbound(std::array{1., 2., 2., 3.}, 0.5) == 0);
+static_assert(index_upperbound(std::array{1., 2., 2., 3.}, 3.) == 4);  // target >= all values gives the past-end index
+static_assert(index_lowerbound(std::array{1., 2., 2., 3.}, 2.) == 1);
+static_assert(index_lowerbound(std::array{1., 2., 2., 3.}, 4.) == 4);
+
 // Signed bin index of value on a grid spaced uniformly by binwidth, where bin 0 starts at minvalue.
 // Values below minvalue give negative indices and values past the last bin give indices >= nbins, so
 // the caller must range-check the result. Flooring matters here: a plain int cast would truncate toward
@@ -127,6 +134,13 @@ static_assert(get_linearbinindex(-5., 1., 2.) == -3);
 [[nodiscard]] inline auto get_logbinindex(const double value, const double minvalue, const double dlog,
                                           const ptrdiff_t nbins) -> ptrdiff_t {
   return std::clamp(static_cast<ptrdiff_t>(std::floor((std::log(value) - std::log(minvalue)) / dlog)), 0Z, nbins - 1);
+}
+
+// Edge value of a log-uniformly spaced grid whose bin 0 starts at minvalue with logarithmic spacing
+// dlog, i.e. bin i spans [get_loggrid_edge(minvalue, dlog, i), get_loggrid_edge(minvalue, dlog, i + 1)).
+// Inverse of get_logbinindex().
+[[nodiscard]] inline auto get_loggrid_edge(const double minvalue, const double dlog, const double index) -> double {
+  return std::exp(std::log(minvalue) + (index * dlog));
 }
 
 #endif  // SN3D_H

--- a/spectrum_lightcurve.cc
+++ b/spectrum_lightcurve.cc
@@ -175,7 +175,7 @@ auto columnindex_from_emissiontype(const int et) -> int {
   if (et == EMTYPE_FREEFREE) {
     // ff-emission
 
-    const int contindex = -1 - et;
+    const int contindex = get_bflistindex_from_emtype_continuum(et);
     assert_always(contindex >= globals::nbfcontinua);  // make sure the special value didn't collide with a real process
 
     return 2 * get_nelements() * get_max_nions();
@@ -184,7 +184,7 @@ auto columnindex_from_emissiontype(const int et) -> int {
     return -1;
   }
   // bf-emission
-  const int bfindex = -1 - et;
+  const int bfindex = get_bflistindex_from_emtype_continuum(et);
   if (globals::nbfcontinua == 0) {
     // no bf continua are in use, so a bf emission type should be impossible; count it in the free-free column
     return 2 * get_nelements() * get_max_nions();
@@ -499,9 +499,9 @@ void init_spectra(Spectra& spectra, const double nu_min, const double nu_max, co
       (spectra.fluxalltimesteps.empty() || (do_emission_absorption && spectra.absorptionalltimesteps.empty()));
 
   for (auto nnu = 0Z; nnu < MNUBINS; nnu++) {
-    spectra.lower_freq[nnu] = static_cast<float>(std::exp(log(nu_min) + (nnu * dlognu)));
+    spectra.lower_freq[nnu] = static_cast<float>(get_loggrid_edge(nu_min, dlognu, static_cast<double>(nnu)));
     spectra.delta_freq[nnu] =
-        static_cast<float>(std::exp(log(nu_min) + ((nnu + 1) * dlognu)) - spectra.lower_freq[nnu]);
+        static_cast<float>(get_loggrid_edge(nu_min, dlognu, static_cast<double>(nnu + 1)) - spectra.lower_freq[nnu]);
   }
 
   if (spectra.fluxalltimesteps.empty()) {

--- a/unittests.cc
+++ b/unittests.cc
@@ -1,0 +1,449 @@
+// Unit tests for the pure numeric helpers (geometry, special relativity, sampling, decay chains,
+// cross-sections, and binning). Build and run with:
+//   make unittests && ./unittests
+// The tests only cover functions with header-visible definitions or external linkage; they use no
+// input files and no MPI communication, and a non-zero exit code means at least one check failed.
+// (Compile-time checks of the constexpr helpers live in static_asserts next to their definitions.)
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <print>
+#include <string_view>
+#include <vector>
+
+#include "artisoptions.h"
+#include "atomic.h"
+#include "constants.h"
+#include "decay.h"
+#include "exspec.h"
+#include "gammapkt.h"
+#include "globals.h"
+#include "input.h"
+#include "macroatom.h"
+#include "mpi_logging.h"
+#include "radfield.h"
+#include "random.h"
+#include "rpkt.h"
+#include "sn3d.h"
+#include "vectors.h"
+
+namespace {
+
+int checks_total = 0;
+int checks_failed = 0;
+
+void check(const bool pass, const std::string_view description) {
+  checks_total++;
+  if (!pass) {
+    checks_failed++;
+    std::println("  FAIL: {}", description);
+  }
+}
+
+// check that a and b agree to within a relative tolerance
+void check_close(const double a, const double b, const double reltol, const std::string_view description) {
+  const bool pass = std::isfinite(a) && std::isfinite(b) &&
+                    ((a == b) || (std::abs(a - b) <= (reltol * std::max(std::abs(a), std::abs(b)))));
+  if (!pass) {
+    std::println("  values: {:.15g} vs {:.15g} (reltol {:g})", a, b, reltol);
+  }
+  check(pass, description);
+}
+
+void test_binindex_helpers() {
+  std::println("bin index and log-grid helpers...");
+  const double minvalue = 1e14;
+  const double dlog = 0.05;
+  const ptrdiff_t nbins = 100;
+  bool all_midpoints_match = true;
+  bool edges_are_contiguous = true;
+  for (ptrdiff_t i = 0; i < nbins; i++) {
+    const double edge_low = get_loggrid_edge(minvalue, dlog, static_cast<double>(i));
+    const double edge_high = get_loggrid_edge(minvalue, dlog, static_cast<double>(i + 1));
+    edges_are_contiguous = edges_are_contiguous && (edge_high > edge_low);
+    // the geometric midpoint of a log-spaced bin must map back to that bin
+    const double midvalue = std::sqrt(edge_low * edge_high);
+    all_midpoints_match = all_midpoints_match && (get_logbinindex(midvalue, minvalue, dlog, nbins) == i);
+  }
+  check(edges_are_contiguous, "get_loggrid_edge produces increasing bin edges");
+  check(all_midpoints_match, "get_logbinindex returns the bin containing its geometric midpoint");
+
+  check(get_logbinindex(minvalue / 10., minvalue, dlog, nbins) == 0, "get_logbinindex clamps below-range to bin 0");
+  check(get_logbinindex(minvalue * 1e10, minvalue, dlog, nbins) == nbins - 1,
+        "get_logbinindex clamps above-range to the last bin");
+}
+
+void test_range_chunks() {
+  std::println("get_range_chunk / get_chunk_count...");
+  rngstate_type rngstate{20260729};
+  bool all_partitions_valid = true;
+  for (int trial = 0; trial < 200; trial++) {
+    const auto size = static_cast<ptrdiff_t>(rng_uniform(rngstate) * 10000);
+    const auto nchunks = 1 + static_cast<ptrdiff_t>(rng_uniform(rngstate) * 32);
+    ptrdiff_t expected_next_start = 0;
+    ptrdiff_t maxchunksize = 0;
+    ptrdiff_t minchunksize = size + 1;
+    for (ptrdiff_t nchunk = 0; nchunk < nchunks; nchunk++) {
+      const auto [nstart, nsize] = get_range_chunk(size, nchunks, nchunk);
+      all_partitions_valid = all_partitions_valid && (nstart == expected_next_start) && (nsize >= 0);
+      expected_next_start = nstart + nsize;
+      maxchunksize = std::max(maxchunksize, nsize);
+      minchunksize = std::min(minchunksize, nsize);
+    }
+    all_partitions_valid =
+        all_partitions_valid && (expected_next_start == size) && ((maxchunksize - minchunksize) <= 1);
+  }
+  check(all_partitions_valid, "get_range_chunk contiguously partitions any range into nearly-equal chunks");
+
+  check(get_chunk_count(0, 5) == 0, "get_chunk_count of an empty range is zero");
+  check(get_chunk_count(10, 5) == 2, "get_chunk_count with exact division");
+  check(get_chunk_count(11, 5) == 3, "get_chunk_count rounds up");
+}
+
+void test_vector_geometry() {
+  std::println("vector geometry and special relativity...");
+  rngstate_type rngstate{81102};
+
+  bool cross_orthogonal = true;
+  bool lagrange_identity = true;
+  for (int trial = 0; trial < 100; trial++) {
+    const auto vec_a = get_rand_isotropic_unitvec(rngstate);
+    const auto vec_b = vec_scale(get_rand_isotropic_unitvec(rngstate), 2.5);
+    const auto crossprod = cross_prod(vec_a, vec_b);
+    cross_orthogonal =
+        cross_orthogonal && (std::abs(dot(crossprod, vec_a)) < 1e-12) && (std::abs(dot(crossprod, vec_b)) < 1e-12);
+    // |a x b|^2 + (a.b)^2 = |a|^2 |b|^2
+    const double lhs = dot(crossprod, crossprod) + pow2(dot(vec_a, vec_b));
+    const double rhs = dot(vec_a, vec_a) * dot(vec_b, vec_b);
+    lagrange_identity = lagrange_identity && (std::abs(lhs - rhs) <= (1e-12 * rhs));
+  }
+  check(cross_orthogonal, "cross product is orthogonal to both inputs");
+  check(lagrange_identity, "cross and dot products satisfy Lagrange's identity");
+
+  bool aberration_roundtrip = true;
+  for (int trial = 0; trial < 100; trial++) {
+    const auto dir_frame1 = get_rand_isotropic_unitvec(rngstate);
+    const auto vel = vec_scale(get_rand_isotropic_unitvec(rngstate), rng_uniform(rngstate) * 0.3 * CLIGHT);
+    const auto dir_frame2 = angle_ab(dir_frame1, vel);
+    const auto dir_frame1_roundtrip = angle_ab(dir_frame2, vec_scale(vel, -1.));
+    for (int d = 0; d < 3; d++) {
+      aberration_roundtrip = aberration_roundtrip && (std::abs(dir_frame1_roundtrip[d] - dir_frame1[d]) < 1e-12);
+    }
+  }
+  check(aberration_roundtrip, "angle_ab aberration with -v inverts aberration with +v");
+
+  // check the Doppler factor against a direct implementation
+  const auto pos_rf = Vec3d{1.1e14, -2.4e14, 0.8e14};
+  const auto dir_rf = vec_norm(Vec3d{0.3, -0.1, 0.9});
+  const double prop_time = 10. * DAY;
+  const auto vel_rf = get_velocity(pos_rf, prop_time);
+  double doppler_expected = 1. - (dot(dir_rf, vel_rf) / CLIGHT);
+  if (USE_RELATIVISTIC_DOPPLER_SHIFT) {
+    doppler_expected /= std::sqrt(1 - (dot(vel_rf, vel_rf) / CLIGHTSQUARED));
+  }
+  check_close(calculate_doppler_nucmf_on_nurf(pos_rf, dir_rf, prop_time), doppler_expected, 1e-14,
+              "calculate_doppler_nucmf_on_nurf matches the direct formula");
+
+  // moving a packet must preserve the frame-invariant ratio e_cmf / nu_cmf = e_rf / nu_rf
+  // (an outward-moving packet, so that the monotonic-nu_cmf clamp in move_pkt_withtime stays inactive)
+  auto pos = vec_scale(dir_rf, 2.0e14);
+  auto dir = dir_rf;
+  double t_current = 10. * DAY;
+  const double nu_rf = 3e15;
+  const double e_rf = 4e-12;
+  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pos, dir, t_current);
+  double nu_cmf = nu_rf * dopplerfactor;
+  double e_cmf = e_rf * dopplerfactor;
+  move_pkt_withtime(pos, dir, t_current, nu_rf, nu_cmf, e_rf, e_cmf, 3.0e13);
+  check_close(e_cmf / nu_cmf, e_rf / nu_rf, 1e-12, "move_pkt_withtime preserves e_cmf / nu_cmf = e_rf / nu_rf");
+}
+
+void test_escapedirectionbin() {
+  std::println("get_escapedirectionbin...");
+  rngstate_type rngstate{5501};
+  constexpr int ndirs = 200000;
+  std::array<int, MABINS> bincounts{};
+  bool all_in_range = true;
+  for (int n = 0; n < ndirs; n++) {
+    const auto dirbin = get_escapedirectionbin(get_rand_isotropic_unitvec(rngstate));
+    if (dirbin >= 0 && dirbin < MABINS) {
+      bincounts[dirbin]++;
+    } else {
+      all_in_range = false;
+    }
+  }
+  check(all_in_range, "escape direction bins are all within [0, MABINS)");
+
+  // every bin covers an equal solid angle, so isotropic directions should fill them equally
+  constexpr double expected_count = static_cast<double>(ndirs) / MABINS;
+  const double sixsigma = 6. * std::sqrt(expected_count * (1. - (1. / MABINS)));
+  const auto [mincount, maxcount] = std::ranges::minmax(bincounts);
+  check(std::abs(mincount - expected_count) < sixsigma && std::abs(maxcount - expected_count) < sixsigma,
+        "isotropic directions fill all equal-solid-angle bins to within 6 sigma");
+}
+
+void test_frame_transform() {
+  std::println("frame_transform...");
+  rngstate_type rngstate{99001};
+  bool roundtrip_ok = true;
+  bool polarisation_invariant = true;
+  for (int trial = 0; trial < 100; trial++) {
+    const auto n_rf = get_rand_isotropic_unitvec(rngstate);
+    const double pol_p = rng_uniform(rngstate) * 0.9;
+    const double pol_angle = rng_uniform(rngstate) * 2. * PI;
+    const double q0 = pol_p * std::cos(pol_angle);
+    const double u0 = pol_p * std::sin(pol_angle);
+    const auto vel = vec_scale(get_rand_isotropic_unitvec(rngstate), rng_uniform(rngstate) * 0.2 * CLIGHT);
+
+    const auto [n_cmf, q_cmf, u_cmf] = frame_transform(n_rf, q0, u0, vel);
+    polarisation_invariant = polarisation_invariant && (std::abs(std::sqrt(pow2(q_cmf) + pow2(u_cmf)) - pol_p) < 1e-10);
+
+    const auto [n_rf2, q2, u2] = frame_transform(n_cmf, q_cmf, u_cmf, vec_scale(vel, -1.));
+    for (int d = 0; d < 3; d++) {
+      roundtrip_ok = roundtrip_ok && (std::abs(n_rf2[d] - n_rf[d]) < 1e-10);
+    }
+    roundtrip_ok = roundtrip_ok && (std::abs(q2 - q0) < 1e-8) && (std::abs(u2 - u0) < 1e-8);
+  }
+  check(polarisation_invariant, "frame_transform preserves the polarisation degree");
+  check(roundtrip_ok, "frame_transform with -v inverts frame_transform with +v");
+}
+
+void test_random_sampling() {
+  std::println("random sampling...");
+  rngstate_type rngstate{31415};
+  constexpr int nsamples = 1000000;
+  double total = 0.;
+  bool all_in_range = true;
+  for (int n = 0; n < nsamples; n++) {
+    const auto zrand = rng_uniform(rngstate);
+    all_in_range = all_in_range && (zrand >= 0.) && (zrand < 1.);
+    total += zrand;
+  }
+  check(all_in_range, "rng_uniform values are within [0, 1)");
+  // standard error of the mean is 1/sqrt(12 N)
+  check(std::abs((total / nsamples) - 0.5) < (6. / std::sqrt(12. * nsamples)), "rng_uniform mean is 0.5");
+
+  double sum_mu = 0.;
+  double sum_musquared = 0.;
+  bool unit_vectors = true;
+  for (int n = 0; n < nsamples; n++) {
+    const auto dir = get_rand_isotropic_unitvec(rngstate);
+    unit_vectors = unit_vectors && (std::abs(vec_len(dir) - 1.) < 1e-6);
+    sum_mu += dir[2];
+    sum_musquared += pow2(dir[2]);
+  }
+  check(unit_vectors, "get_rand_isotropic_unitvec returns unit vectors");
+  check(std::abs(sum_mu / nsamples) < (6. / std::sqrt(3. * nsamples)), "isotropic <cos(theta)> is zero");
+  check(std::abs((sum_musquared / nsamples) - (1. / 3.)) < 1e-3, "isotropic <cos^2(theta)> is 1/3");
+}
+
+void test_planck() {
+  std::println("Planck function integrals...");
+  const double temperature = 6000.;
+  // the frequency range covers x = h nu / k T from ~1e-7 to past the series cutoff, i.e. effectively 0 to infinity
+  const double total = radfield::calculate_planck_integral(temperature, 1e8, 1e25, false);
+  // tolerance covers the (mixed-vintage) physical constants rather than the numerics
+  check_close(total, STEBO * pow4(temperature) / PI, 1e-3,
+              "full-range Planck integral matches the Stefan-Boltzmann law");
+
+  const double nu_split = 5.879e10 * temperature;  // Wien peak
+  const double part_a = radfield::calculate_planck_integral(temperature, 1e8, nu_split, false);
+  const double part_b = radfield::calculate_planck_integral(temperature, nu_split, 1e25, false);
+  check_close(part_a + part_b, total, 1e-12, "Planck integrals over adjacent ranges are additive");
+
+  const double nu_bar = radfield::calculate_planck_integral(temperature, 1e8, 1e25, true) / total;
+  // full-range intensity-weighted mean frequency: <nu> = (k T / h) * 4 zeta(5) / zeta(4) = 3.832229... k T / h,
+  // the same constant that radfield::set_params_fullspec() uses to convert nu_bar into T_R
+  constexpr double zeta4 = 1.08232323371114;
+  constexpr double zeta5 = 1.03692775514337;
+  check_close(nu_bar, KB * temperature / H * 4. * zeta5 / zeta4, 1e-6,
+              "intensity-weighted mean frequency of the full Planck spectrum");
+}
+
+void test_bateman() {
+  std::println("Bateman decay chain solutions...");
+  const double lambda_a = 1. / (8.80 * DAY);  // Ni56-like
+  const double lambda_b = 1. / (113.7 * DAY);  // Co56-like
+  const double time = 30. * DAY;
+  const double initabund = 2.5;
+
+  check_close(decay::calculate_decaychain(initabund, std::array{lambda_a}, time, false),
+              initabund * std::exp(-lambda_a * time), 1e-14, "single-nuclide chain reduces to exponential decay");
+
+  // daughter abundance of a two-step chain: N_b(t) = N_a(0) lambda_a / (lambda_b - lambda_a) (e^-l_a t - e^-l_b t)
+  const double nb_analytic =
+      initabund * lambda_a / (lambda_b - lambda_a) * (std::exp(-lambda_a * time) - std::exp(-lambda_b * time));
+  check_close(decay::calculate_decaychain(initabund, std::array{lambda_a, lambda_b}, time, false), nb_analytic, 1e-12,
+              "two-step chain matches the analytic Bateman solution");
+
+  // with a stable sink at the end of the chain, everything eventually accumulates there
+  check_close(decay::calculate_decaychain(initabund, std::array{lambda_a, 0.}, 1000. * 8.80 * DAY, false), initabund,
+              1e-12, "a stable daughter eventually accumulates the whole initial abundance");
+}
+
+void test_compton() {
+  std::println("Compton scattering cross sections...");
+
+  // reference: the standard Klein-Nishina total cross section, sigma = 2 pi r_e^2 * {...}, with 2 pi r_e^2 = 3/4
+  // sigma_T
+  const auto sigma_kleinnishina_total = [](const double x) -> double {
+    return 0.75 * SIGMA_T *
+           ((((1. + x) / pow3(x)) * (((2. * x * (1. + x)) / (1. + (2. * x))) - std::log(1. + (2. * x)))) +
+            (std::log(1. + (2. * x)) / (2. * x)) - ((1. + (3. * x)) / pow2(1. + (2. * x))));
+  };
+
+  bool total_matches = true;
+  for (const double x : {0.05, 0.2, 1., 5.}) {
+    const double sigma_partial_full = gammapkt::sigma_compton_partial(x, 1. + (2. * x));
+    total_matches = total_matches && (std::abs(sigma_partial_full - sigma_kleinnishina_total(x)) <=
+                                      (1e-10 * sigma_kleinnishina_total(x)));
+  }
+  check(total_matches, "sigma_compton_partial over the full energy-loss range matches the Klein-Nishina formula");
+
+  bool inversion_ok = true;
+  for (const double x : {0.05, 1., 5.}) {
+    for (const double zrand : {0.1, 0.5, 0.9}) {
+      const double f = gammapkt::choose_f(x, zrand);
+      const double fraction = gammapkt::sigma_compton_partial(x, f) / gammapkt::sigma_compton_partial(x, 1. + (2. * x));
+      inversion_ok = inversion_ok && (std::abs(fraction - zrand) < 2e-4);
+    }
+  }
+  check(inversion_ok, "choose_f inverts the partial Compton cross section to the solver tolerance");
+
+  check_close(gammapkt::meanf_sigma(THOMSON_LIMIT * (1. - 1e-6)), gammapkt::meanf_sigma(THOMSON_LIMIT * (1. + 1e-6)),
+              1e-5, "meanf_sigma is continuous across the Taylor-series/closed-form crossover");
+}
+
+void test_rad_deexcitation() {
+  std::println("radiative deexcitation rate coefficient...");
+  const double epsilon_trans = 2. * EV;
+  const float einstein_A = 1e7;
+  const double upperstatweight = 3.;
+  const double lowerstatweight = 1.;
+  const double t_current = 20. * DAY;
+
+  check(rad_deexcitation_ratecoeff(epsilon_trans, einstein_A, upperstatweight, lowerstatweight, 0., 0., t_current) ==
+            einstein_A,
+        "radiative deexcitation is the Einstein A coefficient in the optically thin limit");
+
+  // in the self-absorbed case the rate is reduced by the Sobolev escape probability beta = (1 - e^-tau) / tau
+  const double nnupper = 1e5;
+  const double nnlower = 1e8;
+  const double nu_trans = epsilon_trans / H;
+  const double b_ul = CLIGHTSQUAREDOVERTWOH / pow3(nu_trans) * einstein_A;
+  const double b_lu = upperstatweight / lowerstatweight * b_ul;
+  const double tau_sobolev = ((b_lu * nnlower) - (b_ul * nnupper)) * HCLIGHTOVERFOURPI * t_current;
+  check(tau_sobolev > 1., "the self-absorbed test point is optically thick");
+  check_close(rad_deexcitation_ratecoeff(epsilon_trans, einstein_A, upperstatweight, lowerstatweight, nnupper, nnlower,
+                                         t_current),
+              einstein_A * (-std::expm1(-tau_sobolev)) / tau_sobolev, 1e-12,
+              "radiative deexcitation applies the Sobolev escape probability");
+}
+
+void test_phixs_table_lookup() {
+  std::println("photoionisation cross-section table lookup...");
+  globals::NPHIXSPOINTS = 10;
+  globals::NPHIXSNUINCREMENT = 0.1;
+  last_phixs_nuovernuedge = 1.0 + (globals::NPHIXSNUINCREMENT * (globals::NPHIXSPOINTS - 1));
+
+  std::vector<float> photoion_xs(globals::NPHIXSPOINTS);
+  for (int i = 0; i < globals::NPHIXSPOINTS; i++) {
+    photoion_xs[i] = static_cast<float>((i + 1) * 1e-18);
+  }
+  const double nu_edge = 3e15;
+
+  check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * 0.99) == 0.,
+        "cross section is zero below the threshold");
+  check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge) == photoion_xs[0],
+        "cross section at the threshold is the first table point");
+
+  if constexpr (PHIXS_CLASSIC_NO_INTERPOLATION) {
+    check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * (1. + 0.25)) == photoion_xs[2],
+          "classic mode truncates to the nearest lower table point");
+    // regression test for the former out-of-bounds read: scan frequencies approaching the upper limit of
+    // the tabulated range from below (the last few representable values fall in the final table cell)
+    bool tail_reads_in_table = true;
+    const double nu_out_bound = nu_edge * (1 + (globals::NPHIXSNUINCREMENT * globals::NPHIXSPOINTS));
+    for (double nu = nu_out_bound * (1. - 1e-13); nu < nu_out_bound; nu = std::nextafter(nu, nu_out_bound)) {
+      const auto sigma = photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu);
+      tail_reads_in_table = tail_reads_in_table && (std::ranges::find(photoion_xs, sigma) != photoion_xs.end());
+    }
+    check(tail_reads_in_table, "classic mode reads within the table for every nu below the tabulated range's end");
+  } else {
+    check_close(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * (1. + 0.05)),
+                0.5 * (photoion_xs[0] + photoion_xs[1]), 1e-6, "cross section is interpolated between table points");
+  }
+
+  // past the tabulated range, the Kramers nu^-3 extrapolation continues from the last table point.
+  // classic mode anchors the extrapolation at nu_edge * (1 + increment * npoints) instead of the
+  // frequency of the last table point
+  const double nu_kramers_anchor = PHIXS_CLASSIC_NO_INTERPOLATION
+                                       ? nu_edge * (1. + (globals::NPHIXSNUINCREMENT * globals::NPHIXSPOINTS))
+                                       : nu_edge * last_phixs_nuovernuedge;
+  const double nu_above_table = 4. * nu_edge;
+  check_close(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_above_table),
+              photoion_xs[globals::NPHIXSPOINTS - 1] * pow3(nu_kramers_anchor / nu_above_table), 1e-6,
+              "cross section follows the Kramers extrapolation above the tabulated range");
+}
+
+void test_closest_transition_randomised() {
+  std::println("closest_transition against a reference implementation...");
+  rngstate_type rngstate{777};
+
+  // build a descending-frequency linelist
+  std::vector<double> linelist_nu(500);
+  for (auto& nu : linelist_nu) {
+    nu = 1e14 + (rng_uniform(rngstate) * 1e15);
+  }
+  std::ranges::sort(linelist_nu, std::ranges::greater{});
+
+  bool all_match = true;
+  for (int trial = 0; trial < 1000; trial++) {
+    const double nu_cmf = 0.5e14 + (rng_uniform(rngstate) * 1.2e15);
+    // reference: the first (bluest) line with nu_line <= nu_cmf, or -1 if none
+    int expected = -1;
+    for (int i = 0; i < std::ssize(linelist_nu); i++) {
+      if (linelist_nu[i] <= nu_cmf) {
+        expected = i;
+        break;
+      }
+    }
+    all_match = all_match && (closest_transition(nu_cmf, -1, linelist_nu) == expected);
+  }
+  check(all_match, "closest_transition matches a linear-scan reference for random frequencies");
+}
+
+void test_input_helpers() {
+  std::println("input parsing helpers...");
+  check(lineiscommentonly(""), "empty line is comment-only");
+  check(lineiscommentonly("   \t"), "whitespace line is comment-only");
+  check(lineiscommentonly("# a comment"), "hash line is comment-only");
+  check(lineiscommentonly("   # indented comment"), "indented hash line is comment-only");
+  check(!lineiscommentonly("1 2 3"), "data line is not comment-only");
+  check(!lineiscommentonly("1 2 3 # trailing comment"), "data line with trailing comment is not comment-only");
+}
+
+}  // anonymous namespace
+
+auto main() -> int {
+  test_binindex_helpers();
+  test_range_chunks();
+  test_vector_geometry();
+  test_escapedirectionbin();
+  test_frame_transform();
+  test_random_sampling();
+  test_planck();
+  test_bateman();
+  test_compton();
+  test_rad_deexcitation();
+  test_phixs_table_lookup();
+  test_closest_transition_randomised();
+  test_input_helpers();
+
+  std::println("unit tests: {} of {} checks passed", checks_total - checks_failed, checks_total);
+
+  return (checks_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/unittests.cc
+++ b/unittests.cc
@@ -368,9 +368,11 @@ void test_phixs_table_lookup() {
     // the tabulated range from below (the last few representable values fall in the final table cell)
     bool tail_reads_in_table = true;
     const double nu_out_bound = nu_edge * (1 + (globals::NPHIXSNUINCREMENT * globals::NPHIXSPOINTS));
-    for (double nu = nu_out_bound * (1. - 1e-13); nu < nu_out_bound; nu = std::nextafter(nu, nu_out_bound)) {
+    double nu = nu_out_bound * (1. - 1e-13);
+    while (nu < nu_out_bound) {
       const auto sigma = photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu);
       tail_reads_in_table = tail_reads_in_table && (std::ranges::find(photoion_xs, sigma) != photoion_xs.end());
+      nu = std::nextafter(nu, nu_out_bound);
     }
     check(tail_reads_in_table, "classic mode reads within the table for every nu below the tabulated range's end");
   } else {

--- a/unittests.cc
+++ b/unittests.cc
@@ -150,14 +150,13 @@ void test_vector_geometry() {
   // moving a packet must preserve the frame-invariant ratio e_cmf / nu_cmf = e_rf / nu_rf
   // (an outward-moving packet, so that the monotonic-nu_cmf clamp in move_pkt_withtime stays inactive)
   auto pos = vec_scale(dir_rf, 2.0e14);
-  auto dir = dir_rf;
   double t_current = 10. * DAY;
   const double nu_rf = 3e15;
   const double e_rf = 4e-12;
-  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pos, dir, t_current);
+  const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pos, dir_rf, t_current);
   double nu_cmf = nu_rf * dopplerfactor;
   double e_cmf = e_rf * dopplerfactor;
-  move_pkt_withtime(pos, dir, t_current, nu_rf, nu_cmf, e_rf, e_cmf, 3.0e13);
+  move_pkt_withtime(pos, dir_rf, t_current, nu_rf, nu_cmf, e_rf, e_cmf, 3.0e13);
   check_close(e_cmf / nu_cmf, e_rf / nu_rf, 1e-12, "move_pkt_withtime preserves e_cmf / nu_cmf = e_rf / nu_rf");
 }
 
@@ -291,8 +290,8 @@ void test_compton() {
   // sigma_T
   const auto sigma_kleinnishina_total = [](const double x) -> double {
     return 0.75 * SIGMA_T *
-           ((((1. + x) / pow3(x)) * (((2. * x * (1. + x)) / (1. + (2. * x))) - std::log(1. + (2. * x)))) +
-            (std::log(1. + (2. * x)) / (2. * x)) - ((1. + (3. * x)) / pow2(1. + (2. * x))));
+           ((((1. + x) / pow3(x)) * (((2. * x * (1. + x)) / (1. + (2. * x))) - std::log1p(2. * x))) +
+            (std::log1p(2. * x) / (2. * x)) - ((1. + (3. * x)) / pow2(1. + (2. * x))));
   };
 
   bool total_matches = true;
@@ -357,10 +356,11 @@ void test_phixs_table_lookup() {
 
   check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * 0.99) == 0.,
         "cross section is zero below the threshold");
-  check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge) == photoion_xs[0],
-        "cross section at the threshold is the first table point");
 
   if constexpr (PHIXS_CLASSIC_NO_INTERPOLATION) {
+    // classic mode compares nu == nu_edge directly, so the threshold value is exact in every build
+    check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge) == photoion_xs[0],
+          "classic mode cross section at the threshold is the first table point");
     check(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * (1. + 0.25)) == photoion_xs[2],
           "classic mode truncates to the nearest lower table point");
     // regression test for the former out-of-bounds read: scan frequencies approaching the upper limit of
@@ -373,6 +373,10 @@ void test_phixs_table_lookup() {
     }
     check(tail_reads_in_table, "classic mode reads within the table for every nu below the tabulated range's end");
   } else {
+    // probe just above the threshold rather than exactly at it: the fast-math production builds can
+    // round the interpolation index at exactly nu_edge to either side of zero
+    check_close(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * (1. + 1e-9)), photoion_xs[0],
+                1e-6, "cross section just above the threshold is the first table point");
     check_close(photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu_edge * (1. + 0.05)),
                 0.5 * (photoion_xs[0] + photoion_xs[1]), 1e-6, "cross section is interpolated between table points");
   }

--- a/unittests.cc
+++ b/unittests.cc
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
+#include <functional>
 #include <print>
 #include <string_view>
 #include <vector>

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -488,9 +488,8 @@ void init_vspecpol() {
   }
 
   for (int m = 0; m < VSPEC_NUBINS; m++) {
-    lower_freq_vspec[m] = static_cast<float>(std::exp(log(VSPEC_NUMIN) + (m * dlognu_vspec)));
-    delta_freq_vspec[m] =
-        static_cast<float>(std::exp(log(VSPEC_NUMIN) + ((m + 1) * dlognu_vspec)) - lower_freq_vspec[m]);
+    lower_freq_vspec[m] = static_cast<float>(get_loggrid_edge(VSPEC_NUMIN, dlognu_vspec, m));
+    delta_freq_vspec[m] = static_cast<float>(get_loggrid_edge(VSPEC_NUMIN, dlognu_vspec, m + 1) - lower_freq_vspec[m]);
   }
 
   // start by setting up the time and frequency bins.
@@ -498,9 +497,9 @@ void init_vspecpol() {
   // step sizes first.
   for (int n = 0; n < VSPEC_TIMEBINS; n++) {
     for (int ind_comb = 0; ind_comb < indexmax; ind_comb++) {
-      vspecpol[n][ind_comb].lower_time = static_cast<float>(std::exp(log(VSPEC_TIMEMIN) + (n * dlogt_vspec)));
+      vspecpol[n][ind_comb].lower_time = static_cast<float>(get_loggrid_edge(VSPEC_TIMEMIN, dlogt_vspec, n));
       vspecpol[n][ind_comb].delta_t =
-          static_cast<float>(std::exp(log(VSPEC_TIMEMIN) + ((n + 1) * dlogt_vspec)) - vspecpol[n][ind_comb].lower_time);
+          static_cast<float>(get_loggrid_edge(VSPEC_TIMEMIN, dlogt_vspec, n + 1) - vspecpol[n][ind_comb].lower_time);
 
       for (auto& flux : vspecpol[n][ind_comb].flux) {
         flux.I = 0.;


### PR DESCRIPTION
Implements the findings of a whole-codebase review. **No numerical results change — the stored CI checksums must not be regenerated.** Verified by baseline-vs-changed comparisons on the same machine with the CI build configuration (`REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2`): all output files are md5-identical for `kilonova_2d` (job0 + resume + exspec, 524 files including the angle-resolved spectra) and `classicmode_1d_3dgrid` (55 files). Only log-file content is new.

## Defect fixes (all invisible to the checksum tests)

- **atomic.h**: clamp the classic-mode (`PHIXS_CLASSIC_NO_INTERPOLATION`) table index. The range guard and the index are computed with different floating-point expressions, so for `nu` just under the bound the division could round to exactly `NPHIXSPOINTS` and read one element past the level's cross-section table. `std::min` is an identity in every non-pathological call.
- **grid.cc**: the 2D cylindrical `boundary_distance()` now handles a packet moving exactly along ±z (reachable when the sampled comoving direction is exactly `costheta = ±1` and the local velocity is parallel to z). Previously `dirxylen == 0` produced 0/0 = NaN radial distances that were silently skipped, which could miss an inner-boundary crossing once the overshoot exceeded the snap tolerance. The guard is `dirxylen > 0.`, so every ordinary direction takes the byte-for-byte unchanged path.
- **rpkt.cc**: with `USE_RELATIVISTIC_DOPPLER_SHIFT` + `DETAILED_LINE_ESTIMATORS_ON` (a combination no shipped preset enables), the linear-approximation branches updated `nu_cmf` but not `e_cmf`, so `update_lineestimator()` used a mismatched `e_cmf/nu_cmf` ratio. The sync is guarded by `if constexpr (DETAILED_LINE_ESTIMATORS_ON)` and compiles away in every CI configuration.
- **decay.cc**: two nuclides in one chain with exactly equal decay constants make the Bateman solution singular; this is now rejected at startup with the offending chain printed instead of failing an assertion deep inside packet setup.
- **sn3d.cc**: `-w <hours>` rejects unparseable or non-positive values (previously garbage silently *disabled* the wall-time limit).
- **input.cc**: duplicate bound-bound transitions are detected via sort adjacency instead of a per-ion `O(nlevels²)` index buffer (~200 MB transient for a 10k-level ion). The previously commented-out up-transition assert is reinstated (it holds because the table is sorted, making duplicates adjacent), and the stale comment claiming the code used the wrong index is replaced. The classic dataset contains 670 duplicate transitions across 27 ions, so this branch is genuinely exercised by the classic tests — `linestat.out` and all other outputs are unchanged.

## Efficiency and structure

- **radfield.cc**: `get_allcontindex()` linear scan over all bf continua replaced by a precomputed inverse of the `nu_edge` sort permutation (built in `radfield::init()` when `DETAILED_BF_ESTIMATORS_ON`).
- **packet.cc**: 5 s backoff between packet-file write retries so transient filesystem contention can clear.
- **atomic.h / spectrum_lightcurve.cc**: `get_bflistindex_from_emtype_continuum()` pairs the continuum emission-type encoding with its decode.
- **sn3d.h**: `get_loggrid_edge()` consolidates the three duplicated log-grid bin-edge computations (spectra, vspecpol frequency and time bins) with an identical expression tree.
- **input.cc**: the input.txt line numbers rewritten for restarts are named constants tied to `inputlinecomments` by static_asserts.

## Testing

- New **`unittests.cc`** (`make unittests`, run `./unittests`): 45–46 checks against analytic references — aberration/`frame_transform` round trips, Doppler factor, the `e_cmf/nu_cmf` invariant, equal-solid-angle escape bins, Bateman chains, Klein–Nishina total cross-section and `choose_f` inversion, `meanf_sigma` continuity at the Thomson crossover, Sobolev escape probability, Planck integrals vs the Stefan–Boltzmann law, cross-section table lookup in both modes (including a regression scan for the fixed out-of-bounds read), randomized `closest_transition` cross-check, MPI chunk partitioning, and input parsing. To make these callable, `calculate_decaychain` moved to decay.h, the Compton helpers to gammapkt.h, and `calculate_planck_integral` gained external linkage — bodies verbatim, and `REPRODUCIBLE=ON` builds use `-ffp-contract=off`, so relocation cannot change results (confirmed by the md5 comparisons).
- New **static_asserts** next to the constexpr helpers (`index_upperbound`/`index_lowerbound`, `closest_transition`, `get_linedistance` in both option branches, `select_bin`, and the radfield/expansion-opacity bin edges), using only integer/simple-double arithmetic so they compile under the C++23 nvc++/hipcc builds.
- **Log-only consistency checks**: exspec verifies per timestep that the frequency-integrated `spec.out` does not exceed `light_curve.out`; sn3d warns if cumulative deposition exceeds cumulative decay emission by more than Monte Carlo noise should allow. Neither writes to any checksummed file; both stayed silent in the verification runs.
- **CI**: the compile matrix (gcc 14/15/16, clang 22) now builds and runs the unit tests for the classic and nebular presets, and a new `openmp_smoke` job runs `kilonova_1d` with `OPENMP=ON` (2 ranks × 2 threads, no checksum comparison) to exercise the cell-cache mutex and atomic-accumulation paths that the single-threaded reproducible tests never enter.

## Notes for review

- Local verification used Apple Clang on macOS; the invariance argument transfers to the Linux CI builds because no changed expression tree differs and `-ffp-contract=off` is set in reproducible builds, but gcc/nvc++/hipcc get their first exercise in CI.
- The `openmp_smoke` job took 28 s locally at `-np 4`; the 40-minute runner limit has ample margin, but the first CI run will confirm.
- The unit tests deliberately stop at header-visible/external functions — `select_continuum_nu`, `sample_planck_montecarlo`, and the thermalisation `f_p` expressions remain anonymous-namespace and untested to keep the diff free of further code motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)