### PR TITLE
Add an optional GTH solver for the NLTE level population rate matrix

### DIFF
--- a/artisoptions_christinenonthermal.h
+++ b/artisoptions_christinenonthermal.h
@@ -95,6 +95,8 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING = 1
 
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION = 1e-9;
 
+constexpr bool NLTE_USE_GTH_SOLVER = false;
+
 constexpr bool NT_ON = true;
 
 constexpr bool NT_SOLVE_SPENCERFANO = true;

--- a/artisoptions_classic.h
+++ b/artisoptions_classic.h
@@ -90,6 +90,8 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING = 1
 
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION = 1e-9;
 
+constexpr bool NLTE_USE_GTH_SOLVER = false;
+
 constexpr bool NT_ON = false;
 
 constexpr bool NT_SOLVE_SPENCERFANO = false;

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -141,6 +141,15 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING;
 // population are all individually checked.
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION;
 
+// Solve the NLTE level population equations with the Grassmann-Taksar-Heyman (GTH) state-elimination
+// algorithm instead of the default LU decomposition of the rate matrix with a normalisation row.
+// GTH exploits the fact that the assembled rate matrix is the transpose of a Markov-chain generator:
+// it never reads the diagonal and performs no subtractions, giving populations with componentwise
+// relative accuracy even when they span many orders of magnitude, with no matrix equilibration,
+// balance vector, or iterative refinement. Elements with FORCE_SAHA_ION_BALANCE always use the LU
+// solver, because the Saha constraint rows break the generator structure that GTH requires.
+constexpr bool NLTE_USE_GTH_SOLVER;
+
 // non-thermal ionisation
 constexpr bool NT_ON;
 

--- a/artisoptions_kilonova_lte.h
+++ b/artisoptions_kilonova_lte.h
@@ -90,6 +90,8 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING = 1
 
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION = 1e-9;
 
+constexpr bool NLTE_USE_GTH_SOLVER = false;
+
 constexpr bool NT_ON = false;
 
 constexpr bool NT_SOLVE_SPENCERFANO = false;

--- a/artisoptions_nltenebular.h
+++ b/artisoptions_nltenebular.h
@@ -97,6 +97,8 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING = 2
 
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION = 1e-9;
 
+constexpr bool NLTE_USE_GTH_SOLVER = false;
+
 constexpr bool NT_ON = true;
 
 constexpr bool NT_SOLVE_SPENCERFANO = true;

--- a/artisoptions_nltephotospheric_dynamic_ion_range.h
+++ b/artisoptions_nltephotospheric_dynamic_ion_range.h
@@ -98,6 +98,8 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING = 2
 
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION = 1e-9;
 
+constexpr bool NLTE_USE_GTH_SOLVER = false;
+
 constexpr bool NT_ON = true;
 
 constexpr bool NT_SOLVE_SPENCERFANO = true;

--- a/artisoptions_nltewithoutnonthermal.h
+++ b/artisoptions_nltewithoutnonthermal.h
@@ -93,6 +93,8 @@ constexpr float STRICT_POPULATION_CHECKING_INVERSION_FACTOR_PRINTOUT_WARNING = 1
 
 constexpr double NLTE_LIMIT_ION_STAGES_MAX_LEVELPOP_OVER_ELEMENTPOP_REMOVE_ION = 1e-9;
 
+constexpr bool NLTE_USE_GTH_SOLVER = false;
+
 constexpr bool NT_ON = true;
 
 constexpr bool NT_SOLVE_SPENCERFANO = true;

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <ios>
 #include <numeric>
+#include <optional>
 #include <print>
 #include <ranges>
 #include <span>
@@ -1122,6 +1123,72 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
   return solution_pops_are_valid(nonemptymgi, element, popvec, first_ion_used, nions_used);
 }
 
+// GTH counterpart of nltepop_matrix_solve: solve for the stationary populations of the assembled rate matrix
+// directly, with no normalisation row, balance vector, equilibration, or iterative refinement. The summed rate
+// matrix is consumed in place by the elimination; the per-process matrices are untouched, and the summed matrix is
+// regenerated from them for the residual check (and by the caller on any retry). popvec must be zero-filled on
+// entry and holds a solution only on success.
+[[nodiscard]] auto nltepop_matrix_solve_gth(const int element, const int nonemptymgi, RateMatrices& rate_matrices,
+                                            std::span<double> popvec, const double nnelement,
+                                            const int max_nlte_dimension, const int first_ion_used,
+                                            const int nions_used) -> bool {
+  const auto nlte_dimension = std::ssize(popvec);
+  assert_always(std::cmp_greater_equal(max_nlte_dimension, nlte_dimension));
+
+  const auto rate_matrix = rate_matrices.get_summed_rate_matrix();
+  assert_always(std::ssize(rate_matrix) == (nlte_dimension * nlte_dimension));
+
+  // A non-finite entry anywhere makes the solve meaningless. Report and return false, which lets the caller drop an
+  // ion stage and retry, instead of aborting the run.
+  if (!std::ranges::all_of(rate_matrix, [](const double x) { return std::isfinite(x); })) {
+    printlnlog("  [error] cell {} ts {}: NLTE rate matrix contains a non-finite value for element Z={}",
+               nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+    return false;
+  }
+
+  if (const auto disconnected_index = gth_stationary_distribution(rate_matrix, popvec)) {
+    // report the state with no departure rate into the rest of the chain (popvec is still zero-filled, which is
+    // what can_remove_ion's triage expects)
+    const auto [ion, level] =
+        get_ion_level_of_nlte_vector_index(*disconnected_index, element, first_ion_used, nions_used);
+    printlog(
+        "  [error] cell {} ts {}: NLTE matrix is singular for element Z={} (GTH elimination found no departure rate "
+        "from:",
+        nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+    if (is_nlte(element, ion, level)) {
+      printlnlog(" ionstage {} level {})", get_ionstage(element, ion), level);
+    } else {
+      printlnlog(" ionstage {} superlevel)", get_ionstage(element, ion));
+    }
+    return false;
+  }
+
+  // scale the unit-sum stationary distribution to the element number density (the same normalisation that the LU
+  // path imposes through its replaced zeroth matrix row)
+  for (auto i = 0Z; i < nlte_dimension; i++) {
+    popvec[i] *= nnelement;
+  }
+
+  // the elimination consumed the summed matrix, so regenerate it from the per-process matrices to measure the
+  // componentwise relative backward error of the statistical equilibrium equations rate_matrix * popvec = 0 (every
+  // row is a rate equation on this path)
+  const auto rate_matrix_check = rate_matrices.get_summed_rate_matrix();
+  THREADLOCALONHOST std::vector<double> zero_balance_vector;
+  zero_balance_vector.reserve(max_nlte_dimension);
+  zero_balance_vector.resize(nlte_dimension);
+  std::ranges::fill(zero_balance_vector, 0.);
+  constexpr double relative_residual_warn_tolerance = 1e-8;
+  const double max_relative_residual = get_max_relative_residual(rate_matrix_check, zero_balance_vector, popvec);
+  if (max_relative_residual > relative_residual_warn_tolerance) {
+    printlnlog(
+        "  [warning] cell {} ts {}: NLTE GTH solution for element Z={} has a max componentwise relative backward "
+        "error of {:g}",
+        nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element), max_relative_residual);
+  }
+
+  return solution_pops_are_valid(nonemptymgi, element, popvec, first_ion_used, nions_used);
+}
+
 auto can_remove_ion(const int element, const int ion, const int first_ion_used, const int nions_used,
                     const double nnelement, std::span<const double> popvec) -> bool {
   if (nions_used <= 1) {
@@ -1233,48 +1300,56 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
       }
     });
 
