### PR TITLE
Report where the Spencer-Fano matrix stops being solvable

### DIFF
--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <functional>
 #include <ios>
+#include <iterator>
 #include <numeric>
 #include <ranges>
 #include <span>
@@ -2013,7 +2014,8 @@ void sfmatrix_add_ionisation(std::span<double> sfmatrixuppertri, const int Z, co
 // solve the Spencer-Fano matrix equation and return the y vector (samples of the Spencer-Fano solution function).
 // Multiply y by energy interval [eV] to get non-thermal electron number flux. y(E) * dE is the flux of electrons with
 // energy in the range (E, E + dE) in units of particles/cm2/s. y has units of particles/cm2/s/eV
-auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double, SFPTS> {
+auto sfmatrix_solve(const std::span<const double> sfmatrix, const int modelgridindex, const int timestep,
+                    const double nne) -> std::array<double, SFPTS> {
   // solve the matrix-vector equation sfmatrix * yvec = rhsvec for yvec
 
   THREADLOCALONHOST std::array<double, SFPTS> yvec_arr{};
@@ -2032,6 +2034,45 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
     }
     return true;
   }());
+
+  // Both branches below need every element to be finite and every diagonal element to be non-zero: the matrix is upper
+  // triangular, so it is solved by back-substitution, which divides by each diagonal element in turn and accumulates
+  // the off-diagonal ones. Checked here rather than in either branch so that both builds stop at the same point with
+  // the same message. Otherwise GSL aborts inside gsl_linalg_LU_solve via its own singularity test and the default
+  // error handler, naming neither the cell nor the energy point, while Eigen's triangularView<Upper>().solve() does
+  // not check at all and divides by zero, failing only later on a non-finite residual that points at the refinement
+  // loop rather than the cause. nltepop_matrix_solve checks its own matrix the same way.
+
+  // an off-diagonal non-finite element is just as fatal as a diagonal one, because back-substitution accumulates it
+  // into every solution component below it
+  const auto nonfinite = std::ranges::find_if_not(sfmatrix, [](const double x) { return std::isfinite(x); });
+  if (nonfinite != sfmatrix.end()) {
+    const auto flatindex = std::ranges::distance(sfmatrix.begin(), nonfinite);
+    printlnlog(
+        "  [error] cell {} ts {}: Spencer-Fano matrix element [{}][{}] is non-finite ({:g}) (nne={:g} [e-/cm^3])",
+        modelgridindex, timestep, flatindex / SFPTS, flatindex % SFPTS, *nonfinite, nne);
+  }
+  assert_always(nonfinite == sfmatrix.end());
+
+  // A zero diagonal usually means the cell has no free electrons: electron_loss_rate() returns exactly zero for
+  // nne <= 0, and nothing else reaches the diagonal when every ion is below MIN_ION_OVER_NNTOT.
+  int zero_diag_count = 0;
+  int zero_diag_first = -1;
+  for (int i = 0; i < SFPTS; i++) {
+    if (sfmatrix[(i * SFPTS) + i] == 0.) {
+      zero_diag_count++;
+      if (zero_diag_first < 0) {
+        zero_diag_first = i;
+      }
+    }
+  }
+  if (zero_diag_count > 0) {
+    printlnlog(
+        "  [error] cell {} ts {}: Spencer-Fano matrix is singular: {} of {} diagonal elements are zero, first at "
+        "energy point {} ({:g} [eV]) (nne={:g} [e-/cm^3])",
+        modelgridindex, timestep, zero_diag_count, SFPTS, zero_diag_first, engrid(zero_diag_first), nne);
+  }
+  assert_always(zero_diag_count == 0);
 
 #ifdef EIGEN_OFF
 
@@ -2577,7 +2618,7 @@ void solve_spencerfano(const int nonemptymgi, const int timestep, const int iter
   }
 
   decompactify_triangular_matrix(sfmatrix);
-  const auto yfunc = sfmatrix_solve(sfmatrix);
+  const auto yfunc = sfmatrix_solve(sfmatrix, modelgridindex, timestep, nne);
   constexpr bool verbose = false;
   analyse_sf_solution(nonemptymgi, timestep, yfunc, verbose);
 }


### PR DESCRIPTION
Follow-up to #486, which catalogued this but left it out of scope.

