### PR TITLE
Make the GSL and Eigen linear algebra paths fail the same way

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -964,6 +964,17 @@ template <typename GetDiagElement>
   assert_always(rate_matrix.size() == (nlte_dimension * nlte_dimension));
   assert_always(std::cmp_greater_equal(max_nlte_dimension, nlte_dimension));
 
+  // A non-finite entry anywhere makes the solve meaningless. Checked here rather than in the backend-specific code
+  // below so that both builds react the same way: report and return false, which lets the caller drop an ion stage and
+  // retry, instead of aborting the run.
+  const auto is_finite = [](const double x) { return std::isfinite(x); };
+  if (!std::ranges::all_of(rate_matrix, is_finite) || !std::ranges::all_of(balance_vector, is_finite)) {
+    printlnlog(
+        "  [error] cell {} ts {}: NLTE rate matrix or balance vector contains a non-finite value for element Z={}",
+        nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+    return false;
+  }
+
   // solution vector for the matrix equation
   THREADLOCALONHOST std::vector<double> vec_x;
   vec_x.reserve(max_nlte_dimension);
@@ -1005,12 +1016,10 @@ template <typename GetDiagElement>
 
   auto eigen_vec_x = Eigen::Map<Eigen::VectorX<double>>(vec_x.data(), nlte_dimension);
   const auto eigen_balance_vector = Eigen::Map<const Eigen::VectorX<double>>(balance_vector.data(), nlte_dimension);
-  assert_always(eigen_balance_vector.allFinite());
 
   const auto eigen_rate_matrix =
       Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
           rate_matrix.data(), nlte_dimension, nlte_dimension);
-  assert_always(eigen_rate_matrix.allFinite());
 
   THREADLOCALONHOST Eigen::PartialPivLU<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
       eigen_rate_matrix_lu;
@@ -1022,8 +1031,9 @@ template <typename GetDiagElement>
     return false;
   }
 
+  // a non-finite solution is not checked for here: it leaves error_best negative below, which is reported and returned
+  // as a solver failure in both builds
   eigen_vec_x = eigen_rate_matrix_lu.solve(eigen_balance_vector);
-  assert_always(eigen_vec_x.allFinite());
 
 #endif
 
@@ -1067,7 +1077,10 @@ template <typename GetDiagElement>
     const double error = eigen_vec_residual.cwiseAbs().maxCoeff();
 #endif
 