-    // replace the zeroth row of the matrix and balance vector with the normalisation
-    // constraint (sum of levelpops = total element population)
+    if (NLTE_USE_GTH_SOLVER && !FORCE_SAHA_ION_BALANCE(atomic_number)) {
+      // solve the pristine rate matrix directly for the stationary populations. The GTH elimination needs the
+      // unmodified Markov-generator structure, so the normalisation row, balance vector, and equilibration of the
+      // LU path below are all skipped.
+      matrix_solve_success = nltepop_matrix_solve_gth(element, nonemptymgi, rate_matrices, popvec, nnelement,
+                                                      max_nlte_dimension, first_ion_used, nions_used);
+    } else {
+      // replace the zeroth row of the matrix and balance vector with the normalisation
+      // constraint (sum of levelpops = total element population)
 
-    const auto rate_matrix = rate_matrices.get_summed_rate_matrix();
-    std::ranges::fill(std::span{rate_matrix}.first(nlte_dimension), 1.0);
+      const auto rate_matrix = rate_matrices.get_summed_rate_matrix();
+      std::ranges::fill(std::span{rate_matrix}.first(nlte_dimension), 1.0);
 
-    THREADLOCALONHOST std::vector<double> balance_vector;
-    balance_vector.reserve(max_nlte_dimension);
-    balance_vector.resize(nlte_dimension);
-    std::ranges::fill(balance_vector, 0.0);  // statistical equilibrium means balance vector is zero
-    // except for zeroth element used to normalise the total element population
-    balance_vector[0] = nnelement;
+      THREADLOCALONHOST std::vector<double> balance_vector;
+      balance_vector.reserve(max_nlte_dimension);
+      balance_vector.resize(nlte_dimension);
+      std::ranges::fill(balance_vector, 0.0);  // statistical equilibrium means balance vector is zero
+      // except for zeroth element used to normalise the total element population
+      balance_vector[0] = nnelement;
 
-    if (FORCE_SAHA_ION_BALANCE(atomic_number)) {
-      const auto ionfractions = calculate_ionfractions(element, nonemptymgi, grid::get_nne(nonemptymgi), true);
-      // ssize() to avoid unsigned wraparound to a huge positive value when the vector is empty
-      const int uppermost_ion = static_cast<int>(std::ssize(ionfractions)) - 1;
-      for (int ion = first_ion_used + 1; ion <= std::min(uppermost_ion, max_ion_used); ion++) {
-        // replace matrix row for ion's ground state with:
-        // sum of this ion's level populations is equal to the ion population
-        const double nnion = nnelement * ionfractions[ion];
-        const int index_ion_ground = get_nlte_vector_index(element, ion, 0, first_ion_used);
-        const int index_ion_toplevel =
-            get_nlte_vector_index(element, ion, get_nlevels(element, ion) - 1, first_ion_used);
-        for (int index = 0; index < nlte_dimension; index++) {
-          rate_matrix[(index_ion_ground * nlte_dimension) + index] =
-              (index >= index_ion_ground && index <= index_ion_toplevel) ? 1.0 : 0.0;
+      if (FORCE_SAHA_ION_BALANCE(atomic_number)) {
+        const auto ionfractions = calculate_ionfractions(element, nonemptymgi, grid::get_nne(nonemptymgi), true);
+        // ssize() to avoid unsigned wraparound to a huge positive value when the vector is empty
+        const int uppermost_ion = static_cast<int>(std::ssize(ionfractions)) - 1;
+        for (int ion = first_ion_used + 1; ion <= std::min(uppermost_ion, max_ion_used); ion++) {
+          // replace matrix row for ion's ground state with:
+          // sum of this ion's level populations is equal to the ion population
+          const double nnion = nnelement * ionfractions[ion];
+          const int index_ion_ground = get_nlte_vector_index(element, ion, 0, first_ion_used);
+          const int index_ion_toplevel =
+              get_nlte_vector_index(element, ion, get_nlevels(element, ion) - 1, first_ion_used);
+          for (int index = 0; index < nlte_dimension; index++) {
+            rate_matrix[(index_ion_ground * nlte_dimension) + index] =
+                (index >= index_ion_ground && index <= index_ion_toplevel) ? 1.0 : 0.0;
+          }
+
+          balance_vector[index_ion_ground] = nnion;
         }
-
-        balance_vector[index_ion_ground] = nnion;
       }
+
+      // calculate the normalisation factors and apply them to the matrix columns and balance vector elements
+      THREADLOCALONHOST std::vector<double> pop_normfactors;
+      pop_normfactors.reserve(max_nlte_dimension);
+      pop_normfactors.resize(nlte_dimension);
+      std::ranges::fill(pop_normfactors, 1.0);
+      nltepop_matrix_normalise(rate_matrix, balance_vector, pop_normfactors);
+
+      matrix_solve_success = nltepop_matrix_solve(element, nonemptymgi, rate_matrix, balance_vector, popvec,
+                                                  pop_normfactors, max_nlte_dimension, first_ion_used, nions_used);
     }
-
-    // calculate the normalisation factors and apply them to the matrix columns and balance vector elements
-    THREADLOCALONHOST std::vector<double> pop_normfactors;
-    pop_normfactors.reserve(max_nlte_dimension);
-    pop_normfactors.resize(nlte_dimension);
-    std::ranges::fill(pop_normfactors, 1.0);
-    nltepop_matrix_normalise(rate_matrix, balance_vector, pop_normfactors);
-
-    matrix_solve_success = nltepop_matrix_solve(element, nonemptymgi, rate_matrix, balance_vector, popvec,
-                                                pop_normfactors, max_nlte_dimension, first_ion_used, nions_used);
 
     matrix_solve_required = false;  // will be set to true if we need to retry with a different ion range
     if (matrix_solve_success) {
@@ -1395,6 +1470,74 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 }
 
 }  // anonymous namespace
+
+// Grassmann-Taksar-Heyman (GTH) state-elimination solve for the stationary distribution of the continuous-time
+// Markov chain whose generator is stored transposed in the NLTE rate matrix layout, i.e. rate_matrix[(to * n) +
+// from] with n = vec_x.size(). Only sums, products, and divisions of the (non-negative) off-diagonal rates are
+// used and the diagonal is never read, so there is no subtractive cancellation and assembly rounding in the
+// column sums cannot affect the result. Small negative autoionisation off-diagonals (warned about during
+// assembly) only weaken that guarantee locally; any resulting invalid populations are policed by the caller.
+// rate_matrix is overwritten. On success, returns std::nullopt and fills vec_x with the stationary distribution
+// normalised to a sum of one. On failure, returns the index of a state with no departure rate into the remaining
+// chain (a reducible/disconnected matrix) and leaves vec_x untouched.
+auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double> vec_x)
+    -> std::optional<std::ptrdiff_t> {
+  const auto n = std::ssize(vec_x);
+  assert_always(n >= 1);
+  assert_always(std::ssize(rate_matrix) == (n * n));
+
+  // eliminate the highest-numbered remaining state by folding it into the transition rates among the states below
+  for (auto k = n - 1; k >= 1; k--) {
+    double departure_sum = 0.;
+    for (auto i = 0Z; i < k; i++) {
+      departure_sum += rate_matrix[(i * n) + k];
+    }
+    if (!std::isfinite(departure_sum) || !(departure_sum > 0.)) {
+      return k;
+    }
+    // stash the departure sum in the diagonal slot, which GTH never otherwise reads
+    rate_matrix[(k * n) + k] = departure_sum;
+    for (auto i = 0Z; i < k; i++) {
+      const double rate_k_to_i = rate_matrix[(i * n) + k];
+      if (rate_k_to_i == 0.) {
+        continue;
+      }
+      const double factor = rate_k_to_i / departure_sum;
+      for (auto j = 0Z; j < k; j++) {
+        rate_matrix[(i * n) + j] += factor * rate_matrix[(k * n) + j];
+      }
+    }
+  }
+
+  // back-substitution: stationary weights relative to vec_x[0] = 1
+  vec_x[0] = 1.;
+  for (auto k = 1Z; k < n; k++) {
+    double inflow = 0.;
+    for (auto j = 0Z; j < k; j++) {
+      inflow += vec_x[j] * rate_matrix[(k * n) + j];
+    }
+    vec_x[k] = inflow / rate_matrix[(k * n) + k];
+    // subtraction-free overflow rescue: with extreme population ratios the raw weights can approach the double
+    // range, so rescale everything computed so far (the ratios are preserved, and the normalising sum below then
+    // cannot overflow because every weight stays at or below 1e250)
+    if (vec_x[k] > 1e250) {
+      const double downscale = 1. / vec_x[k];
+      for (auto j = 0Z; j <= k; j++) {
+        vec_x[j] *= downscale;
+      }
+    }
+  }
+
+  double x_sum = 0.;
+  for (auto j = 0Z; j < n; j++) {
+    x_sum += vec_x[j];
+  }
+  for (auto j = 0Z; j < n; j++) {
+    vec_x[j] /= x_sum;
+  }
+
+  return std::nullopt;
+}
 
 void solve_nlte_pops_element(const int element, const int nonemptymgi, const int timestep, const int nlte_iter) {
   // solve the statistical balance equations to find NLTE level populations for all ions of an element

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -179,6 +179,17 @@ auto get_nlte_vector_index(const int element, const int ion, const int level, co
   return {-1, -1};
 }
 
+// log " ionstage {} level {}" or " ionstage {} superlevel" (no newline) identifying an NLTE vector index in a message
+void printlog_nlte_vector_index(const std::ptrdiff_t index, const int element, const int first_ion_used,
+                                const int nions_used) {
+  const auto [ion, level] = get_ion_level_of_nlte_vector_index(index, element, first_ion_used, nions_used);
+  if (is_nlte(element, ion, level)) {
+    printlog(" ionstage {} level {}", get_ionstage(element, ion), level);
+  } else {
+    printlog(" ionstage {} superlevel", get_ionstage(element, ion));
+  }
+}
+
 [[nodiscard]] auto get_total_rate(const ptrdiff_t index_selected, const std::span<const double> rate_matrix,
                                   const std::span<const double> popvec, const bool into_level,
                                   const bool only_levels_below, const bool only_levels_above) -> double {
@@ -945,12 +956,7 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
                  nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
         is_singular = true;
       }
-      const auto [ion, level] = get_ion_level_of_nlte_vector_index(i, element, first_ion_used, nions_used);
-      if (is_nlte(element, ion, level)) {
-        printlog(" ionstage {} level {}", get_ionstage(element, ion), level);
-      } else {
-        printlog(" ionstage {} superlevel", get_ionstage(element, ion));
-      }
+      printlog_nlte_vector_index(i, element, first_ion_used, nions_used);
     }
   }
   if (is_singular) {
@@ -966,6 +972,23 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
     "the NLTE solver requires std::isfinite to detect NaN/inf: compile without -ffinite-math-only (see FASTMATH in the Makefile)"
 #endif
 
+// A non-finite entry anywhere makes a solve meaningless. Report and return false, which lets the caller drop an
+// ion stage and retry, instead of aborting the run. balance_vector may be empty (the GTH path has none).
+[[nodiscard]] auto nlte_system_is_finite(const std::span<const double> rate_matrix,
+                                         const std::span<const double> balance_vector, const int element) -> bool {
+  const auto is_finite = [](const double x) { return std::isfinite(x); };
+  if (!std::ranges::all_of(rate_matrix, is_finite) || !std::ranges::all_of(balance_vector, is_finite)) {
+    printlnlog(
+        "  [error] cell {} ts {}: NLTE rate matrix or balance vector contains a non-finite value for element Z={}",
+        nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+    return false;
+  }
+  return true;
+}
+
+// warn above this componentwise relative backward error (from get_max_relative_residual) on either solver path
+constexpr double RELATIVE_RESIDUAL_WARN_TOLERANCE = 1e-8;
+
 // The largest componentwise relative backward error of a solution: max_i |b_i - (A*x)_i| / (|b_i| + sum_j |A_ij *
 // x_j|), i.e. each row's residual measured against the size of the terms that were differenced to form it. The
 // residual on its own is not a convergence measure: nltepop_matrix_normalise() rescales each row by an arbitrary
@@ -974,22 +997,24 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
 // equilibration only balances each row's norm against its column's, never rows against each other, and with
 // FORCE_SAHA_ION_BALANCE the constraint rows carry right hand sides that differ by many orders of magnitude - a
 // normwise ratio would let a badly violated small-scale row hide behind the largest row. A row whose scale is
-// exactly zero has an exactly zero residual and is skipped.
+// exactly zero has an exactly zero residual and is skipped. An empty balance_vector is treated as all-zero (the
+// homogeneous system solved on the GTH path).
 [[nodiscard]] auto get_max_relative_residual(const std::span<const double> rate_matrix,
                                              const std::span<const double> balance_vector,
                                              const std::span<const double> vec_x) -> double {
-  const auto nlte_dimension = balance_vector.size();
+  const auto nlte_dimension = vec_x.size();
   double max_relative_residual = 0.;
   for (auto i = 0ZU; i < nlte_dimension; i++) {
+    const double b_i = balance_vector.empty() ? 0. : balance_vector[i];
     double rowdot = 0.;
-    double rowscale = std::abs(balance_vector[i]);
+    double rowscale = std::abs(b_i);
     for (auto j = 0ZU; j < nlte_dimension; j++) {
       const double term = rate_matrix[(i * nlte_dimension) + j] * vec_x[j];
       rowdot += term;
       rowscale += std::abs(term);
     }
     if (rowscale > 0.) {
-      max_relative_residual = std::max(max_relative_residual, std::abs(balance_vector[i] - rowdot) / rowscale);
+      max_relative_residual = std::max(max_relative_residual, std::abs(b_i - rowdot) / rowscale);
     }
   }
   return max_relative_residual;
@@ -1008,13 +1033,7 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
   assert_always(rate_matrix.size() == (nlte_dimension * nlte_dimension));
   assert_always(std::cmp_greater_equal(max_nlte_dimension, nlte_dimension));
 
-  // A non-finite entry anywhere makes the solve meaningless. Report and return false, which lets the caller drop an
-  // ion stage and retry, instead of aborting the run.
-  const auto is_finite = [](const double x) { return std::isfinite(x); };
-  if (!std::ranges::all_of(rate_matrix, is_finite) || !std::ranges::all_of(balance_vector, is_finite)) {
-    printlnlog(
-        "  [error] cell {} ts {}: NLTE rate matrix or balance vector contains a non-finite value for element Z={}",
-        nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+  if (!nlte_system_is_finite(rate_matrix, balance_vector, element)) {
     return false;
   }
 
@@ -1105,9 +1124,8 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
   // error_best carries arbitrary per-row equilibration factors, so convergence is judged by the componentwise
   // relative backward error rather than by comparison against a fixed absolute constant, which either fired on
   // every healthy solve or never fired at all depending only on the element number density.
-  constexpr double relative_residual_warn_tolerance = 1e-8;
   const double max_relative_residual = get_max_relative_residual(rate_matrix, balance_vector, vec_x);
-  if (max_relative_residual > relative_residual_warn_tolerance) {
+  if (max_relative_residual > RELATIVE_RESIDUAL_WARN_TOLERANCE) {
     printlnlog(
         "  [warning] cell {} ts {}: NLTE solver iterative refinement: the best solution vector was from pass {} of "
         "up to {} (pass 1 is the unrefined LU solution), with a max residual of {:g} in the equilibrated system and "
@@ -1124,62 +1142,44 @@ using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, E
 }
 
 // GTH counterpart of nltepop_matrix_solve: solve for the stationary populations of the assembled rate matrix
-// directly, with no normalisation row, balance vector, equilibration, or iterative refinement. The summed rate
-// matrix is consumed in place by the elimination; the per-process matrices are untouched, and the summed matrix is
-// regenerated from them for the residual check (and by the caller on any retry). popvec must be zero-filled on
-// entry and holds a solution only on success.
+// directly, with no normalisation row, balance vector, equilibration, or iterative refinement. popvec must be
+// zero-filled on entry and holds a solution only on success.
 [[nodiscard]] auto nltepop_matrix_solve_gth(const int element, const int nonemptymgi, RateMatrices& rate_matrices,
-                                            std::span<double> popvec, const double nnelement,
-                                            const int max_nlte_dimension, const int first_ion_used,
+                                            std::span<double> popvec, const double nnelement, const int first_ion_used,
                                             const int nions_used) -> bool {
   const auto nlte_dimension = std::ssize(popvec);
-  assert_always(std::cmp_greater_equal(max_nlte_dimension, nlte_dimension));
 
   const auto rate_matrix = rate_matrices.get_summed_rate_matrix();
   assert_always(std::ssize(rate_matrix) == (nlte_dimension * nlte_dimension));
 
-  // A non-finite entry anywhere makes the solve meaningless. Report and return false, which lets the caller drop an
-  // ion stage and retry, instead of aborting the run.
-  if (!std::ranges::all_of(rate_matrix, [](const double x) { return std::isfinite(x); })) {
-    printlnlog("  [error] cell {} ts {}: NLTE rate matrix contains a non-finite value for element Z={}",
-               nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
+  if (!nlte_system_is_finite(rate_matrix, {}, element)) {
     return false;
   }
 
-  if (const auto disconnected_index = gth_stationary_distribution(rate_matrix, popvec)) {
-    // report the state with no departure rate into the rest of the chain (popvec is still zero-filled, which is
-    // what can_remove_ion's triage expects)
-    const auto [ion, level] =
-        get_ion_level_of_nlte_vector_index(*disconnected_index, element, first_ion_used, nions_used);
+  // run the elimination on a scratch copy so that the summed matrix stays pristine for the residual check below
+  THREADLOCALONHOST std::vector<double> elimination_matrix;
+  elimination_matrix.assign(rate_matrix.begin(), rate_matrix.end());
+
+  if (const auto disconnected_index = gth_stationary_distribution(elimination_matrix, popvec)) {
+    // popvec is still zero-filled here, which is what can_remove_ion's triage expects
     printlog(
         "  [error] cell {} ts {}: NLTE matrix is singular for element Z={} (GTH elimination found no departure rate "
         "from:",
         nltelog.modelgridindex, nltelog.timestep, get_atomicnumber(element));
-    if (is_nlte(element, ion, level)) {
-      printlnlog(" ionstage {} level {})", get_ionstage(element, ion), level);
-    } else {
-      printlnlog(" ionstage {} superlevel)", get_ionstage(element, ion));
-    }
+    printlog_nlte_vector_index(*disconnected_index, element, first_ion_used, nions_used);
+    printlnlog(")");
     return false;
   }
 
-  // scale the unit-sum stationary distribution to the element number density (the same normalisation that the LU
-  // path imposes through its replaced zeroth matrix row)
-  for (auto i = 0Z; i < nlte_dimension; i++) {
-    popvec[i] *= nnelement;
+  // scale the unit-sum stationary distribution to the element number density
+  for (double& pop : popvec) {
+    pop *= nnelement;
   }
 
-  // the elimination consumed the summed matrix, so regenerate it from the per-process matrices to measure the
-  // componentwise relative backward error of the statistical equilibrium equations rate_matrix * popvec = 0 (every
-  // row is a rate equation on this path)
-  const auto rate_matrix_check = rate_matrices.get_summed_rate_matrix();
-  THREADLOCALONHOST std::vector<double> zero_balance_vector;
-  zero_balance_vector.reserve(max_nlte_dimension);
-  zero_balance_vector.resize(nlte_dimension);
-  std::ranges::fill(zero_balance_vector, 0.);
-  constexpr double relative_residual_warn_tolerance = 1e-8;
-  const double max_relative_residual = get_max_relative_residual(rate_matrix_check, zero_balance_vector, popvec);
-  if (max_relative_residual > relative_residual_warn_tolerance) {
+  // componentwise relative backward error of the statistical equilibrium equations rate_matrix * popvec = 0 (with
+  // no normalisation row on this path, every row is a rate equation)
+  const double max_relative_residual = get_max_relative_residual(rate_matrix, {}, popvec);
+  if (max_relative_residual > RELATIVE_RESIDUAL_WARN_TOLERANCE) {
     printlnlog(
         "  [warning] cell {} ts {}: NLTE GTH solution for element Z={} has a max componentwise relative backward "
         "error of {:g}",
@@ -1260,6 +1260,9 @@ auto can_remove_ion(const int element, const int ion, const int first_ion_used, 
 // Assemble and solve the NLTE rate matrix, retrying with a reduced range of ion stages when the
 // solve fails and NLTE_LIMIT_ION_STAGES_AFTER_FAILURE allows an edge ion to be removed.
 // Returns whether a solution was found and the range of ions included in it.
+// Both solver paths normalise the solution so that the sum over every matrix slot equals the element number
+// density: the LU path through its replaced zeroth matrix row, the GTH path by scaling its unit-sum stationary
+// distribution.
 auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemptymgi, const double t_mid,
                                              const double nnelement,
                                              const std::vector<std::vector<double>>& s_renorm_allions,
@@ -1268,6 +1271,9 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
   const int atomic_number = get_atomicnumber(element);
   const int nions = get_nions(element);
   const auto max_nlte_dimension = get_max_nlte_dimension();
+  // the solver choice is fixed for the element: FORCE_SAHA_ION_BALANCE constraint rows are incompatible with the
+  // Markov-generator structure that the GTH elimination requires, so those elements always use the LU path
+  const bool use_gth_solver = NLTE_USE_GTH_SOLVER && !FORCE_SAHA_ION_BALANCE(atomic_number);
   int nions_used = nions;
   int first_ion_used = 0;
   bool matrix_solve_success = false;
@@ -1300,12 +1306,9 @@ auto nltepop_solve_matrix_with_ion_reduction(const int element, const int nonemp
       }
     });
 
-    if (NLTE_USE_GTH_SOLVER && !FORCE_SAHA_ION_BALANCE(atomic_number)) {
-      // solve the pristine rate matrix directly for the stationary populations. The GTH elimination needs the
-      // unmodified Markov-generator structure, so the normalisation row, balance vector, and equilibration of the
-      // LU path below are all skipped.
-      matrix_solve_success = nltepop_matrix_solve_gth(element, nonemptymgi, rate_matrices, popvec, nnelement,
-                                                      max_nlte_dimension, first_ion_used, nions_used);
+    if (use_gth_solver) {
+      matrix_solve_success =
+          nltepop_matrix_solve_gth(element, nonemptymgi, rate_matrices, popvec, nnelement, first_ion_used, nions_used);
     } else {
       // replace the zeroth row of the matrix and balance vector with the normalisation
       // constraint (sum of levelpops = total element population)
@@ -1480,6 +1483,7 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 // rate_matrix is overwritten. On success, returns std::nullopt and fills vec_x with the stationary distribution
 // normalised to a sum of one. On failure, returns the index of a state with no departure rate into the remaining
 // chain (a reducible/disconnected matrix) and leaves vec_x untouched.
+// Defined with external linkage (declared in nltepop.h) so that unittests.cc can exercise it.
 auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double> vec_x)
     -> std::optional<std::ptrdiff_t> {
   const auto n = std::ssize(vec_x);
@@ -1528,12 +1532,9 @@ auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double
     }
   }
 
-  double x_sum = 0.;
-  for (auto j = 0Z; j < n; j++) {
-    x_sum += vec_x[j];
-  }
-  for (auto j = 0Z; j < n; j++) {
-    vec_x[j] /= x_sum;
+  const double x_sum = std::accumulate(vec_x.begin(), vec_x.end(), 0.);
+  for (double& x : vec_x) {
+    x /= x_sum;
   }
 
   return std::nullopt;

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1476,8 +1476,9 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 
 // Grassmann-Taksar-Heyman (GTH) state-elimination solve for the stationary distribution of the continuous-time
 // Markov chain whose generator is stored transposed in the NLTE rate matrix layout, i.e. rate_matrix[(to * n) +
-// from] with n = vec_x.size(). Only sums, products, and divisions of the (non-negative) off-diagonal rates are
-// used and the diagonal is never read, so there is no subtractive cancellation and assembly rounding in the
+// from] with n = vec_x.size(). The off-diagonal rates must be finite (the caller checks this) and non-negative.
+// Only sums, products, and divisions of the rates are used
+// and the diagonal is never read, so there is no subtractive cancellation and assembly rounding in the
 // column sums cannot affect the result. Small negative autoionisation off-diagonals (warned about during
 // assembly) only weaken that guarantee locally; any resulting invalid populations are policed by the caller.
 // rate_matrix is overwritten. On success, returns std::nullopt and fills vec_x with the stationary distribution
@@ -1513,23 +1514,31 @@ auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double
     }
   }
 
-  // back-substitution: stationary weights relative to vec_x[0] = 1
+  // back-substitution: stationary weights, starting relative to vec_x[0] = 1
   vec_x[0] = 1.;
   for (auto k = 1Z; k < n; k++) {
-    double inflow = 0.;
-    for (auto j = 0Z; j < k; j++) {
-      inflow += vec_x[j] * rate_matrix[(k * n) + j];
-    }
-    vec_x[k] = inflow / rate_matrix[(k * n) + k];
-    // subtraction-free overflow rescue: with extreme population ratios the raw weights can approach the double
-    // range, so rescale everything computed so far (the ratios are preserved, and the normalising sum below then
-    // cannot overflow because every weight stays at or below 1e250)
-    if (vec_x[k] > 1e250) {
-      const double downscale = 1. / vec_x[k];
-      for (auto j = 0Z; j <= k; j++) {
-        vec_x[j] *= downscale;
+    const double departure_sum = rate_matrix[(k * n) + k];
+    const auto get_inflow = [&] {
+      double inflow = 0.;
+      for (auto j = 0Z; j < k; j++) {
+        inflow += vec_x[j] * rate_matrix[(k * n) + j];
       }
+      return inflow;
+    };
+    double inflow = get_inflow();
+    // subtraction-free overflow rescue, applied before the division so that even a single weight ratio beyond the
+    // double range (e.g. rates of 1e200 up and 1e-200 back between two states) cannot overflow to infinity: while
+    // the next weight would exceed 1e250, rescale the earlier weights and recompute the inflow. The ratios are
+    // preserved, weights that underflow to zero are at least ~1e58 times smaller than the largest weight and
+    // physically negligible, and capping every stored weight at 1e250 keeps the normalising sum below from
+    // overflowing.
+    while (!std::isfinite(inflow) || inflow > departure_sum * 1e250) {
+      for (auto j = 0Z; j < k; j++) {
+        vec_x[j] *= 1e-200;
+      }
+      inflow = get_inflow();
     }
+    vec_x[k] = inflow / departure_sum;
   }
 
   const double x_sum = std::accumulate(vec_x.begin(), vec_x.end(), 0.);

--- a/nltepop.h
+++ b/nltepop.h
@@ -14,6 +14,8 @@
 inline MPI_shared_array<double> nltepops_allcells;
 
 void solve_nlte_pops_element(int element, int nonemptymgi, int timestep, int nlte_iter);
+// GTH solve for the stationary distribution of the NLTE rate matrix, exposed here so that unittests.cc can test
+// it (see the definition in nltepop.cc for the full contract)
 [[nodiscard]] auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double> vec_x)
     -> std::optional<std::ptrdiff_t>;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto superlevel_boltzmann(int nonemptymgi, int element, int ion, int level)

--- a/nltepop.h
+++ b/nltepop.h
@@ -3,7 +3,10 @@
 #ifndef NLTEPOP_H
 #define NLTEPOP_H
 
+#include <cstddef>
 #include <cstdio>
+#include <optional>
+#include <span>
 
 #include "constants.h"
 #include "mpi_logging.h"
@@ -11,6 +14,8 @@
 inline MPI_shared_array<double> nltepops_allcells;
 
 void solve_nlte_pops_element(int element, int nonemptymgi, int timestep, int nlte_iter);
+[[nodiscard]] auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double> vec_x)
+    -> std::optional<std::ptrdiff_t>;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto superlevel_boltzmann(int nonemptymgi, int element, int ion, int level)
     -> double;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_nlte_levelpop_over_rho(int nonemptymgi, int element, int ion,

--- a/unittests.cc
+++ b/unittests.cc
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <functional>
+#include <optional>
 #include <print>
 #include <string_view>
 #include <vector>
@@ -25,6 +26,7 @@
 #include "input.h"
 #include "macroatom.h"
 #include "mpi_logging.h"
+#include "nltepop.h"
 #include "radfield.h"
 #include "random.h"
 #include "rpkt.h"
@@ -458,6 +460,128 @@ void test_input_helpers() {
   check(!lineiscommentonly("1 2 3 # trailing comment"), "data line with trailing comment is not comment-only");
 }
 
+void test_gth_solver() {
+  std::println("GTH stationary distribution solver...");
+
+  // build matrices in the NLTE solver layout A[(to * n) + from]: each off-diagonal holds a transition rate and each
+  // diagonal element holds the negated column sum, as the NLTE rate matrix assembly does (GTH must never read it)
+  const auto set_rate = [](std::vector<double>& matrix, const ptrdiff_t n, const ptrdiff_t from, const ptrdiff_t to,
+                           const double rate) {
+    matrix[(to * n) + from] += rate;
+    matrix[(from * n) + from] -= rate;
+  };
+
+  // three-state chain with the exact stationary distribution {53, 23, 18} / 94 from the Markov chain tree theorem
+  // (each state's weight is the sum over its rooted spanning trees of the product of the tree's rates)
+  const auto make_threestate_matrix = [&set_rate] {
+    std::vector<double> matrix(3 * 3, 0.);
+    set_rate(matrix, 3, 0, 1, 1.);
+    set_rate(matrix, 3, 0, 2, 2.);
+    set_rate(matrix, 3, 1, 0, 3.);
+    set_rate(matrix, 3, 1, 2, 4.);
+    set_rate(matrix, 3, 2, 0, 5.);
+    set_rate(matrix, 3, 2, 1, 6.);
+    return matrix;
+  };
+
+  {
+    auto matrix = make_threestate_matrix();
+    std::vector<double> vec_x(3, 0.);
+    const std::optional<std::ptrdiff_t> result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH solves an irreducible three-state chain");
+    check_close(vec_x[0], 53. / 94., 1e-14, "GTH three-state stationary distribution element 0");
+    check_close(vec_x[1], 23. / 94., 1e-14, "GTH three-state stationary distribution element 1");
+    check_close(vec_x[2], 18. / 94., 1e-14, "GTH three-state stationary distribution element 2");
+    check_close(vec_x[0] + vec_x[1] + vec_x[2], 1., 1e-14, "GTH stationary distribution sums to one");
+  }
+
+  {
+    // corrupting the diagonal cannot change the result because GTH never reads it
+    auto matrix = make_threestate_matrix();
+    matrix[(0 * 3) + 0] = 12345.;
+    matrix[(1 * 3) + 1] = -67890.;
+    matrix[(2 * 3) + 2] = 0.5;
+    std::vector<double> vec_x(3, 0.);
+    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH solves with a corrupted diagonal");
+    check_close(vec_x[0], 53. / 94., 1e-14, "GTH ignores the diagonal (element 0)");
+    check_close(vec_x[1], 23. / 94., 1e-14, "GTH ignores the diagonal (element 1)");
+    check_close(vec_x[2], 18. / 94., 1e-14, "GTH ignores the diagonal (element 2)");
+  }
+
+  {
+    // birth-death chain with extreme dynamic range: GTH must reproduce the exact detailed-balance ratios of
+    // neighbouring populations (the componentwise relative accuracy that motivates the algorithm, where an LU solve
+    // with a normalisation row loses the small components to absolute rounding)
+    constexpr ptrdiff_t n = 4;
+    constexpr std::array<double, 3> rate_up = {2e10, 3e-4, 5e2};
+    constexpr std::array<double, 3> rate_down = {7e-6, 1e8, 4e-1};
+    std::vector<double> matrix(n * n, 0.);
+    for (ptrdiff_t k = 0; k < n - 1; k++) {
+      set_rate(matrix, n, k, k + 1, rate_up[k]);
+      set_rate(matrix, n, k + 1, k, rate_down[k]);
+    }
+    std::vector<double> vec_x(n, 0.);
+    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH solves a birth-death chain");
+    for (ptrdiff_t k = 0; k < n - 1; k++) {
+      check_close(vec_x[k + 1] / vec_x[k], rate_up[k] / rate_down[k], 1e-13,
+                  "GTH birth-death chain preserves a detailed-balance population ratio");
+    }
+  }
+
+  {
+    // seven-state chain whose raw stationary weights span 1e360 relative to state zero, which would overflow the
+    // double range without the subtraction-free rescaling in the back-substitution
+    constexpr ptrdiff_t n = 7;
+    std::vector<double> matrix(n * n, 0.);
+    for (ptrdiff_t k = 0; k < n - 1; k++) {
+      set_rate(matrix, n, k, k + 1, 1e30);
+      set_rate(matrix, n, k + 1, k, 1e-30);
+    }
+    std::vector<double> vec_x(n, 0.);
+    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH survives raw weights beyond the double range");
+    check(std::ranges::all_of(vec_x, [](const double x) { return std::isfinite(x) && x >= 0.; }),
+          "GTH extreme-ratio distribution is finite and non-negative");
+    check_close(vec_x[n - 1], 1., 1e-12, "GTH extreme-ratio distribution is dominated by the top state");
+    check_close(vec_x[n - 2] / vec_x[n - 1], 1e-60, 1e-12,
+                "GTH extreme-ratio detailed-balance ratio survives the rescaling");
+  }
+
+  {
+    // state 2 has no departure rate: the chain is reducible, so the solve must fail, identify state 2, and leave the
+    // output vector untouched
+    std::vector<double> matrix(3 * 3, 0.);
+    set_rate(matrix, 3, 0, 1, 1.);
+    set_rate(matrix, 3, 1, 0, 2.);
+    set_rate(matrix, 3, 1, 2, 3.);
+    std::vector<double> vec_x(3, -42.);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(result.has_value() && result.value() == 2, "GTH reports a state with no departure rate");
+    check(std::ranges::all_of(vec_x, [](const double x) { return x == -42.; }),
+          "GTH leaves the output vector untouched on failure");
+  }
+
+  {
+    // two decoupled two-state blocks: eliminating state 3 succeeds (it connects to state 2), then state 2 has no
+    // rate into states 0 or 1 and the solve must fail there
+    std::vector<double> matrix(4 * 4, 0.);
+    set_rate(matrix, 4, 0, 1, 1.);
+    set_rate(matrix, 4, 1, 0, 2.);
+    set_rate(matrix, 4, 2, 3, 3.);
+    set_rate(matrix, 4, 3, 2, 4.);
+    std::vector<double> vec_x(4, 0.);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(result.has_value() && result.value() == 2, "GTH detects decoupled blocks of states");
+  }
+
+  {
+    // a single state has stationary distribution {1}, and the value in the (never-read) diagonal is irrelevant
+    std::vector<double> matrix{12345.};
+    std::vector<double> vec_x(1, 0.);
+    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH solves the single-state chain");
+    check_close(vec_x[0], 1., 1e-15, "GTH single-state distribution is {1}");
+  }
+}
+
 }  // anonymous namespace
 
 auto main() -> int {
@@ -474,6 +598,7 @@ auto main() -> int {
   test_phixs_table_lookup();
   test_closest_transition_randomised();
   test_input_helpers();
+  test_gth_solver();
 
   std::println("unit tests: {} of {} checks passed", checks_total - checks_failed, checks_total);
 

--- a/unittests.cc
+++ b/unittests.cc
@@ -13,6 +13,7 @@
 #include <functional>
 #include <optional>
 #include <print>
+#include <span>
 #include <string_view>
 #include <vector>
 
@@ -484,14 +485,31 @@ void test_gth_solver() {
     return matrix;
   };
 
+  const auto check_threestate_result = [](const std::vector<double>& vec_x, const std::string_view description) {
+    constexpr std::array expected{53. / 94., 23. / 94., 18. / 94.};
+    for (ptrdiff_t k = 0; k < std::ssize(expected); k++) {
+      check_close(vec_x[k], expected[k], 1e-14, description);
+    }
+  };
+
+  // nearest-neighbour birth-death chain: rate_up[k] is the rate from state k to k + 1 and rate_down[k] the reverse
+  const auto make_chain_matrix = [&set_rate](const std::span<const double> rate_up,
+                                             const std::span<const double> rate_down) {
+    const auto n = std::ssize(rate_up) + 1;
+    std::vector<double> matrix(n * n, 0.);
+    for (ptrdiff_t k = 0; k < n - 1; k++) {
+      set_rate(matrix, n, k, k + 1, rate_up[k]);
+      set_rate(matrix, n, k + 1, k, rate_down[k]);
+    }
+    return matrix;
+  };
+
   {
     auto matrix = make_threestate_matrix();
     std::vector<double> vec_x(3, 0.);
-    const std::optional<std::ptrdiff_t> result = gth_stationary_distribution(matrix, vec_x);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
     check(!result.has_value(), "GTH solves an irreducible three-state chain");
-    check_close(vec_x[0], 53. / 94., 1e-14, "GTH three-state stationary distribution element 0");
-    check_close(vec_x[1], 23. / 94., 1e-14, "GTH three-state stationary distribution element 1");
-    check_close(vec_x[2], 18. / 94., 1e-14, "GTH three-state stationary distribution element 2");
+    check_threestate_result(vec_x, "GTH three-state stationary distribution");
     check_close(vec_x[0] + vec_x[1] + vec_x[2], 1., 1e-14, "GTH stationary distribution sums to one");
   }
 
@@ -502,27 +520,22 @@ void test_gth_solver() {
     matrix[(1 * 3) + 1] = -67890.;
     matrix[(2 * 3) + 2] = 0.5;
     std::vector<double> vec_x(3, 0.);
-    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH solves with a corrupted diagonal");
-    check_close(vec_x[0], 53. / 94., 1e-14, "GTH ignores the diagonal (element 0)");
-    check_close(vec_x[1], 23. / 94., 1e-14, "GTH ignores the diagonal (element 1)");
-    check_close(vec_x[2], 18. / 94., 1e-14, "GTH ignores the diagonal (element 2)");
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH solves with a corrupted diagonal");
+    check_threestate_result(vec_x, "GTH ignores the diagonal");
   }
 
   {
     // birth-death chain with extreme dynamic range: GTH must reproduce the exact detailed-balance ratios of
     // neighbouring populations (the componentwise relative accuracy that motivates the algorithm, where an LU solve
     // with a normalisation row loses the small components to absolute rounding)
-    constexpr ptrdiff_t n = 4;
     constexpr std::array<double, 3> rate_up = {2e10, 3e-4, 5e2};
     constexpr std::array<double, 3> rate_down = {7e-6, 1e8, 4e-1};
-    std::vector<double> matrix(n * n, 0.);
-    for (ptrdiff_t k = 0; k < n - 1; k++) {
-      set_rate(matrix, n, k, k + 1, rate_up[k]);
-      set_rate(matrix, n, k + 1, k, rate_down[k]);
-    }
-    std::vector<double> vec_x(n, 0.);
-    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH solves a birth-death chain");
-    for (ptrdiff_t k = 0; k < n - 1; k++) {
+    auto matrix = make_chain_matrix(rate_up, rate_down);
+    std::vector<double> vec_x(rate_up.size() + 1, 0.);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH solves a birth-death chain");
+    for (ptrdiff_t k = 0; k < std::ssize(rate_up); k++) {
       check_close(vec_x[k + 1] / vec_x[k], rate_up[k] / rate_down[k], 1e-13,
                   "GTH birth-death chain preserves a detailed-balance population ratio");
     }
@@ -531,19 +544,14 @@ void test_gth_solver() {
   {
     // seven-state chain whose raw stationary weights span 1e360 relative to state zero, which would overflow the
     // double range without the subtraction-free rescaling in the back-substitution
-    constexpr ptrdiff_t n = 7;
-    std::vector<double> matrix(n * n, 0.);
-    for (ptrdiff_t k = 0; k < n - 1; k++) {
-      set_rate(matrix, n, k, k + 1, 1e30);
-      set_rate(matrix, n, k + 1, k, 1e-30);
-    }
-    std::vector<double> vec_x(n, 0.);
-    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH survives raw weights beyond the double range");
+    auto matrix = make_chain_matrix(std::vector<double>(6, 1e30), std::vector<double>(6, 1e-30));
+    std::vector<double> vec_x(7, 0.);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH survives raw weights beyond the double range");
     check(std::ranges::all_of(vec_x, [](const double x) { return std::isfinite(x) && x >= 0.; }),
           "GTH extreme-ratio distribution is finite and non-negative");
-    check_close(vec_x[n - 1], 1., 1e-12, "GTH extreme-ratio distribution is dominated by the top state");
-    check_close(vec_x[n - 2] / vec_x[n - 1], 1e-60, 1e-12,
-                "GTH extreme-ratio detailed-balance ratio survives the rescaling");
+    check_close(vec_x[6], 1., 1e-12, "GTH extreme-ratio distribution is dominated by the top state");
+    check_close(vec_x[5] / vec_x[6], 1e-60, 1e-12, "GTH extreme-ratio detailed-balance ratio survives the rescaling");
   }
 
   {
@@ -577,7 +585,8 @@ void test_gth_solver() {
     // a single state has stationary distribution {1}, and the value in the (never-read) diagonal is irrelevant
     std::vector<double> matrix{12345.};
     std::vector<double> vec_x(1, 0.);
-    check(!gth_stationary_distribution(matrix, vec_x).has_value(), "GTH solves the single-state chain");
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH solves the single-state chain");
     check_close(vec_x[0], 1., 1e-15, "GTH single-state distribution is {1}");
   }
 }

--- a/unittests.cc
+++ b/unittests.cc
@@ -555,6 +555,18 @@ void test_gth_solver() {
   }
 
   {
+    // a single up/down rate ratio of 1e400 exceeds the double range outright: the pre-division rescaling must keep
+    // the dominant state finite instead of letting the weight overflow to infinity and decay into NaNs
+    auto matrix = make_chain_matrix(std::vector<double>(1, 1e200), std::vector<double>(1, 1e-200));
+    std::vector<double> vec_x(2, 0.);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH solves a two-state chain with a weight ratio beyond the double range");
+    check(std::ranges::all_of(vec_x, [](const double x) { return std::isfinite(x) && x >= 0.; }),
+          "GTH beyond-range-ratio distribution is finite and non-negative");
+    check_close(vec_x[1], 1., 1e-12, "GTH beyond-range-ratio distribution is dominated by the top state");
+  }
+
+  {
     // state 2 has no departure rate: the chain is reducible, so the solve must fail, identify state 2, and leave the
     // output vector untouched
     std::vector<double> matrix(3 * 3, 0.);


### PR DESCRIPTION
Add the compile-time option NLTE_USE_GTH_SOLVER (off in every preset) that
solves the statistical equilibrium equations with the Grassmann-Taksar-Heyman
state-elimination algorithm instead of LU decomposition with a normalisation
row. The assembled rate matrix is the transpose of a Markov-chain generator,
which GTH solves directly: it never reads the diagonal and performs no
subtractions, giving populations with componentwise relative accuracy and
needing no equilibration, balance vector, or iterative refinement. The
solution is scaled to the element number density, matching the normalisation
the LU path imposes through its replaced zeroth row, and failures (a state
with no departure rate) feed the existing ion-removal retry and LTE fallback
machinery. Elements with FORCE_SAHA_ION_BALANCE always use the LU solver
because the Saha constraint rows break the generator structure GTH requires.

The kernel has external linkage so unittests.cc can exercise it: an exact
three-state chain, detailed-balance ratios across 27 orders of magnitude, the
overflow rescaling, disconnected-state detection, and the never-read diagonal.

Results are unchanged by default since the option is disabled in all presets.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019JNp7vzGWDLgW7BHeBchvm