### PR TITLE
Fix the energy that non-thermal particles deposit under adiabatic losses

### DIFF
--- a/update_packets.cc
+++ b/update_packets.cc
@@ -130,17 +130,20 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
     pkt.prop_time = t_new;
     if constexpr (PARTICLE_THERMALISATION_SCHEME == ParticleThermalisationScheme::TIMEDEPENDENT_WITH_ADIABATIC_LOSS) {
       if (absorbed) {
-        // Only the collisional part of the energy loss heats the gas, so the packet must not carry
-        // the adiabatic part into its deposition. Taking the collisional share of the energy pool
-        // makes the deposited energy agree with the trajectory estimator above in expectation: a
-        // packet is absorbed during this step with probability endot * dt / particle_en, while the
-        // estimator adds e_cmf * endot_collisional * dt / particle_en over the same step, so the
-        // two sums agree when the deposit is the collisional fraction of the pool as it stood at
-        // the start of the step. Depositing all of it instead overestimated the energy given to the
-        // gas by a factor that grows without bound as the adiabatic losses come to dominate.
+        // Only the collisional part of the energy loss heats the gas, so the packet gives up that
+        // share of its energy and the remainder goes to the expansion.
+        //
+        // The packet energy is deliberately not degraded adiabatically while the particle is still
+        // travelling. The absorption energy is drawn uniformly, so a packet survives to time t with
+        // probability E(t) / E_start, and the expected total of the trajectory estimator above is
+        // (endot_collisional / E_start) times the integral of e_cmf over time. The energy that the
+        // particles really surrender to the gas is endot_collisional * (t_end - t_start) each, so
+        // the two agree only while e_cmf is held constant. The adiabatic loss is already carried by
+        // that survival weighting, because it shortens the particle's life; degrading e_cmf as well
+        // counted it a second time and made the deposition low by a factor
+        // t_start * ln(t_end / t_start) / (t_end - t_start), which falls to 0.42 once the adiabatic
+        // losses dominate.
         pkt.e_cmf *= endot_collisional / endot;
-      } else {
-        pkt.e_cmf *= ts / t_new;  // account for adiabatic losses
       }
     }
     assert_testmodeonly(grid::get_cellindex_from_pos(pkt.pos, pkt.prop_time) == pkt.cellindex);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -119,7 +119,8 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
     // just reduce the particle energy up to the end of this timestep
     const auto t_new = std::min(t_absorb, ts_end);
 
-    if (t_absorb <= ts_end) {
+    const bool absorbed = (t_absorb <= ts_end);
+    if (absorbed) {
       pkt.type = deposit_type;
     } else {
       pkt.nu_cmf -= (endot * (ts_end - ts)) / H;
@@ -128,7 +129,19 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
     pkt.pos = vec_scale(pkt.pos, t_new / ts);
     pkt.prop_time = t_new;
     if constexpr (PARTICLE_THERMALISATION_SCHEME == ParticleThermalisationScheme::TIMEDEPENDENT_WITH_ADIABATIC_LOSS) {
-      pkt.e_cmf *= ts / t_new;  // account for adiabatic losses
+      if (absorbed) {
+        // Only the collisional part of the energy loss heats the gas, so the packet must not carry
+        // the adiabatic part into its deposition. Taking the collisional share of the energy pool
+        // makes the deposited energy agree with the trajectory estimator above in expectation: a
+        // packet is absorbed during this step with probability endot * dt / particle_en, while the
+        // estimator adds e_cmf * endot_collisional * dt / particle_en over the same step, so the
+        // two sums agree when the deposit is the collisional fraction of the pool as it stood at
+        // the start of the step. Depositing all of it instead overestimated the energy given to the
+        // gas by a factor that grows without bound as the adiabatic losses come to dominate.
+        pkt.e_cmf *= endot_collisional / endot;
+      } else {
+        pkt.e_cmf *= ts / t_new;  // account for adiabatic losses
+      }
     }
     assert_testmodeonly(grid::get_cellindex_from_pos(pkt.pos, pkt.prop_time) == pkt.cellindex);
   } else {


### PR DESCRIPTION
Fixes the deposition under `PARTICLE_THERMALISATION_SCHEME = TIMEDEPENDENT_WITH_ADIABATIC_LOSS`, where two separate errors left both the heating rate given to the T_e solver and the energy the packets inject into the radiation field wrong, in opposite directions.

## The two defects

**The whole packet energy was deposited.** The absorption time is drawn from the total loss rate, collisional plus adiabatic, but the entire packet energy was then handed to `do_ntlepton_deposit()` and turned into macro atoms or k-packets. Energy that the scheme's own trajectory estimator attributes to adiabatic expansion was therefore injected into the radiation field.

**The packet energy was also degraded adiabatically.** `pkt.e_cmf *= ts / t_new` double-counted the adiabatic loss. The absorption energy is drawn uniformly, so a packet survives to time `t` with probability `E(t) / E_start`, and the expected total of the trajectory estimator is

```
(endot_collisional / E_start) * ∫ e_cmf dt
```

while each particle really surrenders `endot_collisional * (t_end - t_start)` to the gas. Those agree only while `e_cmf` is held constant. The adiabatic loss is already carried by that survival weighting, because it shortens the particle's life. Degrading `e_cmf` as well counted it a second time, and the shortfall is exactly

```
t_start * ln(t_end / t_start) / (t_end - t_start)
```

This one also biased the trajectory estimator itself, and hence `dep_estimator_*` and the heating rate that the thermal balance applies — not only the packet energy.

## Fix

Hold `e_cmf` constant while the particle is travelling, and take the collisional share `endot_collisional / endot` at the absorption event. That makes the scheme structurally identical to plain `TIMEDEPENDENT`, which holds `e_cmf` constant for the same reason; the only differences that remain are the adiabatic term in `endot` and the collisional share taken at deposition.

## Verification

Reproducing the packet evolution and comparing against the analytic solution of `dE/dt = -endot_collisional - E/t`, whose collisional deposition per particle is `endot_collisional * (t_end - t_start)` with `t_end = sqrt(t_start^2 + 2 t_start E_start / endot_collisional)`. Ratios to that exact value, with `a` the adiabatic share of the loss rate:

| `a` | before, trajectory | before, deposited | after, trajectory | after, deposited |
|---|---|---|---|---|
| 0.09 | 0.96 | 1.00 | 1.00 | 1.00 |
| 0.25 | 0.88 | 1.01 | 1.00 | 1.00 |
| 0.50 | 0.75 | 1.06 | 1.00 | 1.00 |
| 0.77 | 0.57 | 1.23 | 0.99 | 1.00 |
| 0.91 | 0.42 | 1.61 | 0.99 | 0.99 |

The simulated "before" trajectory ratios reproduce the analytic shortfall `t_start ln(t_end/t_start)/(t_end - t_start)` to four decimal places, which identifies the mechanism rather than just fitting the discrepancy.

The second commit corrects the first: reviewing commit-by-commit, the first made the deposition agree with the trajectory estimator without checking that the estimator was itself unbiased, so the two agreed on the wrong value.

## Testing

No shipped preset selects this scheme and the only test that overrides `PARTICLE_THERMALISATION_SCHEME` sets `BARNES`, so no tested result changes and the checksums must not be regenerated.

That also means **CI cannot validate the physics here** — a green run only shows the change is inert for the tested configurations. The evidence for correctness is the analytic comparison above.

Not verified locally: this environment has no MPI, so CI is the first build.