### PR TITLE
Fix review findings that do not change any tested results

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -170,10 +170,14 @@ void read_decaydata() {
     }
   }
 
-  if (decay::nuc_exists(26, 52)) {
+  // Historical mean gamma energies for the nuclides that decay straight to k-packets. Only apply
+  // these where no gamma-ray line table was found: a table sets the mean energy from its own lines,
+  // and overwriting it would leave choose_gamma_ray() normalising its cumulative distribution by a
+  // total that does not match the lines it is sampling from.
+  if (decay::nuc_exists(26, 52) && gamma_spectra[decay::get_nucindex(26, 52)].empty()) {
     decay::set_nucdecayenergygamma(decay::get_nucindex(26, 52), 0.86 * MEV);  // Fe52
   }
-  if (decay::nuc_exists(25, 52)) {
+  if (decay::nuc_exists(25, 52) && gamma_spectra[decay::get_nucindex(25, 52)].empty()) {
     decay::set_nucdecayenergygamma(decay::get_nucindex(25, 52), 3.415 * MEV);  // Mn52
   }
 
@@ -792,18 +796,20 @@ void wollaeger_thermalisation(Packet& pkt) {
   // need to create a packet copy which is moved during the integration
   Packet pkt_copy = pkt;
   pkt_copy.dir = vec_norm(pkt_copy.pos);  // integrate the optical depth radially outwards
-  const double t_current = pkt.prop_time;
   double tau = 0.;
   bool end_packet = false;
   while (!end_packet) {
     // distance to the next cell
     const auto [boundarydist, next_cellindex] =
         grid::boundary_distance(pkt_copy.dir, pkt_copy.pos, pkt_copy.prop_time, pkt_copy.cellindex);
-    const double s_cont = boundarydist * pow3(t_current / pkt_copy.prop_time);
     const int mgi = grid::get_propcell_modelgridindex(pkt_copy.cellindex);
     if (mgi >= 0) {
-      const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
-      tau += grid::get_rho(nonemptymgi) * s_cont * mean_gamma_opac;  // contribution to the integral
+      // the density is evaluated at the time that the ray reaches each cell, as in
+      // guttman_thermalisation(). Scaling grid::get_rho() by the packet's own decay time instead
+      // left every contribution wrong by a factor of (t_decay / t_mid)^3, since the grid state is
+      // held at the middle of the current timestep rather than at the time of the decay.
+      const double rho = grid::get_rho_tmin(mgi) * pow3(globals::tmin / pkt_copy.prop_time);
+      tau += mean_gamma_opac * rho * boundarydist;  // contribution to the integral
     }
     // move packet copy now
     move_pkt_withtime(pkt_copy, boundarydist);

--- a/grid.cc
+++ b/grid.cc
@@ -1978,13 +1978,15 @@ void read_ejecta_model() {
       const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
       assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
       const int n_z = (mgi / ncoord_model[0]);
-      const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
-      if (pos_z_mid != 0.) {
-        assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
-      } else {
-        // an odd number of z rows puts the middle row at exactly zero, where the relative
-        // comparison used for every other row cannot be evaluated
+      if (((2 * n_z) + 1) == ncoord_model[1]) {
+        // an odd number of z rows puts the middle row at the origin, where a relative comparison
+        // has nothing to divide by. Compare against the cell size instead. The row is identified
+        // from the integer index rather than by testing the coordinate against zero, because the
+        // expression below is not required to evaluate to exactly zero under -ffast-math.
         assert_always(fabs(cell_z_in) < (1e-3 * globals::vmax * t_model / ncoord_model[1]));
+      } else {
+        const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
+        assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
       }
     } else {
       // columns: cell number, x midpoint, y midpoint, z midpoint, density

--- a/grid.cc
+++ b/grid.cc
@@ -1979,7 +1979,13 @@ void read_ejecta_model() {
       assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
       const int n_z = (mgi / ncoord_model[0]);
       const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
-      assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
+      if (pos_z_mid != 0.) {
+        assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
+      } else {
+        // an odd number of z rows puts the middle row at exactly zero, where the relative
+        // comparison used for every other row cannot be evaluated
+        assert_always(fabs(cell_z_in) < (1e-3 * globals::vmax * t_model / ncoord_model[1]));
+      }
     } else {
       // columns: cell number, x midpoint, y midpoint, z midpoint, density
       std::array<float, 3> cellpos_in{};

--- a/input.cc
+++ b/input.cc
@@ -1743,9 +1743,15 @@ void read_parameterfile(std::span<Packet> packets) {
     // reproducible (they also accumulate to shared memory in a non-deterministic order)
     const auto rngseed = pre_zseed + static_cast<std::int64_t>(13 * globals::my_rank * get_max_threads());
 #ifdef GPU_ON
-    // give every packet its own independently-seeded generator
+    // Give every packet its own independently-seeded generator. The ranks are spaced by the number
+    // of packets that they own so that their seed ranges cannot overlap. get_max_threads() is one
+    // for a GPU build, so seeding from rngseed (spaced by only 13 per rank) would leave neighbouring
+    // ranks sharing all but 13 of their seeds, and two packets given the same seed follow identical
+    // histories because the grid state that they see is rank-invariant.
+    const auto rank_seed_base =
+        static_cast<std::uint32_t>(pre_zseed + (static_cast<std::int64_t>(globals::my_rank) * std::ssize(packets)));
     for (auto packetnumber = 0ZU; packetnumber < std::size(packets); packetnumber++) {
-      get_rngstate(packets[packetnumber]).seed(static_cast<std::uint32_t>(rngseed) + packetnumber);
+      get_rngstate(packets[packetnumber]).seed(rank_seed_base + static_cast<std::uint32_t>(packetnumber));
     }
 #else
     get_rngstate().seed(rngseed);

--- a/input.cc
+++ b/input.cc
@@ -1737,29 +1737,33 @@ void read_parameterfile(std::span<Packet> packets) {
   }
 
   if (!packets.empty()) {
-    // For MPI parallelisation, the random seed is changed based on the rank of the process.
-    // This runs on the main thread only; OpenMP/stdpar worker threads get their own randomly-seeded
-    // thread_local generators on first use (see get_rngstate()), so multi-threaded runs are not
-    // reproducible (they also accumulate to shared memory in a non-deterministic order)
-    const auto rngseed = pre_zseed + static_cast<std::int64_t>(13 * globals::my_rank * get_max_threads());
 #ifdef GPU_ON
     // Give every packet its own independently-seeded generator. The ranks are spaced by the number
-    // of packets that they own so that their seed ranges cannot overlap. get_max_threads() is one
-    // for a GPU build, so seeding from rngseed (spaced by only 13 per rank) would leave neighbouring
-    // ranks sharing all but 13 of their seeds, and two packets given the same seed follow identical
-    // histories because the grid state that they see is rank-invariant.
+    // of packets that they own, so that their seed ranges do not overlap. get_max_threads() is one
+    // for a GPU build, so spacing the ranks by 13 as the host generator below does would leave
+    // neighbouring ranks sharing all but 13 of their seeds, and two packets given the same seed
+    // follow identical histories because the grid state that they see is rank-invariant.
+    // Xoshiro128PP is seeded from a 32 bit value, so distinct seeds only exist for as many packets
+    // as fit in that space and the whole run has to stay within it.
+    assert_always((static_cast<std::int64_t>(globals::nprocs) * std::ssize(packets)) <= (1LL << 32));
     const auto rank_seed_base =
         static_cast<std::uint32_t>(pre_zseed + (static_cast<std::int64_t>(globals::my_rank) * std::ssize(packets)));
     for (auto packetnumber = 0ZU; packetnumber < std::size(packets); packetnumber++) {
       get_rngstate(packets[packetnumber]).seed(rank_seed_base + static_cast<std::uint32_t>(packetnumber));
     }
+    printlnlog("rank {}: packet rngseeds start at {}", globals::my_rank, rank_seed_base);
 #else
+    // For MPI parallelisation, the random seed is changed based on the rank of the process.
+    // This runs on the main thread only; OpenMP/stdpar worker threads get their own randomly-seeded
+    // thread_local generators on first use (see get_rngstate()), so multi-threaded runs are not
+    // reproducible (they also accumulate to shared memory in a non-deterministic order)
+    const auto rngseed = pre_zseed + static_cast<std::int64_t>(13 * globals::my_rank * get_max_threads());
     get_rngstate().seed(rngseed);
     for (int n = 0; n < 100; n++) {
       rng_uniform(get_rngstate());
     }
-#endif
     printlnlog("rank {}: main thread has rngseed {}", globals::my_rank, rngseed);
+#endif
   }
 
   assert_always(get_noncommentline(file, line));

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -219,7 +219,10 @@ auto calculate_partfunct(const int element, const int ion, const int nonemptymgi
   }
   U *= stat_weight(element, ion, 0);
   const auto U_float = static_cast<float>(U);
+  // an overflow to infinity passes a bare positivity test, and would then propagate silently
+  // through get_nnion() into the free electron density
   assert_always(U_float > 0.);
+  assert_always(std::isfinite(U_float));
 
   if (initial) {
     // put back the zero, just in case it matters for something

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -396,7 +396,13 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
     std::array<double, MA_ACTION_COUNT> cumulative_transitions{};
     std::partial_sum(levelrates.begin(), levelrates.end(), cumulative_transitions.begin());
 
-    const double randomrate = rng_uniform(get_rngstate(pkt)) * cumulative_transitions[MA_ACTION_COUNT - 1];
+    // With every rate zero the selection below would silently settle on the last action despite its
+    // rate being zero, and that only fails later somewhere much less obvious, such as in
+    // nt_random_upperion() for an ion that has no higher stage to ionise to.
+    const double total_rate = cumulative_transitions[MA_ACTION_COUNT - 1];
+    assert_always(total_rate > 0.);
+
+    const double randomrate = rng_uniform(get_rngstate(pkt)) * total_rate;
 
     // first cumulative_transitions[i] such that cumulative_transitions[i] > randomrate
     const auto selected_action =

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2301,7 +2301,10 @@ DEVICE_FUNC auto nt_random_upperion(const int nonemptymgi, const int element, co
 
     // the channel probabilities are stored as floats and the tabulated Auger yields are only
     // normalised to about one part in a thousand, so a draw very close to one can fall past the end
-    // of the cumulative sum. Use the highest reachable ion rather than failing the whole run.
+    // of the cumulative sum. Absorb that small deficit into the highest reachable ion rather than
+    // failing the whole run, but still reject a distribution that is badly wrong rather than
+    // silently returning the top ion for every draw.
+    assert_always(prob_sum > 0.99);
     return nt_ionisation_maxupperion(element, lowerion);
   }
   return lowerion + 1;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -933,7 +933,11 @@ constexpr auto xs_excitation(const int element, const int ion, const int lower, 
 // nne is the thermal electron density [cm^-3]
 // return value has units of erg/cm
 constexpr auto electron_loss_rate(const double energy, const double nne) -> double {
-  if (energy <= 0.) {
+  // with no thermal electrons there is no Coulomb energy loss. Without this guard the plasma
+  // frequency is zero and the Coulomb logarithm diverges, giving 0 * inf = NaN in a fully neutral
+  // cell (nne can reach exactly zero because the MINPOP floor is a float denormal that is flushed
+  // to zero by the default -ffast-math build)
+  if (energy <= 0. || nne <= 0.) {
     return 0;
   }
 
@@ -1826,8 +1830,12 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
 
   // force frac_sum to be 1.0 by adjusting frac_heating. Clamp to [0, 1] so a bad solution (where
   // excitation + ionisation exceed 1) cannot feed a negative heating fraction into the T_e solver.
+  // When non-thermal excitation is not being modelled, do_ntlepton_deposit() sends the excitation
+  // share to k-packets instead, so it has to be counted as heating here for the energy that the
+  // packets carry to match the heating rate that the T_e solver is given.
+  const double frac_excitation_nonheating = NT_EXCITATION_ON ? frac_excitation_total : 0.;
   nt_solution[nonemptymgi].frac_heating =
-      static_cast<float>(std::clamp(1. - frac_excitation_total - frac_ionisation_total, 0., 1.));
+      static_cast<float>(std::clamp(1. - frac_excitation_nonheating - frac_ionisation_total, 0., 1.));
 
   if (!ftol<0.02>(frac_sum, 1.0)) {
     printlnlog("[warning] frac_sum is {:g}, but should be 1.0", frac_sum);
@@ -2291,8 +2299,10 @@ DEVICE_FUNC auto nt_random_upperion(const int nonemptymgi, const int element, co
       }
     }
 
-    assert_always(false);  // should never get here
-    return -1;
+    // the channel probabilities are stored as floats and the tabulated Auger yields are only
+    // normalised to about one part in a thousand, so a draw very close to one can fall past the end
+    // of the cumulative sum. Use the highest reachable ion rather than failing the whole run.
+    return nt_ionisation_maxupperion(element, lowerion);
   }
   return lowerion + 1;
 }

--- a/packet.cc
+++ b/packet.cc
@@ -287,7 +287,13 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
         printlnlog("[warning] fwrite to {} failed on attempt {} of 10. will retry...", filename, tries + 1);
       }
 
-      fclose(packets_file);
+      // a buffered write can fail at the flush that fclose() performs, so without checking it here a
+      // truncated restart file would be reported as having been written successfully
+      const bool closed_ok = (fclose(packets_file) == 0);
+      if (write_success && !closed_ok) {
+        printlnlog("[warning] fclose of {} failed on attempt {} of 10. will retry...", filename, tries + 1);
+      }
+      write_success = write_success && closed_ok;
     }
     tries++;
   }

--- a/radfield.cc
+++ b/radfield.cc
@@ -1205,6 +1205,13 @@ void read_restart_data(FILE* gridsave_file) {
       for (int jblueindex = 0; jblueindex < detailed_linecount; jblueindex++) {
         assert_always(fscanf(gridsave_file, "%la %d\n", &Jb_lu_raw[nonemptymgi][jblueindex].value,
                              &Jb_lu_raw[nonemptymgi][jblueindex].contribcount) == 2);
+        // normalise_J() is skipped on the timestep that a run resumes from, so the normalised values
+        // that the macro atom reads have to be rebuilt here. Otherwise every detailed line estimator
+        // would be zero for the first timestep after each restart. J_normfactor holds exactly the
+        // factor that normalise_J() applies.
+        prev_Jb_lu_normed[nonemptymgi][jblueindex].value =
+            Jb_lu_raw[nonemptymgi][jblueindex].value * J_normfactor[nonemptymgi];
+        prev_Jb_lu_normed[nonemptymgi][jblueindex].contribcount = Jb_lu_raw[nonemptymgi][jblueindex].contribcount;
       }
     }
   }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -255,7 +255,11 @@ auto get_possible_event_expansion_opacity(const int nonemptymgi, Packet& pkt, co
       // interaction occurs
       if constexpr (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
         const auto edist = std::max(dist + ((tau_rnd - tau) / chi_tot), 0.);
-        const bool event_is_boundbound = rng_uniform(get_rngstate(pkt)) <= chi_bb_expansionopac / chi_tot;
+        // strict comparison, so that a draw of exactly zero cannot select the bound-bound channel
+        // when its opacity is zero (rng_uniform() rejects one but can return zero). Otherwise a
+        // wavelength bin with no line opacity could take the thermalisation branch, and in a cell
+        // with no line opacity at all the Planck sampling that follows has nothing to sample from.
+        const bool event_is_boundbound = rng_uniform(get_rngstate(pkt)) < chi_bb_expansionopac / chi_tot;
         return {edist, event_is_boundbound};
       }
 


### PR DESCRIPTION
Fixes from the whole-codebase review that are **unreachable in the configurations the checksum regression tests exercise**, so the stored checksums must not be regenerated.

Reachability was checked against the four presets the tests use (`classic`, `kilonova_lte`, `nltenebular`, `nltephotospheric_dynamic_ion_range`) **and** the `artisoptions.h` patches that the `tests/setup_*.sh` scripts apply on top of them — several options (`VPKT_ON`, `RPKT_USE_EXPANSION_OPACITIES`, `RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY`, `GAMMA_THERMALISATION_SCHEME=BARNES`, `USE_XCOM_GAMMAPHOTOION`) are enabled only by those scripts and not by any preset.

## Non-thermal (`nonthermal.cc`)

- With `NT_SOLVE_SPENCERFANO` and `NT_EXCITATION_ON=false`, the excitation share of the deposition was routed to k-packets by `do_ntlepton_deposit()` but excluded from the `frac_heating` given to the T_e solver, so the Monte Carlo and analytic accountings disagreed by `frac_excitation`. It is now counted as heating, matching what the packets do. Only the `nltewithoutnonthermal` and `christinenonthermal` presets combine those options, and neither is checksum-tested.
- `electron_loss_rate()` returned NaN for `nne == 0`: the plasma frequency is zero, so the Coulomb logarithm diverges and `nne * inf` is `0 * inf`. A fully neutral cell can reach exactly zero because the `MINPOP` floor is a float denormal that the default `-ffast-math` build flushes to zero. The NaN poisoned the Spencer-Fano matrix diagonal and aborted the run.
- `nt_random_upperion()` aborted when a draw very close to one fell past the end of the cumulative Auger-channel probabilities, which are stored as floats and normalised only to about one part in a thousand. It now returns the highest reachable ion.

## Random number seeding (`input.cc`)

GPU builds seeded packet `n` of rank `r` with `rngseed + n`, where the rank spacing is `13 * get_max_threads()` and `get_max_threads()` is one without OpenMP. Neighbouring ranks therefore shared all but 13 of their seeds. `Xoshiro128PP::seed()` is a pure function of its seed and the grid state is rank-invariant, so those packets followed bit-identical histories — the effective sample size collapsed to roughly one rank's worth. Ranks are now spaced by their packet count. **The CPU seeding is deliberately untouched**, since changing it would move every tested result.

## Restart (`radfield.cc`)

`read_restart_data()` restored `Jb_lu_raw` but never rebuilt `prev_Jb_lu_normed`, which `normalise_J()` produces — and that call is skipped on the timestep a run resumes from. Every detailed line estimator was therefore zero for the first timestep after each restart. `J_normfactor` holds exactly the factor `normalise_J()` applies, so the reconstruction is exact. Requires `DETAILED_LINE_ESTIMATORS_ON`, which no preset enables.

## Gamma transport (`gammapkt.cc`)

- The historical Fe-52 and Mn-52 mean gamma energies were applied unconditionally, including when a gamma-ray line table had been read for those nuclides — leaving `choose_gamma_ray()` normalising its cumulative distribution by a total that did not match the lines it samples. They now apply only when no table was found, which is the case for all bundled data.
- `wollaeger_thermalisation()` scaled the density to the packet's decay time rather than to the epoch the grid state is held at, so every optical-depth contribution was wrong by `(t_decay / t_mid)^3` (roughly ±7–15% for typical timestep widths). It now evaluates the density along the ray exactly as `guttman_thermalisation()` already does. Requires `GAMMA_THERMALISATION_SCHEME=WOLLAEGER`; the `kilonova_2d_barnesthermalisation` test uses `BARNES`.

## Model input (`grid.cc`)

A 2D cylindrical model with an **odd** number of z rows always aborted at model read: the middle row's expected z is exactly zero, so the relative comparison against it cannot be satisfied by any value in the file. That row is now checked against the cell size instead; every other row keeps the existing relative check unchanged.

## Diagnosable failures instead of silent or confusing ones

- `macroatom.cc`: an all-zero rate vector let the selection settle on the last action despite its rate being zero, which then failed somewhere unrelated (for a top-stage ion, inside `nt_random_upperion()`). It is now rejected up front.
- `ltepop.cc`: a partition function that overflows `float` to infinity passed the bare positivity check and propagated into `get_nnion()` and the free electron density.
- `packet.cc`: the restart packet writer ignored the return value of `fclose()`, so a write failing at the flush was reported as success, leaving a truncated file that the retry loop never retried.

## Testing

No numerical results should change. The intended evidence is that **every checksum test stays green without regenerating checksums** — if any regression model goes red, one of the reachability arguments above is wrong and should be re-examined rather than papered over with new checksums.

Not verified locally: this environment has no MPI, so CI is the first build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHWTMDEVohnrdx3qLQYUwc)_