### PR TITLE
Make the NLTE solver reject non-finite solutions in both linear algebra backends and judge convergence by backward error

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -839,16 +839,19 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
         popvec[index] = ltepop;
       }
     } else {
-      // A non-finite population is unrecoverable, and has to be rejected before the triage below, because every
-      // comparison there is false for a NaN: the MINPOP ground check, the -MINPOP negative check, and the inversion
-      // factors. Without this, NaN and +inf reach the "rounding error to zero" branch, are replaced by MINPOP, and
-      // the solve is reported as successful - which then satisfies the assert_always(std::isfinite(pop)) in
-      // nltepop_apply_solution instead of tripping it.
+      // A non-finite population (reachable via the popvec[i] = vec_x[i] * pop_normfactors[i] denormalisation
+      // product overflowing - the solver itself rejects a non-finite solution vector through the residual score)
+      // fails every comparison in the triage below, so without this rejection it would pass through unhandled and
+      // trip the assert_always(std::isfinite(pop)) in nltepop_apply_solution, aborting the run instead of letting
+      // the caller drop an ion stage and retry.
       if (!std::isfinite(population)) {
         printlnlog(
             "  [warning] cell {} ts {}: NLTE solver gave non-finite population for index {} (Z={} ionstage {} level "
             "{}), pop = {:g}. Returning nltepop_matrix_solve failure",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
+        // clear the failed attempt so that can_remove_ion's triage reads zeros, as it does after a singular-matrix
+        // failure, rather than non-finite values whose comparisons would all be meaningless
+        std::ranges::fill(popvec, 0.);
         return false;
       }
 
@@ -964,15 +967,21 @@ template <typename GetDiagElement>
   return is_singular;
 }
 
-// Largest absolute element of a vector, propagating non-finite elements: as soon as one is found, its magnitude
-// (inf or nan) is returned instead of the largest finite magnitude.
-// Neither backend's own reduction can be used for this, because neither propagates a NaN reliably and the two drop
-// them in different places, so the same residual can be scored differently by the two builds. gslcblas's idamax
-// seeds its running maximum at zero and selects with a bare `>`, so it skips a NaN in any position and only returns
-// one when every element is NaN. Eigen's maxCoeff defaults to PropagateFast, which Eigen documents as giving an
-// undefined result for NaN; in practice it keeps the running maximum on the left of the comparison, so it returns a
-// NaN only when the first element is one. Either way a solution vector that is entirely garbage can be scored with a
-// small finite residual and accepted. (An infinity does propagate through both.)
+// The non-finite detection in this solver relies on std::isfinite and NaN comparisons keeping their IEEE semantics,
+// which the FASTMATH build preserves only because -fno-finite-math-only is appended after -ffast-math (Makefile).
+#if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__
+#error \
+    "the NLTE solver requires std::isfinite to detect NaN/inf: compile without -ffinite-math-only (see FASTMATH in the Makefile)"
+#endif
+
+// Largest absolute element of a vector, except that the magnitude of the first non-finite element (inf or nan) is
+// returned as soon as one is found - so callers must test the result only with std::isfinite, never distinguishing
+// inf from nan. Neither linear algebra backend's own reduction is usable here, because neither propagates a NaN
+// reliably and the two drop them in different positions, so the same residual could be scored differently by the two
+// builds: gslcblas's idamax selects with a bare `>` comparison, which a NaN never satisfies, and Eigen's default
+// maxCoeff uses PropagateFast, which Eigen documents as undefined for NaN (its scalar and SIMD paths genuinely
+// differ). Eigen does provide maxCoeff<PropagateNaN>, but GSL has no counterpart, and scoring through one shared
+// scalar function guarantees the two builds agree.
 [[nodiscard]] auto max_abs_propagate_nonfinite(const std::span<const double> values) -> double {
   double maxabs = 0.;
   for (const double value : values) {
@@ -985,27 +994,33 @@ template <typename GetDiagElement>
   return maxabs;
 }
 
-// The size of the largest row of |balance_vector| + |rate_matrix| * |x|, i.e. of the terms that were differenced to
-// form the residual balance_vector - rate_matrix * x.
-// The residual on its own is not a convergence measure. nltepop_matrix_normalise() row-scales row i by
-// 1/pop_normfactors[i], so the residual keeps physical units: cm^-3 for the row-0 population normalisation
-// constraint (where the right hand side is the element number density) and cm^-3 s^-1 for the statistical
-// equilibrium rows. Dividing by this scale gives a dimensionless backward error that a fixed tolerance can
-// meaningfully be compared against. A single scalar scale is representative of every row because the matrix has
-// already been equilibrated.
-[[nodiscard]] auto get_residual_scale(const std::span<const double> rate_matrix,
-                                      const std::span<const double> balance_vector, const std::span<const double> vec_x)
-    -> double {
+// The largest componentwise relative backward error of a solution: max_i |b_i - (A*x)_i| / (|b_i| + sum_j |A_ij *
+// x_j|), i.e. each row's residual measured against the size of the terms that were differenced to form it. The
+// residual on its own is not a convergence measure: nltepop_matrix_normalise() rescales each row by an arbitrary
+// accumulated balancing factor, so the raw residual elements carry no fixed physical magnitude, while in the
+// per-row ratio those factors cancel. The measure must be per-row rather than a single normwise scale because the
+// equilibration only balances each row's norm against its column's, never rows against each other, and with
+// FORCE_SAHA_ION_BALANCE the constraint rows carry right hand sides that differ by many orders of magnitude - a
+// normwise ratio would let a badly violated small-scale row hide behind the largest row. A row whose scale is
+// exactly zero has an exactly zero residual and is skipped.
+[[nodiscard]] auto get_max_relative_residual(const std::span<const double> rate_matrix,
+                                             const std::span<const double> balance_vector,
+                                             const std::span<const double> vec_x) -> double {
   const auto nlte_dimension = balance_vector.size();
-  double scale = 0.;
+  double max_relative_residual = 0.;
   for (auto i = 0ZU; i < nlte_dimension; i++) {
+    double rowdot = 0.;
     double rowscale = std::abs(balance_vector[i]);
     for (auto j = 0ZU; j < nlte_dimension; j++) {
-      rowscale += std::abs(rate_matrix[(i * nlte_dimension) + j] * vec_x[j]);
+      const double term = rate_matrix[(i * nlte_dimension) + j] * vec_x[j];
+      rowdot += term;
+      rowscale += std::abs(term);
     }
-    scale = std::max(scale, rowscale);
+    if (rowscale > 0.) {
+      max_relative_residual = std::max(max_relative_residual, std::abs(balance_vector[i] - rowdot) / rowscale);
+    }
   }
-  return scale;
+  return max_relative_residual;
 }
 
 // solve rate_matrix * x = balance_vector, so that popvec[i] = x[i] * pop_normfactors[i]
@@ -1059,7 +1074,6 @@ template <typename GetDiagElement>
   auto gsl_balance_vector = gsl_vector_const_view_array(balance_vector.data(), nlte_dimension).vector;
 
   int s = 0;  // sign of the transformation
-  // the decomposition is a side effect, so it must not be written inside the assertion
   const int lu_decomp_status = gsl_linalg_LU_decomp(&gsl_rate_matrix_LU_decomp, &p, &s);
   assert_always(lu_decomp_status == GSL_SUCCESS);
 
@@ -1110,11 +1124,12 @@ template <typename GetDiagElement>
   vec_residual.reserve(max_nlte_dimension);
   vec_residual.resize(nlte_dimension);
 
-  // correction applied to the solution vector by the iterative refinement below. Eigen needs a buffer distinct from
-  // vec_residual because its solve begins with dst = P * rhs, which would alias, and assigning the solve to its own
-  // vector also avoids `vec_x += lu.solve(...)`, for which Eigen has no in-place assignment specialisation and so
-  // heap-allocates a temporary on every iteration. The GSL branch could solve in place on vec_residual, but shares
-  // the buffer so that both branches read the residual and write the correction.
+  // correction applied to the solution vector by the iterative refinement below. A named buffer distinct from
+  // vec_residual is a symmetry choice, not a necessity - the GSL branch could solve in place on the residual, and
+  // Eigen's solve handles an aliased destination by materialising the permuted right hand side into a temporary -
+  // but with it both branches read the residual and write the correction, and the assignment form avoids the extra
+  // evaluator temporary that Eigen heap-allocates for `vec_x += lu.solve(...)` on every iteration (the internal
+  // permuted-rhs temporary inside solve remains either way).
   THREADLOCALONHOST std::vector<double> vec_correction;
   vec_correction.reserve(max_nlte_dimension);
   vec_correction.resize(nlte_dimension);
@@ -1127,12 +1142,9 @@ template <typename GetDiagElement>
   auto eigen_vec_correction = Eigen::Map<Eigen::VectorX<double>>(vec_correction.data(), nlte_dimension);
 #endif
 
-  // counted rather than taken from the loop variable afterwards, which would be short by one whenever the loop
-  // exits through the break below
-  int iterations_done = 0;
-  int iteration_best = -1;
-  for (int iteration = 0; iteration < 10; iteration++) {
-    iterations_done = iteration + 1;
+  constexpr int maxiterations = 10;
+  int iteration_best = -1;  // 1-based pass that produced vec_x_best (pass 1 is the unrefined LU solution)
+  for (int iteration = 0; iteration < maxiterations; iteration++) {
     // one step of iterative refinement, x <- x + A^-1 (b - A x), using the residual left by the previous iteration.
     // Spelled out in both branches rather than calling gsl_linalg_LU_refine (which performs exactly these steps
     // internally) so that the two builds run the same operations in the same order under the same sign convention,
@@ -1168,12 +1180,12 @@ template <typename GetDiagElement>
     if (std::isfinite(error) && (error_best < 0. || error < error_best)) {
       std::ranges::copy(vec_x, vec_x_best.begin());
       error_best = error;
-      iteration_best = iterations_done;
+      iteration_best = iteration + 1;
     }
 
-    // only an exactly zero residual can reach this: the residual carries the units described at get_residual_scale(),
-    // so 1e-40 is far below the rounding level of the dot products that form it. Deliberately not converted into a
-    // usable relative tolerance, which would truncate the best-of-ten selection above and change the solution.
+    // deliberately not converted into a usable relative tolerance, which would truncate the best-of-ten selection
+    // above and change the solution. As an absolute threshold on residual rows that carry arbitrary equilibration
+    // factors, it is unreachable in any realistic solve, so every solve runs all of the refinement passes.
     if (error < 1e-40) {
       break;
     }
@@ -1186,19 +1198,17 @@ template <typename GetDiagElement>
   }
   std::ranges::copy(vec_x_best, vec_x.begin());
 
-  // error_best carries units, so it is compared against the size of the terms it was formed from rather than against
-  // a fixed constant. Element number densities span at least 1e6 to 1e11 cm^-3 between the nebular and photospheric
-  // regimes, so an absolute threshold either fires on every healthy solve or never fires at all.
-  const double residual_scale = get_residual_scale(rate_matrix, balance_vector, vec_x);
-  // fall back to the unscaled residual if the scale is unusable, so that a bad solve is still reported
-  const double error_best_relative =
-      (residual_scale > 0. && std::isfinite(residual_scale)) ? (error_best / residual_scale) : error_best;
-  if (error_best_relative > 1e-8) {
+  // error_best carries arbitrary per-row equilibration factors, so convergence is judged by the componentwise
+  // relative backward error rather than by comparison against a fixed absolute constant, which either fired on
+  // every healthy solve or never fired at all depending only on the element number density.
+  constexpr double relative_residual_warn_tolerance = 1e-8;
+  const double max_relative_residual = get_max_relative_residual(rate_matrix, balance_vector, vec_x);
+  if (max_relative_residual > relative_residual_warn_tolerance) {
     printlnlog(
-        "  [warning] cell {} ts {}: NLTE solver iterative refinement: after {} iterations, the best solution vector "
-        "was the one from iteration {}, with a max residual of {:g} ({:g} relative to the size of the terms it was "
-        "formed from)",
-        nltelog.modelgridindex, nltelog.timestep, iterations_done, iteration_best, error_best, error_best_relative);
+        "  [warning] cell {} ts {}: NLTE solver iterative refinement: the best solution vector was from pass {} of "
+        "up to {} (pass 1 is the unrefined LU solution), with a max residual of {:g} in the equilibrated system and "
+        "a max componentwise relative backward error of {:g}",
+        nltelog.modelgridindex, nltelog.timestep, iteration_best, maxiterations, error_best, max_relative_residual);
   }
 
   // get the unnormalised populations from the x solution vector and the normalisation factors

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -847,7 +847,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
       if (!std::isfinite(population)) {
         printlnlog(
             "  [warning] cell {} ts {}: NLTE solver gave non-finite population for index {} (Z={} ionstage {} level "
-            "{}), pop = {:g}. Returning nltepop_matrix_solve fail",
+            "{}), pop = {:g}. Returning nltepop_matrix_solve failure",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         return false;
       }
@@ -857,7 +857,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
       if (index == index_ion_ground && population < MINPOP) {
         printlnlog(
             "  [warning] cell {} ts {}: NLTE solver gave ground pop less than MINPOP for index {} (Z={} ionstage {} "
-            "level {}), pop = {:g}. Returning nltepop_matrix_solve fail",
+            "level {}), pop = {:g}. Returning nltepop_matrix_solve failure",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         return false;
       }
@@ -870,7 +870,7 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
         if (population < -MINPOP) {
           printlnlog(
               "  [warning] negative pop = {:g} less than -MINPOP (-{:g}) unlikely a rounding error to zero so "
-              "returning nltepop_matrix_solve fail",
+              "returning nltepop_matrix_solve failure",
               population, MINPOP);
           return false;
         }
@@ -966,10 +966,13 @@ template <typename GetDiagElement>
 
 // Largest absolute element of a vector, propagating non-finite elements: as soon as one is found, its magnitude
 // (inf or nan) is returned instead of the largest finite magnitude.
-// Neither backend's own reduction can be used for this, and they fail in different directions on the same input:
-// gslcblas's idamax seeds its running maximum at zero and selects with a bare `>`, so it never picks a NaN, and
-// Eigen's maxCoeff defaults to PropagateFast, which Eigen documents as giving an undefined result for NaN. Either
-// one can score a solution vector that is entirely garbage with a small finite residual.
+// Neither backend's own reduction can be used for this, because neither propagates a NaN reliably and the two drop
+// them in different places, so the same residual can be scored differently by the two builds. gslcblas's idamax
+// seeds its running maximum at zero and selects with a bare `>`, so it skips a NaN in any position and only returns
+// one when every element is NaN. Eigen's maxCoeff defaults to PropagateFast, which Eigen documents as giving an
+// undefined result for NaN; in practice it keeps the running maximum on the left of the comparison, so it returns a
+// NaN only when the first element is one. Either way a solution vector that is entirely garbage can be scored with a
+// small finite residual and accepted. (An infinity does propagate through both.)
 [[nodiscard]] auto max_abs_propagate_nonfinite(const std::span<const double> values) -> double {
   double maxabs = 0.;
   for (const double value : values) {
@@ -1087,10 +1090,11 @@ template <typename GetDiagElement>
     return false;
   }
 
-  // a non-finite solution is not checked for here: row 0 of the rate matrix is the population normalisation
-  // constraint, so it is dense with non-zero coefficients, and its residual element below is finite only if every
-  // element of the solution vector is. A non-finite solution therefore leaves error_best negative, which is reported
-  // and returned as a solver failure in both builds.
+  // a non-finite solution is not checked for here: every column of the rate matrix has a non-zero element (an
+  // all-zero column would make the matrix singular, which is rejected above), so a non-finite element of the solution
+  // vector makes at least one element of the residual below non-finite, wherever it lands, and
+  // max_abs_propagate_nonfinite() reports that as a non-finite error. It then leaves error_best negative, which is
+  // reported and returned as a solver failure in both builds.
   eigen_vec_x = eigen_rate_matrix_lu.solve(eigen_balance_vector);
 
 #endif
@@ -1123,9 +1127,12 @@ template <typename GetDiagElement>
   auto eigen_vec_correction = Eigen::Map<Eigen::VectorX<double>>(vec_correction.data(), nlte_dimension);
 #endif
 
-  int iteration = 0;
+  // counted rather than taken from the loop variable afterwards, which would be short by one whenever the loop
+  // exits through the break below
+  int iterations_done = 0;
   int iteration_best = -1;
-  for (iteration = 0; iteration < 10; iteration++) {
+  for (int iteration = 0; iteration < 10; iteration++) {
+    iterations_done = iteration + 1;
     // one step of iterative refinement, x <- x + A^-1 (b - A x), using the residual left by the previous iteration.
     // Spelled out in both branches rather than calling gsl_linalg_LU_refine (which performs exactly these steps
     // internally) so that the two builds run the same operations in the same order under the same sign convention,
@@ -1161,7 +1168,7 @@ template <typename GetDiagElement>
     if (std::isfinite(error) && (error_best < 0. || error < error_best)) {
       std::ranges::copy(vec_x, vec_x_best.begin());
       error_best = error;
-      iteration_best = iteration;
+      iteration_best = iterations_done;
     }
 
     // only an exactly zero residual can reach this: the residual carries the units described at get_residual_scale(),
@@ -1183,13 +1190,15 @@ template <typename GetDiagElement>
   // a fixed constant. Element number densities span at least 1e6 to 1e11 cm^-3 between the nebular and photospheric
   // regimes, so an absolute threshold either fires on every healthy solve or never fires at all.
   const double residual_scale = get_residual_scale(rate_matrix, balance_vector, vec_x);
-  const double error_best_relative = (residual_scale > 0.) ? (error_best / residual_scale) : error_best;
+  // fall back to the unscaled residual if the scale is unusable, so that a bad solve is still reported
+  const double error_best_relative =
+      (residual_scale > 0. && std::isfinite(residual_scale)) ? (error_best / residual_scale) : error_best;
   if (error_best_relative > 1e-8) {
     printlnlog(
         "  [warning] cell {} ts {}: NLTE solver iterative refinement: after {} iterations, the best solution vector "
         "was the one from iteration {}, with a max residual of {:g} ({:g} relative to the size of the terms it was "
         "formed from)",
-        nltelog.modelgridindex, nltelog.timestep, iteration, iteration_best, error_best, error_best_relative);
+        nltelog.modelgridindex, nltelog.timestep, iterations_done, iteration_best, error_best, error_best_relative);
   }
 
   // get the unnormalised populations from the x solution vector and the normalisation factors

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -839,6 +839,19 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
         popvec[index] = ltepop;
       }
     } else {
+      // A non-finite population is unrecoverable, and has to be rejected before the triage below, because every
+      // comparison there is false for a NaN: the MINPOP ground check, the -MINPOP negative check, and the inversion
+      // factors. Without this, NaN and +inf reach the "rounding error to zero" branch, are replaced by MINPOP, and
+      // the solve is reported as successful - which then satisfies the assert_always(std::isfinite(pop)) in
+      // nltepop_apply_solution instead of tripping it.
+      if (!std::isfinite(population)) {
+        printlnlog(
+            "  [warning] cell {} ts {}: NLTE solver gave non-finite population for index {} (Z={} ionstage {} level "
+            "{}), pop = {:g}. Returning nltepop_matrix_solve fail",
+            nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
+        return false;
+      }
+
       // if groundpop is below MINPOP then the NLTE solution fails
       const size_t index_ion_ground = get_nlte_vector_index(element, ion, 0, first_ion_used);
       if (index == index_ion_ground && population < MINPOP) {
@@ -849,9 +862,9 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
         return false;
       }
 
-      if (population < 0.0 || !std::isfinite(population)) {
+      if (population < 0.0) {
         printlnlog(
-            "  [warning] cell {} ts {}: NLTE solver gave negative/non-finite population for index {} (Z={} ionstage {} "
+            "  [warning] cell {} ts {}: NLTE solver gave negative population for index {} (Z={} ionstage {} "
             "level {}), pop = {:g}",
             nltelog.modelgridindex, nltelog.timestep, index, get_atomicnumber(element), ionstage, level, population);
         if (population < -MINPOP) {
@@ -951,6 +964,47 @@ template <typename GetDiagElement>
   return is_singular;
 }
 
+// Largest absolute element of a vector, propagating non-finite elements: as soon as one is found, its magnitude
+// (inf or nan) is returned instead of the largest finite magnitude.
+// Neither backend's own reduction can be used for this, and they fail in different directions on the same input:
+// gslcblas's idamax seeds its running maximum at zero and selects with a bare `>`, so it never picks a NaN, and
+// Eigen's maxCoeff defaults to PropagateFast, which Eigen documents as giving an undefined result for NaN. Either
+// one can score a solution vector that is entirely garbage with a small finite residual.
+[[nodiscard]] auto max_abs_propagate_nonfinite(const std::span<const double> values) -> double {
+  double maxabs = 0.;
+  for (const double value : values) {
+    const double absvalue = std::abs(value);
+    if (!std::isfinite(absvalue)) {
+      return absvalue;
+    }
+    maxabs = std::max(maxabs, absvalue);
+  }
+  return maxabs;
+}
+
+// The size of the largest row of |balance_vector| + |rate_matrix| * |x|, i.e. of the terms that were differenced to
+// form the residual balance_vector - rate_matrix * x.
+// The residual on its own is not a convergence measure. nltepop_matrix_normalise() row-scales row i by
+// 1/pop_normfactors[i], so the residual keeps physical units: cm^-3 for the row-0 population normalisation
+// constraint (where the right hand side is the element number density) and cm^-3 s^-1 for the statistical
+// equilibrium rows. Dividing by this scale gives a dimensionless backward error that a fixed tolerance can
+// meaningfully be compared against. A single scalar scale is representative of every row because the matrix has
+// already been equilibrated.
+[[nodiscard]] auto get_residual_scale(const std::span<const double> rate_matrix,
+                                      const std::span<const double> balance_vector, const std::span<const double> vec_x)
+    -> double {
+  const auto nlte_dimension = balance_vector.size();
+  double scale = 0.;
+  for (auto i = 0ZU; i < nlte_dimension; i++) {
+    double rowscale = std::abs(balance_vector[i]);
+    for (auto j = 0ZU; j < nlte_dimension; j++) {
+      rowscale += std::abs(rate_matrix[(i * nlte_dimension) + j] * vec_x[j]);
+    }
+    scale = std::max(scale, rowscale);
+  }
+  return scale;
+}
+
 // solve rate_matrix * x = balance_vector, so that popvec[i] = x[i] * pop_normfactors[i]
 // return true if the solution is successful, or false if the matrix is singular, contains negative or inverted
 // populations.
@@ -1002,7 +1056,9 @@ template <typename GetDiagElement>
   auto gsl_balance_vector = gsl_vector_const_view_array(balance_vector.data(), nlte_dimension).vector;
 
   int s = 0;  // sign of the transformation
-  assert_always(gsl_linalg_LU_decomp(&gsl_rate_matrix_LU_decomp, &p, &s) == GSL_SUCCESS);
+  // the decomposition is a side effect, so it must not be written inside the assertion
+  const int lu_decomp_status = gsl_linalg_LU_decomp(&gsl_rate_matrix_LU_decomp, &p, &s);
+  assert_always(lu_decomp_status == GSL_SUCCESS);
 
   if (lumatrix_is_singular([&](const size_t i) { return rate_matrix_LU_decomp[(i * nlte_dimension) + i]; },
                            nlte_dimension, element, first_ion_used, nions_used)) {
@@ -1031,8 +1087,10 @@ template <typename GetDiagElement>
     return false;
   }
 
-  // a non-finite solution is not checked for here: it leaves error_best negative below, which is reported and returned
-  // as a solver failure in both builds
+  // a non-finite solution is not checked for here: row 0 of the rate matrix is the population normalisation
+  // constraint, so it is dense with non-zero coefficients, and its residual element below is finite only if every
+  // element of the solution vector is. A non-finite solution therefore leaves error_best negative, which is reported
+  // and returned as a solver failure in both builds.
   eigen_vec_x = eigen_rate_matrix_lu.solve(eigen_balance_vector);
 
 #endif
@@ -1048,34 +1106,54 @@ template <typename GetDiagElement>
   vec_residual.reserve(max_nlte_dimension);
   vec_residual.resize(nlte_dimension);
 
+  // correction applied to the solution vector by the iterative refinement below. Eigen needs a buffer distinct from
+  // vec_residual because its solve begins with dst = P * rhs, which would alias, and assigning the solve to its own
+  // vector also avoids `vec_x += lu.solve(...)`, for which Eigen has no in-place assignment specialisation and so
+  // heap-allocates a temporary on every iteration. The GSL branch could solve in place on vec_residual, but shares
+  // the buffer so that both branches read the residual and write the correction.
+  THREADLOCALONHOST std::vector<double> vec_correction;
+  vec_correction.reserve(max_nlte_dimension);
+  vec_correction.resize(nlte_dimension);
+
 #ifdef EIGEN_OFF
   auto gsl_vec_residual = gsl_vector_view_array(vec_residual.data(), nlte_dimension).vector;
+  auto gsl_vec_correction = gsl_vector_view_array(vec_correction.data(), nlte_dimension).vector;
 #else
   auto eigen_vec_residual = Eigen::Map<Eigen::VectorX<double>>(vec_residual.data(), nlte_dimension);
+  auto eigen_vec_correction = Eigen::Map<Eigen::VectorX<double>>(vec_correction.data(), nlte_dimension);
 #endif
 
   int iteration = 0;
+  int iteration_best = -1;
   for (iteration = 0; iteration < 10; iteration++) {
+    // one step of iterative refinement, x <- x + A^-1 (b - A x), using the residual left by the previous iteration.
+    // Spelled out in both branches rather than calling gsl_linalg_LU_refine (which performs exactly these steps
+    // internally) so that the two builds run the same operations in the same order under the same sign convention,
+    // and so that the GSL build does not form the residual twice per iteration.
 #ifdef EIGEN_OFF
     if (iteration > 0) {
-      // use gsl_vec_residual as the temporary work vector
-      gsl_linalg_LU_refine(&gsl_rate_matrix, &gsl_rate_matrix_LU_decomp, &p, &gsl_balance_vector, &gsl_x,
-                           &gsl_vec_residual);
+      std::ranges::copy(vec_residual, vec_correction.begin());
+      gsl_linalg_LU_svx(&gsl_rate_matrix_LU_decomp, &p, &gsl_vec_correction);
+      gsl_blas_daxpy(1., &gsl_vec_correction, &gsl_x);
     }
 
+    // residual = b - A x
     std::ranges::copy(balance_vector, vec_residual.begin());
-    gsl_blas_dgemv(CblasNoTrans, 1.0, &gsl_rate_matrix, &gsl_x, -1.0,
-                   &gsl_vec_residual);  // calculate Ax - b = residual
-
-    const double error = fabs(gsl_vector_get(
-        &gsl_vec_residual, gsl_blas_idamax(&gsl_vec_residual)));  // value of the largest absolute residual
+    gsl_blas_dgemv(CblasNoTrans, -1., &gsl_rate_matrix, &gsl_x, 1., &gsl_vec_residual);
 #else
     if (iteration > 0) {
-      eigen_vec_x += eigen_rate_matrix_lu.solve(eigen_vec_residual);
+      eigen_vec_correction = eigen_rate_matrix_lu.solve(eigen_vec_residual);
+      eigen_vec_x += eigen_vec_correction;
     }
+
+    // residual = b - A x
     eigen_vec_residual = eigen_balance_vector - eigen_rate_matrix * eigen_vec_x;
-    const double error = eigen_vec_residual.cwiseAbs().maxCoeff();
 #endif
+
+    // computed outside the backend switch so that the two builds cannot score the same residual differently. For an
+    // all-finite residual this is exactly the largest absolute element, i.e. what each backend's own reduction
+    // returns today.
+    const double error = max_abs_propagate_nonfinite(vec_residual);
 
     // only ever store a finite error, so that a non-finite iteration cannot latch error_best and block a later
     // iteration from being accepted. If every iteration is non-finite then error_best stays negative and the solve is
@@ -1083,7 +1161,12 @@ template <typename GetDiagElement>
     if (std::isfinite(error) && (error_best < 0. || error < error_best)) {
       std::ranges::copy(vec_x, vec_x_best.begin());
       error_best = error;
+      iteration_best = iteration;
     }
+
+    // only an exactly zero residual can reach this: the residual carries the units described at get_residual_scale(),
+    // so 1e-40 is far below the rounding level of the dot products that form it. Deliberately not converted into a
+    // usable relative tolerance, which would truncate the best-of-ten selection above and change the solution.
     if (error < 1e-40) {
       break;
     }
@@ -1096,11 +1179,17 @@ template <typename GetDiagElement>
   }
   std::ranges::copy(vec_x_best, vec_x.begin());
 
-  if (error_best > 1e-8) {
+  // error_best carries units, so it is compared against the size of the terms it was formed from rather than against
+  // a fixed constant. Element number densities span at least 1e6 to 1e11 cm^-3 between the nebular and photospheric
+  // regimes, so an absolute threshold either fires on every healthy solve or never fires at all.
+  const double residual_scale = get_residual_scale(rate_matrix, balance_vector, vec_x);
+  const double error_best_relative = (residual_scale > 0.) ? (error_best / residual_scale) : error_best;
+  if (error_best_relative > 1e-8) {
     printlnlog(
-        "  [warning] cell {} ts {}: NLTE solver matrix LU_refine: after {} iterations, best solution vector has a max "
-        "residual of {:g}",
-        nltelog.modelgridindex, nltelog.timestep, iteration, error_best);
+        "  [warning] cell {} ts {}: NLTE solver iterative refinement: after {} iterations, the best solution vector "
+        "was the one from iteration {}, with a max residual of {:g} ({:g} relative to the size of the terms it was "
+        "formed from)",
+        nltelog.modelgridindex, nltelog.timestep, iteration, iteration_best, error_best, error_best_relative);
   }
 
   // get the unnormalised populations from the x solution vector and the normalisation factors


### PR DESCRIPTION
## Context

`nltepop_matrix_solve` carries an `#ifdef EIGEN_OFF` split between GSL (`make EIGEN=OFF`) and Eigen (the default). #486 fixed three divergences where the two builds *crashed* differently on the same input, and listed the remaining known ones. CI compiles `EIGEN=OFF` but never runs it, so the GSL path has no regression coverage.

Re-auditing the two branches turned up a wrong-answer divergence, not just a diagnostic one, plus two backend-independent numerical defects downstream of it. This PR fixes all three, makes the two refinement branches read line-for-line the same, and replaces a meaningless convergence diagnostic with a well-defined one.

## Defect 1: the error metric was a different function in each branch, and neither was NaN-safe

The refinement loop decides whether a solve succeeded from `error = max|residual|`. Measured directly against gslcblas 2.7.1 and the vendored Eigen:

| residual vector | GSL `idamax` | Eigen `maxCoeff` |
|---|---|---|
| NaN at index 0, finite elsewhere | `3e-50` | `nan` |
| NaN in the middle | `3e-50` | `3e-50` |
| NaN at the end | `3e-50` | `3e-50` |
| all NaN | `nan` | `nan` |
| `+inf` in the middle | `inf` | `inf` |
| all finite (control) | `5.5` | `5.5` |

gslcblas's `idamax` selects with a bare `>` comparison, which a NaN never satisfies. Eigen's `maxCoeff` defaults to `PropagateFast`, documented as undefined for NaN (its scalar and SIMD paths genuinely differ; the scalar path propagates only a NaN in the first element).

Index 0 is exactly where this solver puts it: row 0 is the dense population normalisation constraint, so a NaN anywhere in the solution vector poisons `residual[0]`. On that input the Eigen build reported a non-finite `error`, never latched the garbage, and returned false — letting the caller drop an ion stage and retry — while the GSL build got a small finite `error` from one of the many rows the sparse matrix leaves finite, latched the garbage solution, satisfied the `error < 1e-40` early exit and **accepted it**. The Eigen build's rejection was incidental, not guaranteed: it depended on the NaN's position and on a reduction order Eigen documents as undefined. Neither build was safe.

**Fix:** `error` is computed once, outside the backend switch, by a shared scalar helper that propagates a non-finite element from any position (Eigen provides `maxCoeff<PropagateNaN>`, but GSL has no counterpart, and one shared function guarantees the builds agree). For an all-finite residual it returns exactly what each backend returned before. A `#error` guard rejects `-ffinite-math-only` builds, which would silently disable the entire non-finite detection scheme.

## Defect 2: a non-finite population was laundered into MINPOP and reported as success

Under `STRICT_POPULATION_CHECKING`, every comparison in `solution_pops_are_valid`'s triage is false for a NaN: the `MINPOP` ground check, the `-MINPOP` negative check, and both inversion factors. NaN and `+inf` fell through to the "likely a rounding error to zero" branch, were overwritten with `MINPOP`, and the solve was reported successful — which then satisfies the `assert_always(std::isfinite(pop))` in `nltepop_apply_solution` rather than tripping it. Only `-inf` was handled correctly.

**Fix:** a non-finite population — reachable via the denormalisation product `vec_x[i] * pop_normfactors[i]` overflowing, since the solver itself now rejects non-finite solution vectors through the residual score — fails the solve up front, and `popvec` is zero-filled on that failure so `can_remove_ion`'s retry triage reads zeros (as after a singular-matrix failure) rather than non-finite values whose comparisons are meaningless. The negative branch keeps its rounding-error logic for the finite values it was written for.

## Defect 3: the convergence warning compared a dimensional residual against a fixed constant

`nltepop_matrix_normalise` rescales each row by an arbitrary accumulated balancing factor, so the residual elements carry no fixed physical magnitude, and the old absolute `error_best > 1e-8` test compared that against a pure number. Measured on `nltephotospheric_dynamic_ion_range_1d_1dgrid` (n_Fe ~ 1e11 cm^-3), rank 0 alone emitted **45** such warnings under Eigen and **46** under GSL, all on healthy solves — and every log line is flushed. On `nebular_1d_3dgrid` it never fired: the absolute threshold either spams or stays silent depending only on density. Its printed iteration count was also off by one on early exit and never identified which pass produced the accepted solution.

**Fix:** convergence is judged by the **componentwise relative backward error**, `max_i |b_i − (A·x)_i| / (|b_i| + Σ_j|A_ij·x_j|)`, in one O(n²) pass over the equilibrated system. Per-row rather than normwise is load-bearing: the equilibration balances each row's norm against its column's, never rows against each other, and with `FORCE_SAHA_ION_BALANCE` the constraint rows carry right-hand sides differing by many orders of magnitude, so a global ratio would let a badly violated small-scale row hide behind the largest row; the arbitrary per-row factors cancel in the ratio. The warning names the refinement pass that produced the best solution (pass 1 being the unrefined LU solution).

## The refinement loop now reads the same in both branches

The GSL branch called `gsl_linalg_LU_refine` (which forms the residual internally) and then formed `A·x − b` *again* with its own GEMV, while the Eigen branch used `b − A·x` under the same variable name. Both branches now read `correction = A⁻¹·residual; x += correction; residual = b − A·x`, with the `#ifdef` covering only the backend calls (`LU_svx` + `daxpy` on the GSL side) and the error scored below it. This drops one of the two O(n²) passes the GSL build did per refinement iteration, and the shared named correction buffer avoids the evaluator temporary Eigen heap-allocated for `x += lu.solve(r)` on every iteration (the buffer is a symmetry choice — Eigen handles an aliased solve destination correctly). Also hoisted `gsl_linalg_LU_decomp` out of the `assert_always` that was performing the decomposition as a side effect.

## Results are unchanged

Baseline-vs-changed regression runs on one machine, `REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2`, against the same `origin/develop` baseline, at the head commit:

| Test | Eigen | `EIGEN=OFF` |
|---|---|---|
| `nebular_1d_3dgrid` | 26/26 identical | 26/26 identical |
| `nltephotospheric_dynamic_ion_range_1d_1dgrid` | 27/27 identical | 27/27 identical |

The baseline Eigen run of `nebular_1d_3dgrid` reproduces the stored CI checksums exactly, so the comparison is against the same numbers CI checks. (In the photospheric test three files — one `nlte_*.out`, two `radfield_*.out` — differ from the stored checksums both before and after the change: a pre-existing g++-14 vs g++-15 difference, not one introduced here.)

The `EIGEN=OFF` results being bit-identical is the empirical backing for the claim that replacing `gsl_linalg_LU_refine` with `LU_svx` + `daxpy`, and flipping the GEMV's alpha/beta, is an exact negation at every step. The componentwise measure — strictly more sensitive than a normwise one — fires zero warnings on healthy solves of both models under both backends.

Also verified:
- All four of {Eigen, `EIGEN=OFF`} × {default, `TESTMODE=ON`} compile clean under `-Werror` (the `TESTMODE=ON` builds matter, since `assert_testmodeonly` bodies are not compiled otherwise).
- A `TESTMODE=ON EIGEN=OFF` run completes with no assertion or sanitizer failure.
- Unit tests pass for the classic (53/53) and nebular (52/52) presets.
- clang-format is clean and clang-tidy reports no diagnostics beyond the three pre-existing ones.

## Deliberately out of scope

`sfmatrix_solve` in `nonthermal.cc` has the identical NaN-blind error metric, where the consequence is a failed `assert_always(error_best >= 0.)` rather than a corrupted population — left for a separate change. Also untouched: the `error < 1e-40` early exit, which is effectively dead but cannot become a usable relative tolerance without truncating the best-of-ten selection and changing the solution; the fixed count of ten refinement iterations; in-place GSL solving (would reintroduce the branch asymmetry this PR removes); and `gsl_set_error_handler_off()`, which this solver does not need because `lumatrix_is_singular` already rejects the only input that would make GSL abort.

https://claude.ai/code/session_01MsXwyCR7wwnCgnxvCqzq4C