### PR TITLE
Fix incorrect comments and remove redundant ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ mpirun -np 1 ./exspec
 ```
 exspec reads the same input.txt, model, and atomic data files as sn3d, so it must be run in the same folder. The nprocs_exspec line of input.txt sets how many ranks' packets files it reads.
 
-It writes light_curve.out, spec.out, emission.out, emissiontrue.out, and absorption.out (plus gamma-ray and polarisation versions, depending on the compile-time options), direction-resolved versions of these in the speclc_angle_res folder, and a log file exspec.txt.
+It writes light_curve.out, spec.out, emission.out, emissiontrue.out, and absorption.out, plus gamma_light_curve.out and gamma_spec.out when KEEP_ESCAPED_GAMMAS is set, and specpol.out, emissionpol.out and absorptionpol.out when POL_ON is set. Direction-resolved versions of these go in the speclc_angle_res folder, alongside a log file exspec.txt.
 
 To plot and analyse the output, use [artistools](https://github.com/artis-mcrt/artistools), a companion Python package for working with ARTIS light curves, spectra, and estimators.
 
@@ -195,6 +195,8 @@ Transition count rows of:<br/>
 `[lower level index] [upper level index] [A value] [collision strength] [forbidden flag]`
 
 In case the collision strength is not available, it will be -1.0 for permitted and -2.0 for forbidden transitions.
+
+A legacy four-column format (`[transition index] [lower level index] [upper level index] [A value]`, with no collision strength or forbidden columns) is also accepted. The format is detected from the column count of the first row of each block.
 
 ### compositiondata.txt
 Sets a filter on the elements, ion stages, and energy levels that are read in from atomic data files.

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -147,14 +147,9 @@ constexpr bool NT_ON;
 // use the detailed Spencer-Fano solver instead of the work function approximation (only works if NT_ON)
 constexpr bool NT_SOLVE_SPENCERFANO;
 
-// number of energy points in the Spencer-Fano solution vector
-constexpr int SFPTS;
-
-// eV
-constexpr double SF_EMAX;
-
-// eV
-constexpr double SF_EMIN;
+// NB: the energy grid of the Spencer-Fano solution vector is not an artisoptions.h option. SFPTS (the number of
+// energy points) and SF_EMIN / SF_EMAX (the grid limits in eV) are set at the top of nonthermal.cc and apply to
+// every preset.
 
 // trigger a Spencer-Fano solution at least once every n timesteps
 // 0 can only re-use solutions from previous NLTE iterations of the current timestep

--- a/atomic.h
+++ b/atomic.h
@@ -130,12 +130,12 @@ DEVICE_FUNC inline void testmodeassert_valid_level([[maybe_unused]] const int el
   return globals::elements[element].ions[ion].nlevels_ionising;
 }
 
-// Returns the number of target states for photoionisation of (element,ion,level).
+// Returns the number of target states for photoionisation of a level, by unique level index or by
+// (element, ion, level).
 DEVICE_FUNC inline auto get_nphixstargets(const int uniquelevelindex) -> int {
   return globals::alllevels.nphixstargets[uniquelevelindex];
 }
 
-// Returns the number of target states for photoionisation of (element,ion,level).
 DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, const int level) -> int {
   testmodeassert_valid_ion(element, ion);
   const auto nphixstargets = get_nphixstargets(get_uniquelevelindex(element, ion, level));
@@ -152,26 +152,26 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
 
   return globals::alllevels.phixstargetstart[uniquelevelindex] + phixstargetindex;
 }
-// Return the level index of a target state for photoionisation of (element,ion,level).
+// Return the upper-ion level index of a photoionisation target state, by unique level index or by
+// (element, ion, level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_phixsupperlevel(const int uniquelevelindex,
                                                                         const int phixstargetindex) -> int {
   return globals::allphixstargets_levelindex[get_allphixstargetindex(uniquelevelindex, phixstargetindex)];
 }
 
-// Return the level index of a target state for photoionisation of (element,ion,level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_phixsupperlevel(const int element, const int ion,
                                                                         const int level, const int phixstargetindex)
     -> int {
   return get_phixsupperlevel(get_uniquelevelindex(element, ion, level), phixstargetindex);
 }
 
-// Return the probability of a target state for photoionisation of (element,ion,level).
+// Return the branching probability of a photoionisation target state (the targets of a level sum to one),
+// by unique level index or by (element, ion, level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_phixsprobability(const int uniquelevelindex,
                                                                          const int phixstargetindex) -> double {
   return globals::allphixstargets_probability[get_allphixstargetindex(uniquelevelindex, phixstargetindex)];
 }
 
-// Return the probability of a target state for photoionisation of (element,ion,level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto get_phixsprobability(const int element, const int ion,
                                                                          const int level, const int phixstargetindex)
     -> double {
@@ -219,9 +219,9 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
                              globals::NPHIXSPOINTS - 1);
       sigma_bf = photoion_xs[i];
     } else {
-      // use a parameterization of sigma_bf by the Kramers formula
-      // which anchor point should we take ??? the cross-section at the edge or at the highest grid point ???
-      // so far the highest grid point, otherwise the cross-section is not continuous
+      // above the top of the table, extrapolate with the Kramers (1923) nu^-3 scaling. It is anchored to the
+      // highest tabulated point rather than to the threshold value so that the cross-section stays continuous
+      // across the end of the table.
       sigma_bf = static_cast<float>(photoion_xs[globals::NPHIXSPOINTS - 1] *
                                     pow(nu_edge * (1 + (globals::NPHIXSNUINCREMENT * globals::NPHIXSPOINTS)) / nu, 3));
     }
@@ -241,9 +241,9 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
     const double factor_b = ireal - i;
     sigma_bf = static_cast<float>(((1. - factor_b) * sigma_bf_a) + (factor_b * sigma_bf_b));
   } else {
-    // use a parameterization of sigma_bf by the Kramers formula
-    // which anchor point should we take ??? the cross-section at the edge or at the highest grid point ???
-    // so far the highest grid point, otherwise the cross-section is not continuous
+    // above the top of the table, extrapolate with the Kramers (1923) nu^-3 scaling. It is anchored to the
+    // highest tabulated point rather than to the threshold value so that the cross-section stays continuous
+    // across the end of the table.
     const double nu_max_phixs = nu_edge * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
     sigma_bf = static_cast<float>(photoion_xs[globals::NPHIXSPOINTS - 1] * pow3(nu_max_phixs / nu));
   }
@@ -271,12 +271,11 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
   assert_always(false);  // uniquelevelindex too high to be valid
   return {-1, -1, -1};
 }
-// Return the statistical weight of (element,ion,level).
+// Return the statistical weight of a level, by unique level index or by (element, ion, level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto stat_weight(const int uniquelevelindex) -> double {
   return globals::alllevels.statweight[uniquelevelindex];
 }
 
-// Return the statistical weight of (element,ion,level).
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC inline auto stat_weight(const int element, const int ion, const int level)
     -> double {
   testmodeassert_valid_level(element, ion, level);
@@ -451,12 +450,11 @@ inline void update_includedionslevels_maxnions() {
   return (get_nlevels(element, ion) > (get_nlevels_excited_nlte(element, ion) + get_nlevels_autoion(element, ion) + 1));
 }
 
-// the number of downward bound-bound transitions from the specified level
+// the number of downward bound-bound transitions from a level, by unique level index or by (element, ion, level)
 [[gnu::pure]] [[nodiscard]] inline auto get_ndowntrans(const int uniquelevelindex) -> int {
   return globals::alllevels.ndowntrans[uniquelevelindex];
 }
 
-// the number of downward bound-bound transitions from the specified level
 [[gnu::pure]] [[nodiscard]] inline auto get_ndowntrans(const int element, const int ion, const int level) -> int {
   testmodeassert_valid_level(element, ion, level);
   return get_ndowntrans(get_uniquelevelindex(element, ion, level));
@@ -477,12 +475,11 @@ inline void update_includedionslevels_maxnions() {
   return get_alltrans_startup(uniquelevelindex);
 }
 
-// the number of upward bound-bound transitions from the specified level
+// the number of upward bound-bound transitions from a level, by unique level index or by (element, ion, level)
 [[gnu::pure]] [[nodiscard]] inline auto get_nuptrans(const int uniquelevelindex) -> int {
   return globals::alllevels.nuptrans[uniquelevelindex];
 }
 
-// the number of upward bound-bound transitions from the specified level
 [[gnu::pure]] [[nodiscard]] inline auto get_nuptrans(const int element, const int ion, const int level) -> int {
   testmodeassert_valid_level(element, ion, level);
   return get_nuptrans(get_uniquelevelindex(element, ion, level));

--- a/decay.cc
+++ b/decay.cc
@@ -570,7 +570,6 @@ auto get_endecay_to_tinf_per_ejectamass_at_time(const int modelgridindex, const 
 
   const double abund_endsink = calculate_decaychain(top_initabund, lambdas, t_afterinit, false);
   const double ndecays_remaining = decaypath.branchproduct * (top_initabund - abund_endsink);
-  // TODO ensure non-negative due to numerical precision?
 
   const double endecay = ndecays_remaining * get_decaypath_lastdecayenergy(decaypath);
 
@@ -1152,7 +1151,6 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   // Read in data for gamma ray lines and make a list of them in energy order.
   gammapkt::init_gamma_data();
 
-  // TODO: generalise this to all included nuclides
   printlnlog("decayenergy(NI56) {:g} [MeV], decayenergy(CO56) {:g} [MeV], decayenergy_gamma(CO56) {:g} [MeV]",
              nucdecayenergytotal(28, 56) / MEV, nucdecayenergytotal(27, 56) / MEV, nucdecayenergygamma(27, 56) / MEV);
   printlnlog("decayenergy(NI57) {:g} [MeV], decayenergy_gamma(NI57) {:g} [MeV], decayenergy(CO57) {:g} [MeV]",

--- a/decay.cc
+++ b/decay.cc
@@ -895,11 +895,13 @@ void read_alpha_decaydata() {
         // The electron and gamma energies are only taken for a nuclide that this file introduces.
         // betaminusdecays.txt is read first and stays authoritative for a nuclide listed in both
         // (its E_elec agrees with the E_beta column here for every such nuclide anyway).
-        nuclides.push_back({.z = z,
-                            .a = a,
-                            .meanlife = tau_sec,
-                            .endecay_electron = e_beta_mev * MEV,
-                            .endecay_gamma = e_gamma_mev * MEV});
+        nuclides.push_back({
+            .z = z,
+            .a = a,
+            .meanlife = tau_sec,
+            .endecay_electron = e_beta_mev * MEV,
+            .endecay_gamma = e_gamma_mev * MEV,
+        });
         alphanucindex = static_cast<int>(nuclides.size() - 1);
       }
       nuclides[alphanucindex].branchprobs[DECAYTYPE_BETAMINUS] = branch_beta;

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -38,7 +38,6 @@
 #include "vectors.h"
 
 namespace gammapkt {
-// Code for handing gamma rays - creation and propagation
 
 namespace {
 struct GammaLine {
@@ -262,13 +261,12 @@ void init_xcom_photoion_data() {
     return 0.;
   }
 
+  // photon energy in units of the electron rest mass, the parameter that sets how far the Klein-Nishina cross
+  // section departs from the low-energy Thomson limit
   const double xx = H * nu_cmf / ME / CLIGHT / CLIGHT;
-
-  // Use this to decide whether the Thompson limit is acceptable.
 
   const double sigma_cmf = (xx < THOMSON_LIMIT) ? SIGMA_T : sigma_compton_partial(xx, 1 + (2 * xx));
 
-  // Now need to multiply by the electron number density.
   const double chi_cmf = sigma_cmf * grid::get_nnetot(nonemptymgi);
 
   assert_testmodeonly(std::isfinite(chi_cmf));

--- a/gammapkt.h
+++ b/gammapkt.h
@@ -17,9 +17,10 @@ DEVICE_FUNC void pellet_gamma_decay(Packet& pkt);
 DEVICE_FUNC void do_gamma(Packet& pkt, int nts, double t2);
 auto choose_gamma_ray(int nucindex, rngstate_type& rngstate) -> double;
 
-// The partial cross section for Compton scattering.
-// - xx: is the photon energy (in units of electron mass)
-// - f_max: is the energy loss factor up to which we wish to integrate
+// The Klein-Nishina (1929) Compton cross section, integrated over the energy loss factor from 1 up to f_max.
+// Passing f_max = 1 + 2x (the maximum possible loss, i.e. backscattering) gives the total cross section.
+// - x: the photon energy in units of the electron rest mass
+// - f_max: the energy loss factor (nu_before / nu_after) up to which we integrate
 [[nodiscard]] constexpr auto sigma_compton_partial(const double x, const double f_max) -> double {
   const double term1 = ((x * x) - (2 * x) - 2) * std::log(f_max) / x / x;
   const double term2 = (((f_max * f_max) - 1) / (f_max * f_max)) / 2;
@@ -28,7 +29,8 @@ auto choose_gamma_ray(int nucindex, rngstate_type& rngstate) -> double;
   return (3 * SIGMA_T * (term1 + term2 + term3) / (8 * x));
 }
 
-// To choose the value of f to integrate to - idea is we want sigma_compton_partial(xx,f) = zrand.
+// Sample an energy loss factor f from the Klein-Nishina distribution, by bisecting for the f at which the
+// partial cross section reaches the fraction zrand of the total.
 [[nodiscard]] inline auto choose_f(const double xx, const double zrand) -> double {
   double f_max = 1 + (2 * xx);
   double f_min = 1;

--- a/globals.h
+++ b/globals.h
@@ -60,7 +60,7 @@ struct Element {
   int anumber{-1};  // Atomic number
   int lowest_ionstage{-1};  // ionisation stage (charge + 1) of ion 0 for this element
   int uniqueionindexstart{-1};  // uniqueionindex of the lowest ionisation stage of this element
-  float initstablemeannucmass = {0.};  // Atomic mass number in multiple of MH
+  float initstablemeannucmass = {0.};  // mean nuclear mass [g] of the element's stable component (mass_amu * MH)
   bool has_nlte_levels{false};
 };
 
@@ -221,8 +221,8 @@ inline MPI_shared_array<Ion> allions;
 
 struct TransitionLines {
   MPI_shared_array<const double> nu;  // Frequency of the line transition
-  MPI_shared_array<const int> elementindex;  // It's a transition of element (not its atomic number,
-                                             // but the (x-1)th element included in the simulation.
+  MPI_shared_array<const int> elementindex;  // index into the list of elements included in the simulation
+                                             // (not the atomic number)
   MPI_shared_array<const int> ionindex;  // The same for the elements ion
   MPI_shared_array<const int> uniquelevelindex_lower;  // globally unique index of the lower level of the transition
   MPI_shared_array<const int> uniquelevelindex_upper;  // globally unique index of the upper level of the transition

--- a/grid.cc
+++ b/grid.cc
@@ -661,7 +661,7 @@ void read_elem_abundances() {
     assert_always(cellnumberinput == mgi + first_cellindex);
 
     // the abundances.txt file specifies the elemental mass fractions for each model cell
-    // (or proportial to mass frac, e.g. element densities because they will be normalised anyway)
+    // (or proportional to mass frac, e.g. element densities, because they will be normalised anyway)
     // The abundances begin with hydrogen, helium, etc, going as far up the atomic numbers as required
     double normfactor = 0.;
     std::array<float, 150> elem_massfracs_in{};
@@ -1204,7 +1204,7 @@ void setup_grid_cartesian_3d() {
     ncoordgrid = {CUBOID_NCOORDGRID_X, CUBOID_NCOORDGRID_Y, CUBOID_NCOORDGRID_Z};
   }
 
-  // artis assumes in some places that the cells are cubes, not cubioids
+  // artis assumes in some places that the cells are cubes, not cuboids
   assert_always(ncoordgrid[0] == ncoordgrid[1]);
   assert_always(ncoordgrid[0] == ncoordgrid[2]);
 
@@ -1502,7 +1502,7 @@ template <BoundaryType boundarytype>
 
 }  // anonymous namespace
 
-// for a uniform grid get the the extent along the x,y,z coordinate (x_2 - x_1, etc.) at time tmin
+// for a uniform grid get the extent along the x,y,z coordinate (x_2 - x_1, etc.) at time tmin
 // for spherical grid get the radial extent (r_outer - r_inner) at time tmin
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto propcell_width_tmin(const int cellindex, const int axis) -> double {
   return get_cellcoordmax(cellindex, axis) - get_cellcoordmin(cellindex, axis);
@@ -1632,12 +1632,12 @@ auto get_rho_tmin(const int modelgridindex) -> float { return modelgrid_input[mo
   return massfrac;
 }
 
-// mass fraction of an element (all isotopes combined)
+// set the mass fraction of an element (all isotopes combined)
 void set_elem_massfrac(const ptrdiff_t nonemptymgi, const int element, const float newmassfrac) {
   elem_massfracs_allcells[(nonemptymgi * get_nelements()) + element] = newmassfrac;
 }
 
-// mass fraction of an element (all isotopes combined)
+// number density [cm^-3] of an element (all isotopes combined)
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_elem_numberdens(const ptrdiff_t nonemptymgi, const int element)
     -> double {
   return get_elem_massfrac(nonemptymgi, element) / static_cast<double>(get_element_meanweight(nonemptymgi, element)) *
@@ -1681,14 +1681,13 @@ DEVICE_FUNC auto get_modelgridtype() -> GridType {
   return model_type.value();
 }
 
-[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_npts_model() -> int
-// number of model grid cells
-{
+// total number of model grid cells, including empty ones
+[[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_npts_model() -> int {
   assert_testmodeonly(npts_model > 0);
   return static_cast<int>(npts_model);
 }
 
-// number of model grid cells
+// number of non-empty model grid cells, i.e. the length of the nonemptymgi index space
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_nonempty_npts_model() -> int {
   assert_testmodeonly(nonempty_npts_model > 0);
   return static_cast<int>(nonempty_npts_model);
@@ -1736,7 +1735,7 @@ DEVICE_FUNC auto get_modelgridtype() -> GridType {
   return nonemptymgi;
 }
 
-// get the index in the list of non-empty cells for a given model grid cell
+// inverse of get_nonemptymgi_of_mgi(): get the model grid index of an entry in the list of non-empty cells
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_mgi_of_nonemptymgi(const ptrdiff_t nonemptymgi) -> int {
   assert_testmodeonly(get_nonempty_npts_model() > 0);
   assert_testmodeonly(nonemptymgi >= 0);

--- a/input.cc
+++ b/input.cc
@@ -262,9 +262,9 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
     }
   }
 
-  // The level contributes to the ionisinglevels if its energy is below the ionisation potential and the level doesn't
-  // belong to the topmost ion included. Rate coefficients are only available for ionising levels.
-  //  also need (levelenergy < ionpot && ...)?
+  // Every photoionisation target of this level is a level that the upper ion can recombine from, so raise the
+  // upper ion's maxrecombininglevel to cover them. The topmost included ion is skipped because it has no ion
+  // above it to recombine into.
   if (lowerion < get_nions(element) - 1) {
     for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
          phixstargetindex++) {

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -225,9 +225,11 @@ void set_ncoolingterms() {
   }
 }
 
-// return a randomly chosen frequency according to the Planck distribution of temperature T using a Monte Carlo method
+// Draw a frequency from the Planck distribution at temperature T, truncated to the [NU_MIN_R, NU_MAX_R] range
+// that r-packets are tracked over. Uses rejection sampling against a uniform proposal, with the envelope set by
+// the peak of the Planck function, so it stays valid whatever part of the curve falls inside the range.
 auto sample_planck_montecarlo(const double T, rngstate_type& rngstate) -> double {
-  const double nu_peak = 5.879e10 * T;
+  const double nu_peak = 5.879e10 * T;  // Wien displacement law in frequency [Hz/K]
   const double B_peak = radfield::planck(nu_peak, T);
 
   while (true) {
@@ -457,10 +459,9 @@ DEVICE_FUNC void do_kpkt(Packet& pkt, const double t2, const int nts) {
 
   if (rndcoolingtype == CoolingType::FREEFREE) {
     // The k-packet converts directly into a r-packet by free-free emission.
-    // Need to select the r-packets frequency and a random direction in the co-moving frame.
-
-    // Sample the packets comoving frame frequency according to paperII 5.4.3 eq.41
-
+    // Sample the comoving-frame frequency from the free-free emissivity (paper II, Sect. 5.4.3 eq. 41). The
+    // emissivity is treated as frequency-independent apart from its exp(-h nu / k T_e) factor, so nu is
+    // exponentially distributed with mean k T_e / h and can be drawn by inverting the CDF.
     pkt.nu_cmf = -KB * T_e / H * std::log(static_cast<double>(rng_uniform_pos(get_rngstate(pkt))));
 
     assert_always(std::isfinite(pkt.nu_cmf));
@@ -482,15 +483,14 @@ DEVICE_FUNC void do_kpkt(Packet& pkt, const double t2, const int nts) {
     }
 
   } else if (rndcoolingtype == CoolingType::FREEBOUND) {
-    // The k-packet converts directly into a r-packet by free-bound-emission.
-    // Need to select the r-packets frequency and a random direction in the co-moving frame.
+    // The k-packet converts directly into a r-packet by free-bound emission.
     const int lowerion = ion;
     const int lowerlevel = coolinglist_level[i];
     const int upper = coolinglist_upperlevel[i];
 
-    // then randomly sample the packets frequency according to the continuums energy distribution
-
-    // Sample the packets comoving frame frequency according to paperII 4.2.2
+    // Sample the comoving-frame frequency from the energy distribution of this recombination continuum
+    // (paper II, Sect. 4.2.2), i.e. by inverting the CDF of the energy-weighted emissivity over the
+    // continuum's frequency range.
     pkt.nu_cmf = select_continuum_nu(element, lowerion, lowerlevel, upper, T_e, get_rngstate(pkt));
 
     // and then emit the packet randomly in the comoving frame

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -53,7 +53,8 @@ THREADLOCALONHOST CellWarningMarker nne_maxit_warned;
 THREADLOCALONHOST CellWarningMarker uppermost_ion_warned;
 THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
 
-// use Saha equation for LTE ionisation balance
+// LTE ionisation balance from the Saha equation. Returns phi = N_ion / (N_(ion+1) * nne) in [cm^3], the same
+// quantity that phi_rate_balance() returns for the nebular approximation.
 [[gnu::pure]] [[nodiscard]] auto phi_saha(const int element, const int ion, const int nonemptymgi) -> double {
   const auto partfunc_ion = get_ion_partfunct(nonemptymgi, element, ion);
   const auto partfunc_upperion = get_ion_partfunct(nonemptymgi, element, ion + 1);
@@ -242,7 +243,9 @@ void set_calculated_nne(const int nonemptymgi) {
   grid::set_nne(nonemptymgi, static_cast<float>(std::max(MINPOP, nne)));
 }
 
-// Special case of only neutral ions, set nne to some finite value so that packets are not lost in kpkts
+// Fallback for a cell in which every element is confined to its lowest included ion stage: put each element's whole
+// population in that stage and floor the higher stages at MINPOP. The MINPOP floor leaves nne slightly above zero,
+// which keeps the collisional rates in the k-packet treatment finite so that packets are not lost there.
 void set_groundlevelpops_neutral(const ptrdiff_t nonemptymgi) {
   if (neutralcell_warned.is_first_occurrence(nonemptymgi)) {
     printlnlog("[warning] set_groundlevelpops_neutral: only neutral ions in cell {} timestep {} (repeats suppressed)",
@@ -272,8 +275,6 @@ void set_groundlevelpops_neutral(const ptrdiff_t nonemptymgi) {
 // Solve for the free electron density nne in [0, nne_max] that makes the ion balance self-consistent, using the
 // Boost TOMS 748 root-finder on the charge-conservation residual.
 auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_lte) -> float {
-  // search for nne solution in [0.,nne_max]
-
   const auto f_nne = [nonemptymgi, force_lte](const double nne) { return nne_solution_f(nne, nonemptymgi, force_lte); };
 
   constexpr double nne_min = 0.;
@@ -284,7 +285,6 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
   constexpr double fractional_accuracy = 1e-3;
   constexpr auto maxit = 50U;
 
-  // use TOMS 748 solver from Boost
   uintmax_t iter = maxit;
   const auto result =
       boost::math::tools::toms748_solve(f_nne, nne_min, nne_max, f_nne_min, f_nne_max, ftol<fractional_accuracy>, iter);
@@ -478,6 +478,7 @@ void set_groundlevelpops(const int nonemptymgi, const int element, const float n
 auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
   const bool force_saha = globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1;
 
+  // upper bound on nne: at most one free electron per nucleon, i.e. fully ionised hydrogen
   const double nne_max = grid::get_rho(nonemptymgi) / MH;
 
   bool only_lowest_ionstage = true;  // could be completely neutral, or just at each element's lowest ion stage

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -635,7 +635,8 @@ void macroatom_open_file() {
   return 0.;
 }
 
-// multiply by upper level population to get a rate per second
+// Collisional (three-body) recombination rate, the detailed-balance reverse of col_ionisation_ratecoeff().
+// Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_recombination_ratecoeff(const float T_e, const float clumpednne, const int element,
                                                              const int upperion, const int upper, const int lower,
                                                              const double epsilon_trans) -> double {
@@ -679,17 +680,17 @@ void macroatom_open_file() {
 
   const double fac1 = epsilon_trans / KB / T_e;
 
+  // the Seaton formula uses the photoionisation cross-section at the threshold edge, i.e. the first table point
   const double sigma_bf =
       get_phixs_table(element, ion, lower)[0] * get_phixsprobability(element, ion, lower, phixstargetindex);
-  const double C =
-      clumpednne * 1.55e13 * pow(T_e, -0.5) * g * sigma_bf * exp(-fac1) / fac1;  // photoionisation at the edge
+  const double C = clumpednne * 1.55e13 * pow(T_e, -0.5) * g * sigma_bf * exp(-fac1) / fac1;
 
   assert_testmodeonly(std::isfinite(C));
 
   return C;
 }
 
-// multiply by upper level population to get a rate per second
+// Collisional de-excitation rate. Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_deexcitation_ratecoeff(const float T_e, const float clumpednne,
                                                             const double epsilon_trans, const double upperstatweight,
                                                             const double lowerstatweight, const int alltransindex)
@@ -720,18 +721,19 @@ void macroatom_open_file() {
              eoverkt * g_ratio * gauntfac;
     }
 
-    // forbidden transitions: magnetic dipole, electric quadropole...
-    // could be Axelrod? or Maurer
+    // forbidden transitions: magnetic dipole, electric quadrupole... Axelrod's approximation (thesis 1980),
+    // i.e. the effective-collision-strength form below with an assumed Omega = 0.01 * lowerstatweight.
+    // This is the detailed-balance reverse of the branch in col_excitation_ratecoeff().
     return clumpednne * 8.629e-6 * 0.01 * lowerstatweight / std::sqrt(T_e);
   }
 
-  // positive coll_str is treated as effective collision strength
-
-  // from Osterbrock and Ferland, p51
+  // a positive coll_str in the atomic data is the effective collision strength Omega, giving the
+  // de-excitation rate coefficient 8.629e-6 * Omega / (g_upper * sqrt(T_e)) [cm^3/s]
+  // (Osterbrock & Ferland 2006, Astrophysics of Gaseous Nebulae and AGN, 2nd ed., eq. 3.20, p. 51)
   return clumpednne * 8.629e-6 * static_cast<double>(coll_strength) / upperstatweight / std::sqrt(T_e);
 }
 
-// multiply by lower level population to get a rate per second
+// Collisional excitation rate. Multiply by the lower-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(const float T_e, const float clumpednne,
                                                           const double upperstatweight, const int alltransindex,
                                                           const double epsilon_trans, const double lowerstatweight)
@@ -761,12 +763,14 @@ void macroatom_open_file() {
              eoverkt / exp_eoverkt * Gamma;
     }
 
-    // forbidden transitions: magnetic dipole, electric quadropole... Axelrod's approximation (thesis 1980)
-
+    // forbidden transitions: magnetic dipole, electric quadrupole... Axelrod's approximation (thesis 1980),
+    // i.e. the effective-collision-strength form below with an assumed Omega = 0.01 * upperstatweight
     return clumpednne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }
 
-  // from Osterbrock and Ferland, p51
+  // a positive coll_str in the atomic data is the effective collision strength Omega, giving the
+  // excitation rate coefficient 8.629e-6 * Omega * exp(-dE/kT) / (g_lower * sqrt(T_e)) [cm^3/s]
+  // (Osterbrock & Ferland 2006, Astrophysics of Gaseous Nebulae and AGN, 2nd ed., eq. 3.20, p. 51)
   return clumpednne * 8.629e-6 * static_cast<double>(coll_strength) * std::exp(-eoverkt) / lowerstatweight /
          std::sqrt(T_e);
 }

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -175,7 +175,8 @@ auto get_nlte_vector_index(const int element, const int ion, const int level, co
 [[nodiscard]] auto get_ion_level_of_nlte_vector_index(const std::ptrdiff_t index, const int element,
                                                       const int first_ion_used, const int nions_used)
     -> std::tuple<int, int> {
-  // this could easily be optimized if need be
+  // inverse of get_nlte_vector_index() by linear search. Called once per vector entry when validating or
+  // reporting a solution, never from the rate matrix assembly, so the O(nlevels) scan is not on a hot path.
   for (int dion = first_ion_used; dion < first_ion_used + nions_used; dion++) {
     for (int dlevel = 0; dlevel < get_nlevels(element, dion); dlevel++) {
       if (get_nlte_vector_index(element, dion, dlevel, first_ion_used) == index) {
@@ -677,7 +678,7 @@ void nltepop_matrix_add_autoionisation(const int nonemptymgi, const int element,
     const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
     const int nautoiondowntrans = get_nautoiondowntrans(uniquelevelindex);
     for (int i = 0; i < nautoiondowntrans; i++) {
-      // autoionisation (which is a de-excitation propcess)
+      // autoionisation (which is a de-excitation process)
       const auto& autoiontransition = globals::allautoion[globals::alllevels.allautoion_start[uniquelevelindex] + i];
       const double A_a = autoiontransition.autoion_A;
       const int target_ion = autoiontransition.upperionindex;

--- a/radfield.cc
+++ b/radfield.cc
@@ -215,9 +215,9 @@ void update_bfestimators(const ptrdiff_t nonemptymgi, const double distance_e_cm
   // LUT gammaestimator in rpkt.cc)
   const double distance_e_cmf_over_nu = distance_e_cmf / nu_cmf;
 
-  // I think the nu_cmf slightly differs from when the phixslist was calculated
-  // so the nu condition on this nu_cmf can truncate the list further compared to what was used in the calculation
-  // of phixslist.gamma_contr
+  // The packet has propagated since the phixslist was built, so nu_cmf has drifted (downwards) from the value the
+  // list was truncated at. Re-deriving the bounds from the current nu_cmf can therefore narrow the range further
+  // than the stored phixslist.bfestimbegin/bfestimend, and the contributions are only made over that narrower range.
   const auto bfestimcount = std::ssize(globals::bfestim_nu_edge);
 
   assert_testmodeonly(phixslist.bfestimend <= bfestimcount);
@@ -353,24 +353,24 @@ auto nu_bar_planck_minus_estimator(const double T_R, const int nonemptymgi, cons
   return delta_nu_bar;
 }
 
+// Find the radiation temperature of a bin by matching the Planck mean frequency to the bin's nuJ/J estimator.
+// nu_bar_planck_minus_estimator() increases with T_R, so a root outside [bins_T_R_min, bins_T_R_max] is clamped to
+// whichever bound it lies beyond.
 auto find_bin_T_R(const int nonemptymgi, const int binindex) -> float {
   const auto f_deltanubar = [nonemptymgi, binindex](const double T_R) {
     return nu_bar_planck_minus_estimator(T_R, nonemptymgi, binindex);
   };
 
-  // Check whether the equation has a root in [T_min,T_max]
   const double f_Tmin = f_deltanubar(bins_T_R_min);
   const double f_Tmax = f_deltanubar(bins_T_R_max);
 
   const bool invalid_values = (!std::isfinite(f_Tmin) || !std::isfinite(f_Tmax));
 
+  // a sign change over the interval guarantees a root that the bracketing solver can find
   if (!invalid_values && f_Tmin * f_Tmax < 0) {
-    // If there is a root in the interval, solve for T_R
-
     constexpr double epsrel = 1e-4;
     const auto maxit = 100U;
 
-    // use TOMS 748 solver from Boost
     uintmax_t iteration_num = maxit;
     const auto result = boost::math::tools::toms748_solve(f_deltanubar, bins_T_R_min, bins_T_R_max, f_Tmin, f_Tmax,
                                                           ftol<epsrel>, iteration_num);
@@ -384,10 +384,12 @@ auto find_bin_T_R(const int nonemptymgi, const int binindex) -> float {
     return T_R_solution;
   }
   if (invalid_values || f_Tmax < 0) {
-    // At T_R_max, nu_bar_planck_minus_estimator is negative or not finite, so any root lies above T_R_max; clamp to
-    // upper bound
+    // the Planck mean frequency is still below the estimator at the top of the range (or the residual is not
+    // finite), so any root lies above bins_T_R_max
     return bins_T_R_max;
   }
+  // the residual is positive at both ends, so the Planck mean frequency already exceeds the estimator at the
+  // bottom of the range and any root lies below bins_T_R_min
   return bins_T_R_min;
 }
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -435,7 +435,9 @@ void precalculate_ion_alpha_sp() {
   MPI_Barrier_node();
 }
 
-// Integrand to calculate the rate coefficient for photoionisation. Corrected for stimulated recombination.
+// Integrand to calculate the rate coefficient for photoionisation, corrected for stimulated recombination.
+// Unlike integrand_corrphotoioncoeff() above, which assumes LTE at T_R, the correction factor here is built from
+// the cell's actual level populations (via modified_departure_ratio) and T_e.
 auto integrand_corrphotoioncoeff_custom_radfield(const double nu_minus_nu_edge, const double nu_edge,
                                                  const double modified_departure_ratio,
                                                  const std::span<const float> photoion_xs, const float T_e,
@@ -449,7 +451,7 @@ auto integrand_corrphotoioncoeff_custom_radfield(const double nu_minus_nu_edge, 
 
   const double Jnu = radfield::radfield(nu_minus_nu_edge + nu_edge, nonemptymgi);
 
-  // TODO: MK thesis page 41, use population ratios and Te?
+  // 4 pi / (h nu) * sigma_bf * J_nu, with the 4 pi applied by the caller
   return (1. / H) * sigma_bf / (nu_minus_nu_edge + nu_edge) * Jnu * corrfactor;
 }
 
@@ -682,7 +684,9 @@ auto calculate_ionrecombcoeff(const int nonemptymgi, const float T_e, const int 
     return 0.;
   }
 
-  // this gets divided and cancelled out in the radiative case anyway
+  // the rate coefficients below are divided by clumpednne again at alpha_level, so this factor cancels exactly in
+  // the radiative case. In the collisional case the rate goes as clumpednne^2, so one factor of clumpednne survives
+  // into the returned coefficient (see the clumping note in ltepop.cc's phi_rate_balance()).
   const auto clumpednne = (nonemptymgi >= 0) ? grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi) : 1.F;
   double alpha = 0.;
   const int maxrecombininglevel = get_maxrecombininglevel(element, lowerion + 1);
@@ -887,7 +891,8 @@ auto calculate_iongamma_per_ionpop(const int nonemptymgi, const int element, con
         ionisation_rate += nnlowerlevel * calculate_corrphotoioncoeff_integral(element, lowerion, lower,
                                                                                phixstargetindex, nonemptymgi, false);
       } else {
-        // whatever ARTIS uses internally, maybe using detailed bound-free estimators
+        // the same coefficient the simulation itself uses, which draws on the detailed bound-free estimators
+        // when they are enabled and available
         ionisation_rate +=
             nnlowerlevel * get_corrphotoioncoeff(element, lowerion, lower, phixstargetindex, nonemptymgi, false);
       }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -113,12 +113,9 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Continuu
   double tau = 0.;  // optical depth along path
   double dist = 0.;  // position on path
   while (true) {
-    // calculate distance to next line encounter ldist
-    // first select the closest transition in frequency
-    // we need its frequency nu_trans, the element/ion and the corresponding levels
-    // create therefore new variables in packet, which contain next_lowerlevel, ...
-
-    // returns negative value if nu_cmf > nu_trans
+    // step to the next line the packet will redshift onto, accumulating the continuum optical depth over the
+    // distance to it. closest_transition() returns a negative index once no line remains at or below nu_cmf, or
+    // when the packet has already been tagged as having no further line interactions.
     const int lineindex = closest_transition(nu_cmf, next_trans, linelist.nu);
 
     if (lineindex < 0) [[unlikely]] {
@@ -135,13 +132,12 @@ auto get_possible_event(const int nonemptymgi, const Packet& pkt, const Continuu
       return {dist + ((tau_rnd - tau) / chi_cont), globals::nlines + 1, false};
     }
 
-    // line interaction is possible (nu_cmf > nu_trans)
+    // a line interaction is possible, i.e. the packet redshifts onto this line before nu_cmf_abort
 
     const double nu_trans = linelist.nu[lineindex];
 
-    // helper variable to overcome numerical problems after line scattering
-    // further scattering events should be located at lower frequencies to prevent
-    // multiple scattering events of one packet in a single line
+    // advance past this line so that any further event this step is found at a lower frequency. Without this the
+    // packet could scatter repeatedly in the same line when rounding leaves nu_cmf marginally above nu_trans.
     next_trans = lineindex + 1;
 
     const double ldist = get_linedistance(prop_time, nu_cmf, nu_trans, dnu_on_dl);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -724,9 +724,9 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
   }
   time_timestep_start = std::chrono::steady_clock::now();
 
-  // set all the estimators to zero before moving packets. This is now done
-  // after update_grid so that, if requires, the gamma-ray heating estimator is known there
-  // and also the photoion and stimrecomb estimators
+  // set all the estimators to zero before moving packets. This is done after update_grid() so that the
+  // gamma-ray heating estimator, and the photoionisation and stimulated recombination estimators, are still
+  // available to it from the previous timestep.
   zero_estimators();
 
   MPI_Barrier_allranks();
@@ -812,7 +812,9 @@ auto main(int argc, char* argv[]) -> int {
 #endif
 
 #if defined(_OPENMP) && !defined(GPU_ON)
-  // Explicitly turn off dynamic threads because we use the threadprivate directive!!!
+  // Explicitly turn off dynamic threads. The per-thread log file handles in mpi_logging.h are threadprivate,
+  // and OpenMP only guarantees that threadprivate data persists between parallel regions while the team size
+  // stays fixed, which dynamic adjustment would break.
   omp_set_dynamic(0);
 #pragma omp parallel
 #endif

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -109,16 +109,19 @@ void calculate_heating_rates(const int nonemptymgi, const float T_e, const float
   if constexpr (DIRECT_COL_HEAT) {
     heatingcoolingrates.heating_collisional = C_deexc;
   } else {
-    // Collisional heating (from estimators)
-    heatingcoolingrates.heating_collisional = globals::colheatingestimator.at(nonemptymgi);  // C_deexc + C_recomb;
+    // from Monte Carlo estimators, which accumulate collisional recombination heating as well as
+    // the collisional de-excitation heating that the DIRECT_COL_HEAT branch above sums analytically
+    heatingcoolingrates.heating_collisional = globals::colheatingestimator.at(nonemptymgi);
   }
 
   heatingcoolingrates.heating_bf = bfheating;
   heatingcoolingrates.heating_ff = ffheating;
 }
 
-// Thermal balance equation on which we have to iterate to get T_e
-
+// Residual (total heating minus total cooling) of the thermal balance equation, as a function of T_e.
+// NB: this is not a pure function of T_e. Evaluating it stores T_e in the grid and re-solves the cell's
+// ionisation balance, populations and nne at that temperature, so the cell is left in the state belonging
+// to the last T_e passed in. call_T_e_finder() relies on this and re-evaluates at the final T_e.
 auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const double t_current,
                                    HeatingCoolingRates& heatingcoolingrates,
                                    const std::span<const double> bfheatingcoeffs) -> double {
@@ -165,9 +168,10 @@ auto T_e_eqn_heating_minus_cooling(const double T_e, int nonemptymgi, const doub
           ? heatingcoolingrates.heating_dep / (ntlepton_dep + ntalpha_dep + ntspfission_dep)
           : ntlepton_frac_heating;
 
-  // Adiabatic cooling term
+  // Adiabatic cooling p dV/dt per unit volume. Homologous expansion gives V proportional to t^3, so this
+  // reduces to 3p/t, but it is written out below in terms of the cell volume at tmin.
   const double nntot = get_nnion_tot(nonemptymgi) + nne;
-  const double p = nntot * KB * T_e;  // pressure in [erg/cm^3]
+  const double p = nntot * KB * T_e;  // ideal gas pressure in [erg/cm^3]
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   const double volumetmin = grid::get_modelcell_assocvolume_tmin(modelgridindex);
   const double dV_on_dt = 3 * volumetmin / pow3(globals::tmin) * pow2(t_current);
@@ -206,7 +210,9 @@ auto calculate_bfheatingcoeff(const int element, const int ion, const int level,
   return bfheating;
 }
 
-// depends only the radiation field - no dependence on T_e or populations
+// Calculate the bound-free heating coefficient of every level in a cell. These depend only on the radiation
+// field, not on T_e or the populations, so they are computed once per cell and reused at every T_e that the
+// temperature solver tries.
 void calculate_bfheatingcoeffs(int nonemptymgi, std::span<double> bfheatingcoeffs) {
   assert_always(std::ssize(bfheatingcoeffs) == get_includedlevels());
   const double minelfrac = 0.01;
@@ -245,7 +251,9 @@ void calculate_bfheatingcoeffs(int nonemptymgi, std::span<double> bfheatingcoeff
 }
 
 // Solve the thermal-balance equation (heating = cooling) for the electron temperature T_e in a cell by
-// root-finding between MINTEMP and MAXTEMP, then store the resulting T_e in the grid.
+// root-finding between MINTEMP and MAXTEMP, then store the resulting T_e in the grid. If the equation has no
+// sign change over that range, T_e is pinned to whichever bound the residual points towards. The change from
+// the previous timestep's T_e is then damped to at most a factor of two in either direction.
 void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCoolingRates& heatingcoolingrates,
                      const std::span<const double> bfheatingcoeffs) {
   const int modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
@@ -267,12 +275,13 @@ void call_T_e_finder(const int nonemptymgi, const double t_current, HeatingCooli
   }
 
   double T_e{NAN};
-  // Check whether the thermal balance equation has a root in [T_min,T_max]
+  // a sign change over [MINTEMP, MAXTEMP] guarantees a root that the bracketing solver can find
   if (!invalid_values && f_T_min * f_T_max < 0) {
     const auto maxit = 100U;
-    // If it has, then solve for the root T_e
 
-    // use TOMS 748 solver from Boost
+    // TOMS 748 (Alefeld, Potra & Shi 1995, ACM Trans. Math. Softw. 21, 327, doi:10.1145/210089.210111):
+    // bracketing solver with inverse cubic interpolation, so it keeps the root bracketed like bisection
+    // but converges superlinearly on the smooth part of the residual
     uintmax_t iternum = maxit;
     auto result = boost::math::tools::toms748_solve(f_T_e, MINTEMP, MAXTEMP, f_T_min, f_T_max,
                                                     ftol<TEMPERATURE_SOLVER_ACCURACY>, iternum);

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -36,7 +36,8 @@ std::vector<HeatingCoolingRates> heatingcoolingrates_thisrankcells;
 
 void write_to_estimators_file(std::ostream& estimators_file, const int nonemptymgi, const int timestep, const int titer,
                               const HeatingCoolingRates& heatingcoolingrates) {
-  // return; disable for better performance (if estimators files are not needed)
+  // writing the estimators file is a measurable cost per cell per timestep. If the estimators output is not
+  // needed, an early return here skips it.
   const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
   const auto sys_time_start_write_estimators = std::chrono::steady_clock::now();
@@ -304,7 +305,7 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
       // 2012-01-11. These loops should terminate here to precalculate *ALL* corrphotoionrenorm
       // values so that the values are known when required by the call to get_corrphotoioncoeff in
       // the following loops. Otherwise get_corrphotoioncoeff tries to renormalize by the closest
-      // corrphotoionrenorm in frequency space which can lead to zero contributions to the total photoionsation rate!
+      // corrphotoionrenorm in frequency space which can lead to zero contributions to the total photoionisation rate!
     }
   }
   for (int element = 0; element < get_nelements(); element++) {

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -233,8 +233,10 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
       gammapkt::pellet_gamma_decay(pkt);
     }
   } else if ((tdecay > 0) && (nts == 0)) {
-    // These are pellets whose decay times were before the first time step
-    // They will be made into r-packets with energy reduced for doing work on the ejecta following Lucy 2004.
+    // These are pellets whose decay times were before the first time step. They become pre-k-packets, which
+    // do_packet() immediately re-emits as r-packets with a blackbody frequency. The energy is reduced by
+    // tdecay / tmin to account for the work done on the ejecta by the trapped radiation between the decay and
+    // the start of the simulation (equation 18 of Lucy 2005, as also applied in decay.cc).
     // The position is already set at globals::tmin so don't need to move it. Assume
     // that it is fixed in place from decay to globals::tmin - i.e. short mfp.
 

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -107,7 +107,7 @@ constexpr auto all_taus_past_taumax(std::vector<double>& tau, const double tau_m
   return std::ranges::all_of(tau, [tau_max](const double tau_i) { return tau_i > tau_max; });
 }
 
-// Add a packet to the outgoing spectrum
+// Add an escaping virtual packet's Stokes I, Q and U contributions to the observer's time/frequency spectrum
 void add_to_vspecpol(const double nu_rf, const double e_rf, const double prob, const double q_rf, const double u_rf,
                      const int obsdirindex, const int opachoiceindex, const double t_arrive) {
   // Need to decide in which (1) time and (2) frequency bin the vpkt is escaping
@@ -128,7 +128,8 @@ void add_to_vspecpol(const double nu_rf, const double e_rf, const double prob, c
   atomicadd(vspecpol[nt][ind_comb].flux[nnu].U, prob * u_rf * pktcontrib);
 }
 
-// Add a packet to the outgoing spectrum
+// Add an escaping virtual packet to the optional velocity-space map, binned by the emitting material's
+// velocity projected onto the plane perpendicular to the observer direction
 void add_to_vpkt_grid(const double nu_rf, const double e_rf, const double prob, const double stokes_q,
                       const double stokes_u, const Vec3d& vel, const int wlbin, const int obsdirindex,
                       const Vec3d& obsdir) {
@@ -180,7 +181,10 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
   int mgi = 0;
 
   auto cellindex = rpkt.cellindex;
-  auto next_trans = rpkt.next_trans;  // should be -1 since doppler factor changed it?
+  // The vpkt leaves from the real packet's position with the same comoving-frame frequency (nu_cmf does not
+  // depend on direction, only nu_rf does), so the same lines lie ahead of it and it can inherit the real
+  // packet's line list position.
+  auto next_trans = rpkt.next_trans;
   auto e_cmf = rpkt.e_cmf;
   auto nu_cmf = rpkt.nu_cmf;
   auto vpktpos = rpkt.pos;
@@ -724,7 +728,8 @@ void read_vpktparameterfile() {
 
   printlnlog("vpkt.txt: Nspectra {} per observer", nspectraperobsdir);
 
-  // time window. If dum4=1 it restrict vpkt to time windown (dum5,dum6)
+  // Emission time window: a leading 1 restricts vpkts to the [tmin, tmax] (in days) that follow on the same
+  // line, otherwise the compile-time VSPEC_TIMEMIN/VSPEC_TIMEMAX are used and the two values are ignored.
   int override_tminmax = 0;
   double vspec_tmin_in_days = 0.;
   double vspec_tmax_in_days = 0.;
@@ -751,8 +756,9 @@ void read_vpktparameterfile() {
   assert_always(vspec_timemin_input >= globals::tmin);
   assert_always(vspec_timemax_input <= globals::tmax);
 
-  // frequency window. dum4 restrict vpkt to a frequency range, dum5 indicates the number of ranges,
-  // followed by a list of ranges (dum6,dum7)
+  // Wavelength windows: a leading 1 selects custom ranges, followed by the number of ranges and then that
+  // many (lambda_min, lambda_max) pairs in Angstroms. Otherwise a single range spanning the compile-time
+  // VSPEC_NUMIN to VSPEC_NUMAX is used.
   int flag_custom_freq_ranges = 0;
   assert_always(fscanf(input_file, "%d ", &flag_custom_freq_ranges) == 1);
 
@@ -795,7 +801,8 @@ void read_vpktparameterfile() {
                1e8 * CLIGHT / vspec_numin_input[i]);
   }
 
-  // if dum7=1, vpkt are not created when cell optical depth is larger than optical_depth_is_thick_vpkt
+  // Thick-cell threshold: a leading 1 overrides optical_depth_is_thick_vpkt with the value that follows,
+  // otherwise the global optical_depth_is_thick is inherited. vpkts are not created in cells above it.
   int override_thickcell_tau = 0;
   assert_always(fscanf(input_file, "%d %lg", &override_thickcell_tau, &optical_depth_is_thick_vpkt) == 2);
 
@@ -807,7 +814,7 @@ void read_vpktparameterfile() {
                optical_depth_is_thick_vpkt);
   }
 
-  // Maximum optical depth. If a vpkt reaches dum7 is thrown away
+  // Maximum optical depth: a vpkt is discarded once it exceeds tau_max_vpkt in every opacity setup
   assert_always(fscanf(input_file, "%lg", &tau_max_vpkt) == 1);
   printlnlog("vpkt.txt: tau_max_vpkt {:g}", tau_max_vpkt);
 
@@ -828,7 +835,8 @@ void read_vpktparameterfile() {
     printlnlog("vpkt.txt: velocity grid time range tmin_grid {:g} [d] tmax_grid {:g} [d]", tmin_grid / DAY,
                tmax_grid / DAY);
 
-    // Specify wavelength range: number of intervals (dum9) and limits (dum10,dum11)
+    // Velocity grid map wavelength ranges: the number of intervals, then that many
+    // (lambda_min, lambda_max) pairs in Angstroms
     assert_always(fscanf(input_file, "%d ", &grid_nwavelengthranges) == 1);
 
     printlnlog("vpkt.txt: velocity grid frequency intervals {}", grid_nwavelengthranges);


### PR DESCRIPTION
Full review of the code comments across the ~27k lines of source, plus the markdown documentation.

**Comment and documentation changes only — no code was changed.** Every non-comment line in the diff is a trailing-comment edit or pure reflow, so results are bit-identical and the stored test checksums are unaffected.

## Comments that described the wrong thing

- **grid.cc**: `get_elem_numberdens()` was documented as returning a mass fraction, but it returns a number density. `get_mgi_of_nonemptymgi()` described the *inverse* mapping, copy-pasted from the function directly above it. `get_nonempty_npts_model()` said "number of model grid cells", omitting non-empty. `set_elem_massfrac()` was described as a getter.
- **update_packets.cc**: pellets decaying before `tmin` become pre-k-packets, not r-packets as the comment claimed. The `e_cmf *= tdecay/tmin` scaling was attributed to a non-existent "Lucy 2004"; it is equation 18 of Lucy 2005, which `decay.cc` already cites correctly for the same physics.
- **input.cc**: a comment about counting ionising levels sat above the code that raises `maxrecombininglevel`. The misplacement is also what produced the trailing `// also need (levelenergy < ionpot ...)?` question.
- **rpkt.cc**: referenced a packet field `next_lowerlevel` that exists nowhere in the codebase, and adjacent comments gave contradictory sign conventions for `closest_transition()`.
- **vpkt.cc**: five vpkt.txt parsing comments referred to variables `dum4`–`dum11` that were renamed long ago.
- **artisoptions_doc.md**: documented `SFPTS`, `SF_EMIN` and `SF_EMAX` as artisoptions.h options. They are set in nonthermal.cc and appear in no preset.
- **README.md**: implied the gamma-ray and polarisation outputs are unconditional; they are gated on `KEEP_ESCAPED_GAMMAS` and `POL_ON`. Also documents the legacy four-column transitiondata.txt format that the reader accepts.

