### PR TITLE
Remove the optional GSL dependency and simplify the Eigen-only solver code

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -125,10 +125,10 @@ jobs:
                   echo "OMPI_CXX=clang++-${{ matrix.compiler.ver }}" >> $GITHUB_ENV
                   echo "LDFLAGS=-L/usr/lib/llvm-${{ matrix.compiler.ver }}/lib" >> $GITHUB_ENV
 
-            - name: Install Open MPI and GSL
+            - name: Install Open MPI
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev libgsl-dev
+                  sudo apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev
 
             - name: Install TBB
               if: matrix.compiler.name == 'gcc'
@@ -167,12 +167,6 @@ jobs:
               run: |
                   make -j$(nproc) unittests
                   ./unittests
-
-            - name: Compile nebular mode EIGEN=OFF
-              run: |
-                  cp -v -p artisoptions_nltenebular.h artisoptions.h
-                  make clean
-                  make -j$(nproc) EIGEN=OFF sn3d exspec
 
             - name: Compile nebular mode OPENMP=ON
               run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,10 +25,10 @@ jobs:
                   echo "CXX=g++-14" >> $GITHUB_ENV
                   echo "OMPI_CXX=g++-14" >> $GITHUB_ENV
 
-            - name: Install Open MPI, GSL, and TBB
+            - name: Install Open MPI and TBB
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev libgsl-dev libtbb-dev
+                  sudo apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev libtbb-dev
 
             - name: Set artisoptions to nltenebular
               run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,7 @@ that everything compiles (this is what the pre-commit hook runs).
 
 Useful make options (see README for the full list): `TESTMODE=ON` (assertions +
 address/UB sanitizers), `REPRODUCIBLE=ON`, `FASTMATH=OFF`, `OPTIMIZE=OFF`,
-`EIGEN=OFF` (use GSL instead of Eigen), `OPENMP=ON`, `STDPAR=ON`, `GPU=ON`,
-`MAX_NODE_SIZE=N`.
+`OPENMP=ON`, `STDPAR=ON`, `GPU=ON`, `MAX_NODE_SIZE=N`.
 
 The build uses `-Werror` with extensive warnings — new warnings break CI.
 

--- a/Makefile
+++ b/Makefile
@@ -187,20 +187,6 @@ ifeq ($(shell uname -s),Darwin)
 	# CXXFLAGS += -Rpass-analysis=loop-vectorize
 endif
 
-ifeq ($(EIGEN),OFF)
-	BUILD_DIR := $(BUILD_DIR)_eigenoff
-
-	# if EIGEN is off, we need GSL for linear algebra
-	CXXFLAGS += -DEIGEN_OFF $(shell pkg-config --cflags gsl) -DHAVE_INLINE -DGSL_C99_INLINE
-
-	# static linking
-	gsllibdir := $(shell pkg-config --variable=libdir gsl)
-	gsl_objects = $(gsllibdir)/libgsl.a $(gsllibdir)/libgslcblas.a
-
-	# dynamic linking
-# 	LDFLAGS += $(shell pkg-config --libs gsl)
-endif
-
 ifneq ($(MAX_NODE_SIZE),)
 	CXXFLAGS += -DMAX_NODE_SIZE=$(MAX_NODE_SIZE)
 endif
@@ -220,10 +206,6 @@ ifeq ($(TESTMODE),ON)
 	CXXFLAGS += -fsanitize=undefined,address
 
 	BUILD_DIR := $(BUILD_DIR)_testmode
-else
-	ifeq ($(GSL),ON)
-		CXXFLAGS += -DGSL_RANGE_CHECK_OFF
-	endif
 endif
 
 ifeq ($(OPTIMIZE),OFF)
@@ -334,28 +316,28 @@ check: $(sn3d_files)
 	run-clang-tidy $(sn3d_files)
 
 $(BUILD_DIR)/sn3d: $(sn3d_objects)
-	$(CXX) $(CXXFLAGS) $(sn3d_objects) $(gsl_objects) $(LDFLAGS) -o $(BUILD_DIR)/sn3d
+	$(CXX) $(CXXFLAGS) $(sn3d_objects) $(LDFLAGS) -o $(BUILD_DIR)/sn3d
 -include $(sn3d_dep)
 
 sn3d: $(BUILD_DIR)/sn3d
 	ln -sf $(BUILD_DIR)/sn3d sn3d
 
 $(BUILD_DIR)/sn3dwhole: $(sn3d_files) version.h artisoptions.h Makefile
-	$(CXX) $(CXXFLAGS) $(sn3d_files) $(gsl_objects) $(LDFLAGS) -o $(BUILD_DIR)/sn3dwhole
+	$(CXX) $(CXXFLAGS) $(sn3d_files) $(LDFLAGS) -o $(BUILD_DIR)/sn3dwhole
 -include $(sn3d_dep)
 
 sn3dwhole: $(BUILD_DIR)/sn3dwhole
 	ln -sf $(BUILD_DIR)/sn3dwhole sn3d
 
 $(BUILD_DIR)/exspec: $(exspec_objects)