-    if ((std::isfinite(error) && (error < error_best)) || error_best < 0.) {
+    // only ever store a finite error, so that a non-finite iteration cannot latch error_best and block a later
+    // iteration from being accepted. If every iteration is non-finite then error_best stays negative and the solve is
+    // reported as a failure below.
+    if (std::isfinite(error) && (error_best < 0. || error < error_best)) {
       std::ranges::copy(vec_x, vec_x_best.begin());
       error_best = error;
     }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2018,6 +2018,21 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
 
   THREADLOCALONHOST std::array<double, SFPTS> yvec_arr{};
 
+  // Both branches below require sfmatrix to be upper triangular, so the check belongs here rather than in either one.
+  // The GSL branch is the one that silently depends on it: it passes the full matrix to gsl_linalg_LU_solve with an
+  // identity permutation, so anything left below the diagonal would be taken as the unit-lower factor L and a
+  // different system would be solved. The Eigen branch is correct by construction via triangularView<Upper>().
+  assert_testmodeonly([sfmatrix] {
+    for (int i = 1; i < SFPTS; i++) {
+      for (int j = 0; j < i; j++) {
+        if (sfmatrix[(i * SFPTS) + j] != 0.) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }());
+
 #ifdef EIGEN_OFF
 
   auto gsl_yvec = gsl_vector_view_array(yvec_arr.data(), SFPTS).vector;
@@ -2039,7 +2054,6 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
 
   const Eigen::Map<const Eigen::Vector<double, SFPTS>> eigen_rhsvec{rhsvec.data()};
   const Eigen::Map<const Eigen::Matrix<double, SFPTS, SFPTS, Eigen::RowMajor>> eigen_sfmatrix{sfmatrix.data()};
-  assert_testmodeonly(eigen_sfmatrix.isUpperTriangular());
 
   const auto eigen_sfmatrix_LU = eigen_sfmatrix.triangularView<Eigen::Upper>();
   Eigen::Map<Eigen::Vector<double, SFPTS>> eigen_yvec{yvec_arr.data()};
@@ -2077,7 +2091,10 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
     const double error = eigen_residual_vec.cwiseAbs().maxCoeff();
 #endif
 
-    if (error < error_best || error_best < 0.) {
+    // only ever store a finite error, so that a non-finite iteration cannot latch error_best and block a later
+    // iteration from being accepted. If every iteration is non-finite then error_best stays negative and the assertion
+    // below fails.
+    if (std::isfinite(error) && (error_best < 0. || error < error_best)) {
       std::ranges::copy(yvec_arr, yvec_best.begin());
       error_best = error;
     }


### PR DESCRIPTION
## Context

ARTIS builds its linear algebra against either Eigen (default) or GSL (`make EIGEN=OFF`). Two solvers carry `#ifdef EIGEN_OFF` branches: `nltepop_matrix_solve` (NLTE level populations) and `sfmatrix_solve` (Spencer-Fano).

The codebase already treats drift between these branches as a hazard — `lumatrix_is_singular` was deliberately factored out as a shared template so "the log messages cannot drift apart". Three divergences had nonetheless crept in where the two builds do *different things* on the same input, rather than merely differing in round-off. CI compiles `EIGEN=OFF` but never runs it, so none of them were visible.

## The three fixes

**1. Eigen hard-aborted where GSL recovered gracefully.** Three `assert_always(...allFinite())` calls existed only in the Eigen branch, and `assert_always` is live in every build (the Makefile never defines `NDEBUG`). Since `nltepop_matrix_solve` is contractually a `return false` function with a real recovery path (`NLTE_LIMIT_ION_STAGES_AFTER_FAILURE` → `can_remove_ion` retries with a narrower ion range), a non-finite rate matrix killed the run under Eigen but was recovered under GSL.

The two input checks became one backend-independent check above the `#ifdef` that logs and returns false. The third — on the solution vector — is dropped, because the existing `error_best` logic already reports a non-finite solution in both builds; the assert had made that path dead code under Eigen.

**2. A precondition was asserted only in the branch that doesn't need it.** `isUpperTriangular()` was checked only under Eigen, which is correct by construction via `triangularView<Upper>()`. It is the *GSL* branch that silently depends on the property: it passes the full matrix to `gsl_linalg_LU_solve` with an identity permutation, so a stray nonzero below the diagonal would be taken as the unit-lower factor `L` and a different system solved. This was the one wrong-answer divergence rather than a crash. The check is now shared and still testmode-only.

**3. `error_best` latched on NaN.** The two solvers guarded the best-so-far selection differently, and neither form recovers once `error_best` is non-finite — a NaN on the first refinement iteration latches it permanently, since every subsequent comparison against NaN is false. Both now store only finite errors, so a transient NaN no longer blocks a later iteration from being accepted. The all-NaN failure modes are unchanged.

## Results are unchanged

No checksum regeneration needed. `tests/nebular_1d_3dgrid` (which exercises both solvers, including the `NLTE_LIMIT_ION_STAGES_AFTER_FAILURE` fallback) was run baseline-vs-changed on one machine: **all 26 output checksums identical in the Eigen build, and identical in the `EIGEN=OFF` build.**

Also verified:
- Eigen and `EIGEN=OFF`, each with and without `TESTMODE=ON` — all four compile clean under `-Werror`. The TESTMODE builds matter, since `assert_testmodeonly` bodies are not compiled at all otherwise.
- A `TESTMODE=ON EIGEN=OFF` run completes with no assertion or sanitizer failures, so the new triangularity check holds on real SF matrices.
- Unit tests pass for the classic (53/53) and nebular (52/52) presets.

Incidentally, measured on this test: `spec.out`, `light_curve.out` and `deposition.out` come out bit-identical between the two backends. They differ only in `nlte_*.out`, `radfield_*.out`, `estimators_*.out` and `packets*.out`, and every differing value is below 1e-6 of its file's maximum — the largest relative differences are on level populations ~1e-27 of the peak.

## Deliberately out of scope

Scoped to behavioural divergences only. Noted but not touched: the residual sign convention differs between branches (GSL `A·x−b`, Eigen `b−A·x`) under the same variable name; GSL does a redundant GEMV per refinement iteration since `LU_refine` already computes the residual internally; `gsl_linalg_LU_decomp` is called inside `assert_always`; `gsl_set_error_handler_off()` is never called, so GSL's default handler bare-aborts; `sfmatrix_solve` has no singularity check in either branch (both die, only the diagnostics differ); and the Spencer-Fano refinement loop has no early exit where the NLTE one breaks at `error < 1e-40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