> **Updated after self-review.** The first version of this PR checked only the diagonal. That let a non-finite element *off* the diagonal through, producing exactly the misleading failure this PR exists to remove — verified by injecting an off-diagonal NaN, which fell straight through to `assert_always(error_best >= 0.)`. The check now covers the whole matrix, matching what `nltepop_matrix_solve` already does.

## The problem

`sfmatrix_solve` had no check on the matrix it was about to solve, unlike its sibling `nltepop_matrix_solve`, which rejects a non-finite rate matrix and then checks the LU diagonal via `lumatrix_is_singular`. The Spencer-Fano matrix is upper triangular and solved by back-substitution, which divides by each diagonal element in turn and accumulates the off-diagonal ones. An unusable element sent the two backends down different paths, none of which said what had gone wrong:

| input | GSL | Eigen |
|---|---|---|
| zero diagonal | aborts inside `gsl_linalg_LU_solve` via its own singularity test and the default error handler — names neither cell nor energy point, writes nothing to `output_<rank>-0.txt` | `triangularView<Upper>().solve()` does not check; divides by zero and fails later on a non-finite residual, pointing at the refinement loop |
| non-finite element (on or off diagonal) | not caught — misleading refinement-loop failure | not caught — misleading refinement-loop failure |

## The change

Two checks above the `#ifdef`, shared by both builds:

1. **Every element must be finite** — the same criterion `nltepop_matrix_solve` applies to its whole matrix, which is why it covers off-diagonal entries too. Reports the offending row and column.
2. **Every diagonal element must be non-zero** — reports the count, and the first offending energy point with its energy.

Both report the cell, timestep and `nne`. `nne` is there because it is the likely cause of a zero diagonal: `electron_loss_rate()` returns exactly zero for `nne <= 0`, and nothing else reaches the diagonal when every ion is below `MIN_ION_OVER_NNTOT`, so a cell with no free electrons produces one. The comment on `electron_loss_rate` records that `nne` genuinely reaches zero, since `MINPOP = 1e-40` is a float denormal that `-ffast-math` flushes to zero. The upstream `MINDEPRATE` guard does not cover this — it keys on deposition rate, not `nne`.

`sfmatrix_solve` gains `modelgridindex`, `timestep` and `nne` parameters; the sole caller already has all three in scope.

**The run still stops, exactly as before.** `sfmatrix_solve` returns by value and has no failure channel. Giving the solver a fallback would be a behaviour change — `solve_spencerfano`'s existing `skip_solution` path (Axelrod values) is the natural place for that if it is ever wanted. Only the diagnostic changes here.

## Verified

Both failure modes, confirmed by temporary injection:

```
[error] cell 0 ts 5: Spencer-Fano matrix element [7][9] is non-finite (nan) (nne=207192 [e-/cm^3])
[rank 0] nonthermal.cc:2055: failed assertion `nonfinite == sfmatrix.end()`

[error] cell 0 ts 5: Spencer-Fano matrix is singular: 1 of 4096 diagonal elements
are zero, first at energy point 7 (27.4503 [eV]) (nne=207192 [e-/cm^3])
[rank 2] nonthermal.cc:2074: failed assertion `zero_diag_count == 0`
```

Also checked that `isfinite` is not optimised away in the default `-ffast-math` build — it is not, because [Makefile:248](Makefile#L248) also passes `-fno-finite-math-only`. Confirmed by running the NaN injection against a default build.

Results are unchanged, so the stored checksums do not need regenerating:

- `tests/nebular_1d_3dgrid` run baseline-vs-changed on one machine — all 26 output checksums identical in the Eigen build **and** in the `EIGEN=OFF` build.
- The added full-matrix scan costs about 2% of wall time (30.75 s vs 30.10 s), against a solve that already streams the matrix a dozen times.
- All four configurations compile clean: Eigen and `EIGEN=OFF`, each with and without `TESTMODE=ON`.
- Unit tests pass for the classic (53/53) and nebular (52/52) presets.

## Caveat

It is **not** confirmed that an unusable matrix arises in a real model. The `nne == 0` route is open in the code and documented by the `electron_loss_rate` comment, but proving it happens in practice was not attempted. This change improves the diagnostic without claiming the failure is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