-	$(CXX) $(CXXFLAGS) $(exspec_objects) $(gsl_objects) $(LDFLAGS) -o $(BUILD_DIR)/exspec
+	$(CXX) $(CXXFLAGS) $(exspec_objects) $(LDFLAGS) -o $(BUILD_DIR)/exspec
 -include $(exspec_dep)
 
 exspec: $(BUILD_DIR)/exspec
 	ln -sf $(BUILD_DIR)/exspec exspec
 
 $(BUILD_DIR)/unittests: $(unittests_objects)
-	$(CXX) $(CXXFLAGS) $(unittests_objects) $(gsl_objects) $(LDFLAGS) -o $(BUILD_DIR)/unittests
+	$(CXX) $(CXXFLAGS) $(unittests_objects) $(LDFLAGS) -o $(BUILD_DIR)/unittests
 -include $(unittests_dep)
 
 unittests: $(BUILD_DIR)/unittests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cd artis
 ```
 On macOS, it's recommended that you install homebrew llvm to get clang-format, clang-tidy, clangd language server, and the clang C++ compiler. You can install this and other dependencies with:
 ```sh
-brew install llvm open-mpi gsl prek compiledb
+brew install llvm open-mpi prek compiledb
 ```
 Install the pre-commit hooks and generate a compilation database for clang tools:
 ```sh
@@ -142,7 +142,6 @@ source ./setup_kilonova_1d.sh   # creates tests/kilonova_1d_testrun/
 ## Make options
 - TESTMODE=ON: Enable additional assertions and the address and undefined behaviour sanitizers.
 - FASTMATH=OFF: Don't enable compiler transformations that affect round-off-level results (e.g. a*(b\*c) = (a\*b)*c).
-- EIGEN=OFF: Use GSL (not Eigen) for matrix-vector solving (Spencer-Fano and NLTE pops).
 - MAX_NODE_SIZE=N: Artificially limit MPI node size to N ranks. Useful for testing and preventing MPI shared memory windows from crossing CPU sockets.
 - REPRODUCIBLE=ON: Use stable sorts and disable FASTMATH.
 - GPU=ON: Required to compile for GPUs. Works around incompatible function calls and uses a Simpson-rule integrator in place of Gauss-Kronrod.

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -21,18 +21,8 @@
 #include <vector>
 
 #pragma clang unsafe_buffer_usage begin
-#ifdef EIGEN_OFF
-#include <gsl/gsl_blas.h>
-#include <gsl/gsl_cblas.h>
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_linalg.h>
-#include <gsl/gsl_matrix_double.h>
-#include <gsl/gsl_permutation.h>
-#include <gsl/gsl_vector_double.h>
-#else
 #include <Eigen/Core>
 #include <Eigen/Dense>
-#endif
 #pragma clang unsafe_buffer_usage end
 
 #include "artisoptions.h"
@@ -937,16 +927,17 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   return true;
 }
 
+// row-major so that the rate matrix assembled in a flat std::vector can be mapped without a copy
+using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+
 // Check the diagonal of an LU decomposition for zero or non-finite elements, which indicate levels that are
 // disconnected from the rest of the NLTE rate matrix. Reports and returns true if the matrix is singular.