## Hedges and stale notes resolved against the code

The `???` questions on the Kramers extrapolation in atomic.h, "I think the nu_cmf slightly differs" in radfield.cc, "should be -1 since doppler factor changed it?" in vpkt.cc, and a TODO in ratecoeff.cc asking for population ratios and T_e that the function already uses.

## Citations added

TOMS 748 (Alefeld, Potra & Shi 1995), Klein-Nishina (1929), Kramers (1923), Osterbrock & Ferland (2006) eq. 3.20, and Wien's displacement law. The two forbidden-transition branches in macroatom.cc are now consistently attributed — previously one asserted Axelrod (1980) while its detailed-balance partner said "could be Axelrod? or Maurer".

## Redundancy removed

Duplicate comments on adjacent overloads in atomic.h, a file-header line in gammapkt.cc restating the header above it, restatements of the `toms748_solve` calls, and commented-out code fragments (`// C_deexc + C_recomb;`, `// return;`) rewritten as prose.

## decay.cc

The two follow-up commits on this branch drop two stale TODOs in decay.cc and bring the file back in line with clang-format (it had pre-existing drift on `develop`, which the pinned v22.1.8 wanted to reformat).

## Verification

- clang-format clean across the whole branch under **v22.1.8**, the version pinned in `.pre-commit-config.yaml`
- clean `-Werror` build of `sn3d` and `exspec`
- 52/52 unit tests pass

## Note for the reviewer

One item left unsettled: **kpkt.cc "paperII"**. I made both sampling comments describe the method accurately but left the shorthand in place. The k-packet subject matter fits Lucy (2003), while the README's numbering (Sim 2007, then Kromer & Sim 2009) points the other way, and I did not want to commit a citation I could not verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)