-// Shared between the GSL and Eigen builds so that the log messages cannot drift apart.
-template <typename GetDiagElement>
-[[nodiscard]] auto lumatrix_is_singular(GetDiagElement getdiagelement, const size_t nlte_dimension, const int element,
-                                        const int first_ion_used, const int nions_used) -> bool {
+[[nodiscard]] auto lumatrix_is_singular(const RowMajorMatrixXd& lumatrix, const int element, const int first_ion_used,
+                                        const int nions_used) -> bool {
   bool is_singular = false;
-  for (auto i = 0ZU; i < nlte_dimension; i++) {
+  for (Eigen::Index i = 0; i < lumatrix.rows(); i++) {
     // diagonal elements of LU matrix must be non-zero and finite
-    const double matrixelement = getdiagelement(i);
+    const double matrixelement = lumatrix(i, i);
     if (matrixelement == 0. || !std::isfinite(matrixelement)) {
       if (!is_singular) {
         printlog("  [error] cell {} ts {}: NLTE matrix is singular for element Z={} (disconnected:",
@@ -973,26 +964,6 @@ template <typename GetDiagElement>
 #error \
     "the NLTE solver requires std::isfinite to detect NaN/inf: compile without -ffinite-math-only (see FASTMATH in the Makefile)"
 #endif
-
-// Largest absolute element of a vector, except that the magnitude of the first non-finite element (inf or nan) is
-// returned as soon as one is found - so callers must test the result only with std::isfinite, never distinguishing
-// inf from nan. Neither linear algebra backend's own reduction is usable here, because neither propagates a NaN
-// reliably and the two drop them in different positions, so the same residual could be scored differently by the two
-// builds: gslcblas's idamax selects with a bare `>` comparison, which a NaN never satisfies, and Eigen's default
-// maxCoeff uses PropagateFast, which Eigen documents as undefined for NaN (its scalar and SIMD paths genuinely
-// differ). Eigen does provide maxCoeff<PropagateNaN>, but GSL has no counterpart, and scoring through one shared
-// scalar function guarantees the two builds agree.
-[[nodiscard]] auto max_abs_propagate_nonfinite(const std::span<const double> values) -> double {
-  double maxabs = 0.;
-  for (const double value : values) {
-    const double absvalue = std::abs(value);
-    if (!std::isfinite(absvalue)) {
-      return absvalue;
-    }
-    maxabs = std::max(maxabs, absvalue);
-  }
-  return maxabs;
-}
 
 // The largest componentwise relative backward error of a solution: max_i |b_i - (A*x)_i| / (|b_i| + sum_j |A_ij *
 // x_j|), i.e. each row's residual measured against the size of the terms that were differenced to form it. The
@@ -1036,9 +1007,8 @@ template <typename GetDiagElement>
   assert_always(rate_matrix.size() == (nlte_dimension * nlte_dimension));
   assert_always(std::cmp_greater_equal(max_nlte_dimension, nlte_dimension));
 
-  // A non-finite entry anywhere makes the solve meaningless. Checked here rather than in the backend-specific code
-  // below so that both builds react the same way: report and return false, which lets the caller drop an ion stage and
-  // retry, instead of aborting the run.
+  // A non-finite entry anywhere makes the solve meaningless. Report and return false, which lets the caller drop an
+  // ion stage and retry, instead of aborting the run.
   const auto is_finite = [](const double x) { return std::isfinite(x); };
   if (!std::ranges::all_of(rate_matrix, is_finite) || !std::ranges::all_of(balance_vector, is_finite)) {
     printlnlog(
@@ -1052,68 +1022,24 @@ template <typename GetDiagElement>
   vec_x.reserve(max_nlte_dimension);
   vec_x.resize(nlte_dimension);
 
-#ifdef EIGEN_OFF
-
-  THREADLOCALONHOST std::vector<double> rate_matrix_LU_decomp;
-  rate_matrix_LU_decomp.reserve(static_cast<ptrdiff_t>(max_nlte_dimension) * max_nlte_dimension);
-  rate_matrix_LU_decomp.resize(rate_matrix.size());
-
-  // make a copy of the rate matrix for the LU decomp call as gsl_linalg_LU_decomp modifies the input matrix
-  std::ranges::copy(rate_matrix, rate_matrix_LU_decomp.begin());
-  auto gsl_rate_matrix_LU_decomp =
-      gsl_matrix_view_array(rate_matrix_LU_decomp.data(), nlte_dimension, nlte_dimension).matrix;
-  auto gsl_x = gsl_vector_view_array(vec_x.data(), nlte_dimension).vector;
-  auto gsl_rate_matrix = gsl_matrix_const_view_array(rate_matrix.data(), nlte_dimension, nlte_dimension).matrix;
-
-  THREADLOCALONHOST std::vector<size_t> vec_permutation;
-  vec_permutation.reserve(max_nlte_dimension);
-  vec_permutation.resize(nlte_dimension);
-  gsl_permutation_struct p{.size = nlte_dimension, .data = vec_permutation.data()};
-  gsl_permutation_init(&p);
-
-  auto gsl_balance_vector = gsl_vector_const_view_array(balance_vector.data(), nlte_dimension).vector;
-
-  int s = 0;  // sign of the transformation
-  const int lu_decomp_status = gsl_linalg_LU_decomp(&gsl_rate_matrix_LU_decomp, &p, &s);
-  assert_always(lu_decomp_status == GSL_SUCCESS);
-
-  if (lumatrix_is_singular([&](const size_t i) { return rate_matrix_LU_decomp[(i * nlte_dimension) + i]; },
-                           nlte_dimension, element, first_ion_used, nions_used)) {
-    return false;
-  }
-
-  // solve matrix equation: rate_matrix * x = balance_vector for x (population vector)
-  gsl_linalg_LU_solve(&gsl_rate_matrix_LU_decomp, &p, &gsl_balance_vector, &gsl_x);
-
-#else
-
   auto eigen_vec_x = Eigen::Map<Eigen::VectorX<double>>(vec_x.data(), nlte_dimension);
   const auto eigen_balance_vector = Eigen::Map<const Eigen::VectorX<double>>(balance_vector.data(), nlte_dimension);
 
-  const auto eigen_rate_matrix =
-      Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
-          rate_matrix.data(), nlte_dimension, nlte_dimension);
+  const auto eigen_rate_matrix = Eigen::Map<const RowMajorMatrixXd>(rate_matrix.data(), nlte_dimension, nlte_dimension);
 
-  THREADLOCALONHOST Eigen::PartialPivLU<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
-      eigen_rate_matrix_lu;
+  THREADLOCALONHOST Eigen::PartialPivLU<RowMajorMatrixXd> eigen_rate_matrix_lu;
 
   eigen_rate_matrix_lu.compute(eigen_rate_matrix);
-  if (lumatrix_is_singular(
-          [&](const size_t i) { return eigen_rate_matrix_lu.matrixLU().diagonal()[static_cast<ptrdiff_t>(i)]; },
-          nlte_dimension, element, first_ion_used, nions_used)) {
+  if (lumatrix_is_singular(eigen_rate_matrix_lu.matrixLU(), element, first_ion_used, nions_used)) {
     return false;
   }
 
   // a non-finite solution is not checked for here: every column of the rate matrix has a non-zero element (an
   // all-zero column would make the matrix singular, which is rejected above), so a non-finite element of the solution
-  // vector makes at least one element of the residual below non-finite, wherever it lands, and
-  // max_abs_propagate_nonfinite() reports that as a non-finite error. It then leaves error_best negative, which is
-  // reported and returned as a solver failure in both builds.
+  // vector makes at least one element of the residual below non-finite, wherever it lands, and the residual reduction
+  // reports that as a non-finite error. It then leaves error_best negative, which is reported and returned as a
+  // solver failure.
   eigen_vec_x = eigen_rate_matrix_lu.solve(eigen_balance_vector);
-
-#endif
-
-  double error_best = -1.;
 
   // population solution vector with lowest error
   THREADLOCALONHOST std::vector<double> vec_x_best;
@@ -1124,42 +1050,21 @@ template <typename GetDiagElement>
   vec_residual.reserve(max_nlte_dimension);
   vec_residual.resize(nlte_dimension);
 
-  // correction applied to the solution vector by the iterative refinement below. A named buffer distinct from
-  // vec_residual is a symmetry choice, not a necessity - the GSL branch could solve in place on the residual, and
-  // Eigen's solve handles an aliased destination by materialising the permuted right hand side into a temporary -
-  // but with it both branches read the residual and write the correction, and the assignment form avoids the extra
-  // evaluator temporary that Eigen heap-allocates for `vec_x += lu.solve(...)` on every iteration (the internal
-  // permuted-rhs temporary inside solve remains either way).
+  // correction applied to the solution vector by the iterative refinement below. Solving into a named buffer and
+  // adding it on avoids the evaluator temporary that Eigen heap-allocates for `vec_x += lu.solve(...)` on every
+  // iteration (the permuted-rhs temporary inside solve itself remains either way).
   THREADLOCALONHOST std::vector<double> vec_correction;
   vec_correction.reserve(max_nlte_dimension);
   vec_correction.resize(nlte_dimension);
 
-#ifdef EIGEN_OFF
-  auto gsl_vec_residual = gsl_vector_view_array(vec_residual.data(), nlte_dimension).vector;
-  auto gsl_vec_correction = gsl_vector_view_array(vec_correction.data(), nlte_dimension).vector;
-#else
   auto eigen_vec_residual = Eigen::Map<Eigen::VectorX<double>>(vec_residual.data(), nlte_dimension);
   auto eigen_vec_correction = Eigen::Map<Eigen::VectorX<double>>(vec_correction.data(), nlte_dimension);
-#endif
 
   constexpr int maxiterations = 10;
+  double error_best = -1.;
   int iteration_best = -1;  // 1-based pass that produced vec_x_best (pass 1 is the unrefined LU solution)
   for (int iteration = 0; iteration < maxiterations; iteration++) {
-    // one step of iterative refinement, x <- x + A^-1 (b - A x), using the residual left by the previous iteration.
-    // Spelled out in both branches rather than calling gsl_linalg_LU_refine (which performs exactly these steps
-    // internally) so that the two builds run the same operations in the same order under the same sign convention,
-    // and so that the GSL build does not form the residual twice per iteration.
-#ifdef EIGEN_OFF
-    if (iteration > 0) {
-      std::ranges::copy(vec_residual, vec_correction.begin());
-      gsl_linalg_LU_svx(&gsl_rate_matrix_LU_decomp, &p, &gsl_vec_correction);
-      gsl_blas_daxpy(1., &gsl_vec_correction, &gsl_x);
-    }
-
-    // residual = b - A x
-    std::ranges::copy(balance_vector, vec_residual.begin());
-    gsl_blas_dgemv(CblasNoTrans, -1., &gsl_rate_matrix, &gsl_x, 1., &gsl_vec_residual);
-#else
+    // one step of iterative refinement, x <- x + A^-1 (b - A x), using the residual left by the previous iteration
     if (iteration > 0) {
       eigen_vec_correction = eigen_rate_matrix_lu.solve(eigen_vec_residual);
       eigen_vec_x += eigen_vec_correction;
@@ -1167,12 +1072,10 @@ template <typename GetDiagElement>
 
     // residual = b - A x
     eigen_vec_residual = eigen_balance_vector - eigen_rate_matrix * eigen_vec_x;
-#endif
 
-    // computed outside the backend switch so that the two builds cannot score the same residual differently. For an
-    // all-finite residual this is exactly the largest absolute element, i.e. what each backend's own reduction
-    // returns today.
-    const double error = max_abs_propagate_nonfinite(vec_residual);
+    // PropagateNaN is required for the non-finite detection below: Eigen documents the default (PropagateFast) as
+    // undefined in the presence of a NaN, and its scalar and SIMD paths genuinely differ there.
+    const double error = eigen_vec_residual.cwiseAbs().maxCoeff<Eigen::PropagateNaN>();
 
     // only ever store a finite error, so that a non-finite iteration cannot latch error_best and block a later
     // iteration from being accepted. If every iteration is non-finite then error_best stays negative and the solve is

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2041,7 +2041,11 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
       eigen_yvec += eigen_sfmatrix_upper.solve(eigen_residual_vec);
     }
     eigen_residual_vec = eigen_rhsvec - eigen_sfmatrix * eigen_yvec;
-    const double error = eigen_residual_vec.cwiseAbs().maxCoeff();
+
+    // PropagateNaN is required for the non-finite test below: Eigen documents the default (PropagateFast) as
+    // undefined in the presence of a NaN, and its scalar and SIMD paths genuinely differ there, so a NaN residual
+    // could otherwise be scored as a finite value and accepted. For an all-finite residual the two agree exactly.
+    const double error = eigen_residual_vec.cwiseAbs().maxCoeff<Eigen::PropagateNaN>();
 
     // only ever store a finite error, so that a non-finite iteration cannot latch error_best and block a later
     // iteration from being accepted. If every iteration is non-finite then error_best stays negative and the assertion

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -22,17 +22,8 @@
 #include <vector>
 
 #pragma clang unsafe_buffer_usage begin
-#ifdef EIGEN_OFF
-#include <gsl/gsl_blas.h>
-#include <gsl/gsl_cblas.h>
-#include <gsl/gsl_linalg.h>
-#include <gsl/gsl_matrix_double.h>
-#include <gsl/gsl_permutation.h>
-#include <gsl/gsl_vector_double.h>
-#else
 #include <Eigen/Core>
 #include <Eigen/Dense>
-#endif
 #pragma clang unsafe_buffer_usage end
 
 #include "artisoptions.h"
@@ -2018,10 +2009,9 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
 
   THREADLOCALONHOST std::array<double, SFPTS> yvec_arr{};
 
-  // Both branches below require sfmatrix to be upper triangular, so the check belongs here rather than in either one.
-  // The GSL branch is the one that silently depends on it: it passes the full matrix to gsl_linalg_LU_solve with an
-  // identity permutation, so anything left below the diagonal would be taken as the unit-lower factor L and a
-  // different system would be solved. The Eigen branch is correct by construction via triangularView<Upper>().
+  // The solve below reads only the upper triangle (via triangularView<Upper>()) while the residual is formed from the
+  // full matrix, so anything left below the diagonal would make the refinement iterate on a different system than the
+  // one that was solved.
   assert_testmodeonly([sfmatrix] {
     for (int i = 1; i < SFPTS; i++) {
       for (int j = 0; j < i; j++) {
@@ -2033,63 +2023,25 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
     return true;
   }());
 
-#ifdef EIGEN_OFF
-
-  auto gsl_yvec = gsl_vector_view_array(yvec_arr.data(), SFPTS).vector;
-  const auto gsl_rhsvec = gsl_vector_const_view_array(rhsvec.data(), SFPTS).vector;
-
-  THREADLOCALONHOST std::array<size_t, SFPTS> vec_permutation{};
-  gsl_permutation p{.size = SFPTS, .data = vec_permutation.data()};
-  gsl_permutation_init(&p);
-
-  const auto gsl_sfmatrix = gsl_matrix_const_view_array(sfmatrix.data(), SFPTS, SFPTS).matrix;
-
-  // sfmatrix is already in upper triangular form
-  const auto& gsl_sfmatrix_LU = gsl_sfmatrix;
-
-  // solve matrix equation: sf_matrix * y_vec = rhsvec for yvec
-  gsl_linalg_LU_solve(&gsl_sfmatrix_LU, &p, &gsl_rhsvec, &gsl_yvec);
-
-#else
-
   const Eigen::Map<const Eigen::Vector<double, SFPTS>> eigen_rhsvec{rhsvec.data()};
   const Eigen::Map<const Eigen::Matrix<double, SFPTS, SFPTS, Eigen::RowMajor>> eigen_sfmatrix{sfmatrix.data()};
 
-  const auto eigen_sfmatrix_LU = eigen_sfmatrix.triangularView<Eigen::Upper>();
+  const auto eigen_sfmatrix_upper = eigen_sfmatrix.triangularView<Eigen::Upper>();
   Eigen::Map<Eigen::Vector<double, SFPTS>> eigen_yvec{yvec_arr.data()};
-  eigen_yvec = eigen_sfmatrix_LU.solve(eigen_rhsvec);
-
-#endif
+  eigen_yvec = eigen_sfmatrix_upper.solve(eigen_rhsvec);
 
   // refine the solution
 
   THREADLOCALONHOST std::array<double, SFPTS> yvec_best{};
-#ifdef EIGEN_OFF
-  THREADLOCALONHOST std::array<double, SFPTS> residual_vec{};
-  auto gsl_residual_vec = gsl_vector_view_array(residual_vec.data(), SFPTS).vector;
-#else
   THREADLOCALONHOST Eigen::Vector<double, SFPTS> eigen_residual_vec{};
-#endif
 
   double error_best = -1.;
   for (int iteration = 0; iteration < 10; iteration++) {
-#ifdef EIGEN_OFF
     if (iteration > 0) {
-      // use gsl_vec_residual as the temporary work vector
-      gsl_linalg_LU_refine(&gsl_sfmatrix, &gsl_sfmatrix_LU, &p, &gsl_rhsvec, &gsl_yvec, &gsl_residual_vec);
-    }
-    // residual = sfmatrix * yvec - rhsvec
-    std::ranges::copy(rhsvec, residual_vec.begin());
-    gsl_blas_dgemv(CblasNoTrans, 1.0, &gsl_sfmatrix, &gsl_yvec, -1.0, &gsl_residual_vec);
-    // error is the largest absolute residual element
-    const double error = fabs(gsl_vector_get(&gsl_residual_vec, gsl_blas_idamax(&gsl_residual_vec)));
-#else
-    if (iteration > 0) {
-      eigen_yvec += eigen_sfmatrix_LU.solve(eigen_residual_vec);
+      eigen_yvec += eigen_sfmatrix_upper.solve(eigen_residual_vec);
     }
     eigen_residual_vec = eigen_rhsvec - eigen_sfmatrix * eigen_yvec;
     const double error = eigen_residual_vec.cwiseAbs().maxCoeff();
-#endif
 
     // only ever store a finite error, so that a non-finite iteration cannot latch error_best and block a later
     // iteration from being accepted. If every iteration is non-finite then error_best stays negative and the assertion
@@ -2104,7 +2056,7 @@ auto sfmatrix_solve(const std::span<const double> sfmatrix) -> std::array<double
   std::ranges::copy(yvec_best, yvec_arr.begin());
 
   if (error_best > 1e-10) {
-    printlnlog("  SF solver LU_refine: best solution vector has a max residual of {:g}", error_best);
+    printlnlog("  SF solver iterative refinement: best solution vector has a max residual of {:g}", error_best);
   }
 
   assert_always(std::ranges::all_of(yvec_arr, [](double y) { return y >= 0.; }));

--- a/scripts/artis-cosma8.sh
+++ b/scripts/artis-cosma8.sh
@@ -19,7 +19,6 @@
 module purge
 module load cosma
 module load gnu_comp
-module load gsl
 module load openmpi
 module load python
 

--- a/scripts/artis-cosma8.sh
+++ b/scripts/artis-cosma8.sh
@@ -19,6 +19,8 @@
 module purge
 module load cosma
 module load gnu_comp
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load gsl
 module load openmpi
 module load python
 

--- a/scripts/artis-juwels.sh
+++ b/scripts/artis-juwels.sh
@@ -10,7 +10,7 @@
 #SBATCH --mail-type=ALL
 ##SBATCH --mail-user=luke.shingles@gmail.com
 
-module load Stages/2025 GCC ParaStationMPI GSL
+module load Stages/2025 GCC ParaStationMPI
 module load UCX-settings/plain
 
 module list

--- a/scripts/artis-juwels.sh
+++ b/scripts/artis-juwels.sh
@@ -10,7 +10,8 @@
 #SBATCH --mail-type=ALL
 ##SBATCH --mail-user=luke.shingles@gmail.com
 
-module load Stages/2025 GCC ParaStationMPI
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load Stages/2025 GCC ParaStationMPI GSL
 module load UCX-settings/plain
 
 module list

--- a/scripts/artis-kelvin2.sh
+++ b/scripts/artis-kelvin2.sh
@@ -7,6 +7,8 @@
 ##SBATCH --mail-user=fmcneill07@qub.ac.uk
 
 module load libs/gcc/14.1.0
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load gsl/2.8/gcc-14.1.0
 module load compilers/gcc/14.1.0
 module load mpi/openmpi/5.0.3/gcc-14.1.0
 module load apps/python3/3.12.4/gcc-14.1.0

--- a/scripts/artis-kelvin2.sh
+++ b/scripts/artis-kelvin2.sh
@@ -7,7 +7,6 @@
 ##SBATCH --mail-user=fmcneill07@qub.ac.uk
 
 module load libs/gcc/14.1.0
-module load gsl/2.8/gcc-14.1.0
 module load compilers/gcc/14.1.0
 module load mpi/openmpi/5.0.3/gcc-14.1.0
 module load apps/python3/3.12.4/gcc-14.1.0

--- a/scripts/artis-meluxina.sh
+++ b/scripts/artis-meluxina.sh
@@ -10,7 +10,7 @@
 #SBATCH --mail-type=ALL
 ##SBATCH --mail-user=luke.shingles@gmail.com
 
-module load env/release/2025.1 gompi/2025a zstd GSL git Python
+module load env/release/2025.1 gompi/2025a zstd git Python
 
 module list
 

--- a/scripts/artis-meluxina.sh
+++ b/scripts/artis-meluxina.sh
@@ -10,7 +10,8 @@
 #SBATCH --mail-type=ALL
 ##SBATCH --mail-user=luke.shingles@gmail.com
 
-module load env/release/2025.1 gompi/2025a zstd git Python
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load env/release/2025.1 gompi/2025a zstd GSL git Python
 
 module list
 

--- a/scripts/artis-virgo-slurmjob.sh
+++ b/scripts/artis-virgo-slurmjob.sh
@@ -8,10 +8,8 @@ export APPTAINER_SHARENS=true
 export APPTAINER_CONFIGDIR=/tmp/$USER
 
 eval `spack load --first --sh openmpi%gcc`
-eval `spack load --first --sh gsl%gcc`
 eval `spack load --first --sh gcc%gcc`
 
-export LD_LIBRARY_PATH=$(gsl-config --prefix)/lib/:$LD_LIBRARY_PATH
 export MAKEFLAGS="--check-symlink-times --jobs=$(nproc --all)"
 export OMPI_CXX=g++
 

--- a/scripts/artis-virgo-slurmjob.sh
+++ b/scripts/artis-virgo-slurmjob.sh
@@ -8,8 +8,11 @@ export APPTAINER_SHARENS=true
 export APPTAINER_CONFIGDIR=/tmp/$USER
 
 eval `spack load --first --sh openmpi%gcc`
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+eval `spack load --first --sh gsl%gcc`
 eval `spack load --first --sh gcc%gcc`
 
+export LD_LIBRARY_PATH=$(gsl-config --prefix)/lib/:$LD_LIBRARY_PATH
 export MAKEFLAGS="--check-symlink-times --jobs=$(nproc --all)"
 export OMPI_CXX=g++
 

--- a/scripts/exspec-zip-cosma8.sh
+++ b/scripts/exspec-zip-cosma8.sh
@@ -16,7 +16,6 @@
 module purge
 module load cosma
 module load gnu_comp
-module load gsl
 module load openmpi
 module load python
 

--- a/scripts/exspec-zip-cosma8.sh
+++ b/scripts/exspec-zip-cosma8.sh
@@ -16,6 +16,8 @@
 module purge
 module load cosma
 module load gnu_comp
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load gsl
 module load openmpi
 module load python
 

--- a/scripts/exspec-zip-juwels.sh
+++ b/scripts/exspec-zip-juwels.sh
@@ -11,6 +11,8 @@
 
 module load Stages/2025
 module load ParaStationMPI
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load GSL
 module load zstd/.1.5.6
 module list
 

--- a/scripts/exspec-zip-juwels.sh
+++ b/scripts/exspec-zip-juwels.sh
@@ -11,7 +11,6 @@
 
 module load Stages/2025
 module load ParaStationMPI
-module load GSL
 module load zstd/.1.5.6
 module list
 

--- a/scripts/exspec-zip-kelvin2.sh
+++ b/scripts/exspec-zip-kelvin2.sh
@@ -9,7 +9,6 @@
 ##SBATCH --mail-user=fmcneill07@qub.ac.uk
 
 module load libs/gcc/14.1.0
-module load gsl/2.8/gcc-14.1.0
 module load compilers/gcc/14.1.0
 module load mpi/openmpi/5.0.3/gcc-14.1.0
 module load apps/python3/3.12.4/gcc-14.1.0

--- a/scripts/exspec-zip-kelvin2.sh
+++ b/scripts/exspec-zip-kelvin2.sh
@@ -9,6 +9,8 @@
 ##SBATCH --mail-user=fmcneill07@qub.ac.uk
 
 module load libs/gcc/14.1.0
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load gsl/2.8/gcc-14.1.0
 module load compilers/gcc/14.1.0
 module load mpi/openmpi/5.0.3/gcc-14.1.0
 module load apps/python3/3.12.4/gcc-14.1.0

--- a/scripts/exspec-zip-meluxina.sh
+++ b/scripts/exspec-zip-meluxina.sh
@@ -9,7 +9,8 @@
 #SBATCH --mail-type=ALL
 ##SBATCH --mail-user=luke.shingles@gmail.com
 
-module load env/release/2025.1 gompi/2025a zstd git Python
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+module load env/release/2025.1 gompi/2025a zstd GSL git Python
 module list
 
 cd $SLURM_SUBMIT_DIR

--- a/scripts/exspec-zip-meluxina.sh
+++ b/scripts/exspec-zip-meluxina.sh
@@ -9,7 +9,7 @@
 #SBATCH --mail-type=ALL
 ##SBATCH --mail-user=luke.shingles@gmail.com
 
-module load env/release/2025.1 gompi/2025a zstd GSL git Python
+module load env/release/2025.1 gompi/2025a zstd git Python
 module list
 
 cd $SLURM_SUBMIT_DIR

--- a/scripts/exspec-zip-virgo-slurmjob.sh
+++ b/scripts/exspec-zip-virgo-slurmjob.sh
@@ -6,8 +6,11 @@ export APPTAINER_SHARENS=true
 export APPTAINER_CONFIGDIR=/tmp/$USER
 
 eval `spack load --first --sh openmpi%gcc`
+# GSL is no longer used by artis, but is still loaded so that these scripts work with older versions too
+eval `spack load --first --sh gsl%gcc`
 eval `spack load --first --sh gcc%gcc`
 
+export LD_LIBRARY_PATH=$(gsl-config --prefix)/lib/:$LD_LIBRARY_PATH
 export MAKEFLAGS="--check-symlink-times --jobs=$(nproc --all)"
 export OMPI_CXX=g++
 

--- a/scripts/exspec-zip-virgo-slurmjob.sh
+++ b/scripts/exspec-zip-virgo-slurmjob.sh
@@ -6,10 +6,8 @@ export APPTAINER_SHARENS=true
 export APPTAINER_CONFIGDIR=/tmp/$USER
 
 eval `spack load --first --sh openmpi%gcc`
-eval `spack load --first --sh gsl%gcc`
 eval `spack load --first --sh gcc%gcc`
 
-export LD_LIBRARY_PATH=$(gsl-config --prefix)/lib/:$LD_LIBRARY_PATH
 export MAKEFLAGS="--check-symlink-times --jobs=$(nproc --all)"
 export OMPI_CXX=g++
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -852,12 +852,6 @@ auto main(int argc, char* argv[]) -> int {
   printlnlog("Boost Gauss-Kronrod quadrature");
 #endif
 
-#ifdef EIGEN_OFF
-  printlnlog("Linear algebra solvers are from GSL");
-#else
-  printlnlog("Linear algebra solvers are from Eigen");
-#endif
-
 #ifdef WALLTIMELIMITSECONDS
   int walltimelimitseconds = WALLTIMELIMITSECONDS;
 #else


### PR DESCRIPTION
## What

Removes GSL as a build dependency. Eigen is now the only linear algebra backend, and the `EIGEN=OFF` make option is gone.

- Deleted the `#ifdef EIGEN_OFF` branches of `nltepop_matrix_solve()` (nltepop.cc) and `sfmatrix_solve()` (nonthermal.cc), and the backend `printlnlog` switch in sn3d.cc.
- Makefile: dropped the `EIGEN=OFF` block, the `gsl_objects` static-link inputs from all four link rules, and the dead `GSL=ON` → `-DGSL_RANGE_CHECK_OFF` branch (nothing ever set `GSL`).
- CI: dropped `libgsl-dev` from ci-checks.yml and copilot-setup-steps.yml, and removed the "Compile nebular mode EIGEN=OFF" job.
- Docs: dropped `gsl` from the README brew line and the `EIGEN=OFF` entry from the make-option lists in README.md and AGENTS.md.

The cluster job scripts in `scripts/` **keep** their GSL module loads. They are copied into a simulation folder and run against whatever artis checkout sits beside them, which is not necessarily this version; loading GSL costs nothing for a current build and keeps the scripts usable with older versions that still need it. Each load now carries a one-line comment saying so, which is the only change to those files.

## Why

GSL was only reachable via `EIGEN=OFF`, which CI compiled but never ran, so the branch was carried without ever being exercised on real output. In exchange, every change to the NLTE or Spencer-Fano solver had to be written twice and kept numerically in step — see the fixes in #486 and #488, which existed purely to stop the two paths from drifting apart.

## Simplifications the removal enables

- `lumatrix_is_singular()` was a template taking a diagonal-accessor lambda so the two backends could share its log messages. It now takes the LU matrix directly, and a `RowMajorMatrixXd` alias replaces three spellings of `Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>`.
- `max_abs_propagate_nonfinite()` existed only because gslcblas's `idamax` cannot propagate a NaN; its own comment noted Eigen provides `maxCoeff<PropagateNaN>` but GSL had no counterpart. The helper is gone and the residual reduction is now `eigen_vec_residual.cwiseAbs().maxCoeff<Eigen::PropagateNaN>()`. `PropagateNaN` is load-bearing — Eigen documents the default `PropagateFast` as undefined for NaN — and for an all-finite residual it returns exactly the same value as the old scalar loop.
- `sfmatrix_solve()` now scores its residual the same way. It was scoring with plain `maxCoeff()` while guarding on `std::isfinite(error)` and asserting that some pass was finite, so a NaN residual could have been scored as finite and its y-vector accepted (thanks @copilot for catching this).
- Renamed `eigen_sfmatrix_LU` → `eigen_sfmatrix_upper`. The "LU" name came from GSL being handed the matrix as its own LU factor with an identity permutation; the surviving path is a `triangularView<Upper>` with no factorisation. The `SF solver LU_refine:` log label was retitled for the same reason.
- The upper-triangular `assert_testmodeonly` in `sfmatrix_solve()` is kept, but its comment now gives the reason that still applies: the solve reads only the upper triangle while the residual is formed from the full matrix.

## Results are unchanged

`nebular_1d_3dgrid` job0, 4 ranks, `REPRODUCIBLE=ON MAX_NODE_SIZE=2 FASTMATH=OFF`, compared against a baseline built from the merge base on the same machine: **all 26 `*.out` md5s identical**, including `nlte_*.out` and `estimators_*.out`. Re-checked after the `PropagateNaN` change above, which only alters behaviour when a residual contains a NaN. No checksum regeneration needed.

Also verified: classic and nltenebular presets build clean under `-Werror`, unit tests pass for both (53/53 and 52/52), nltenebular builds and passes under `TESTMODE=ON`, clang-format clean.

## Note for reviewers

Anyone building an older branch that still has `EIGEN=OFF` will need `brew install gsl` / `libgsl-dev` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)