### PR TITLE
Speed up startup: faster model/abundance parsing, single-reader input files, and buffered linestat.out

### DIFF
--- a/grid.cc
+++ b/grid.cc
@@ -2049,6 +2049,8 @@ void read_ejecta_model() {
       mgi++;
     }
 
+    printlnlog("Finished reading {} model cells from model.txt", mgi);
+
     if (mgi != get_npts_model()) {
       printlnlog("[error] model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
       std::abort();

--- a/grid.cc
+++ b/grid.cc
@@ -648,16 +648,14 @@ void read_elem_abundances() {
   // i.e. in total one integer and 30 floats.
 
   static std::string line;
-  static std::istringstream ssline;
 
   // loop over propagation cells for 3D models, or modelgrid cells
   for (int mgi = 0; mgi < get_npts_model(); mgi++) {
     assert_always(get_noncommentline(abundance_file, line));
-    ssline.clear();
-    ssline.str(line);
+    auto remainder = std::string_view{line};
 
     int cellnumberinput = -1;
-    assert_always(ssline >> cellnumberinput);
+    assert_always(parse_next_token(remainder, cellnumberinput));
     assert_always(cellnumberinput == mgi + first_cellindex);
 
     // the abundances.txt file specifies the elemental mass fractions for each model cell
@@ -669,7 +667,7 @@ void read_elem_abundances() {
     double abund_in = 0.;
     for (int elem_z_index = 0; elem_z_index < std::ssize(elem_massfracs_in); elem_z_index++) {
       const int atomic_number = elem_z_index + 1;
-      if (!(ssline >> abund_in)) {
+      if (!parse_next_token(remainder, abund_in)) {
         // at least one element (hydrogen) should have been specified for nonempty cells
         assert_always(atomic_number > 1 || get_numpropcells(mgi) == 0);
         break;
@@ -770,14 +768,13 @@ auto get_token_count(std::string const& line) -> int {
   return abundcolcount;
 }
 
-void read_model_radioabundances(std::istream& fmodel, std::istringstream& ssline, const int mgi, const bool keepcell,
+void read_model_radioabundances(std::istream& fmodel, std::string_view& remainder, const int mgi, const bool keepcell,
                                 const std::vector<std::string>& colnames, const std::vector<int>& nucindexlist,
                                 const bool one_line_per_cell) {
   if (!one_line_per_cell) {
     static std::string line;
     assert_always(std::getline(fmodel, line));
-    ssline.clear();
-    ssline.str(line);
+    remainder = std::string_view{line};
   }
 
   if (!keepcell) {
@@ -786,7 +783,7 @@ void read_model_radioabundances(std::istream& fmodel, std::istringstream& ssline
 
   for (auto i = 0Z; i < std::ssize(colnames); i++) {
     double valuein = 0.;
-    assert_always(ssline >> valuein);  // usually a mass fraction, but now can be anything
+    assert_always(parse_next_token(remainder, valuein));  // usually a mass fraction, but now can be anything
 
     if (nucindexlist[i] >= 0) {
       assert_testmodeonly(valuein <= 1.);
@@ -806,7 +803,7 @@ void read_model_radioabundances(std::istream& fmodel, std::istringstream& ssline
     }
   }
   double valuein = 0.;
-  assert_always(!(ssline >> valuein));  // should be no tokens left!
+  assert_always(!parse_next_token(remainder, valuein));  // should be no tokens left!
 }
 
 auto read_model_columns(std::istream& fmodel) -> std::tuple<std::vector<std::string>, std::vector<int>, bool> {
@@ -1947,8 +1944,7 @@ void read_ejecta_model() {
 
   int mgi = 0;
   while (mgi < get_npts_model() && std::getline(fmodel, line)) {
-    ssline.clear();
-    ssline.str(line);
+    auto remainder = std::string_view{line};
     int cellnumberin = 0;
     double rho_tmodel{NAN};  // the cell density [g/cm3] at the model snapshot time t_model
 
@@ -1958,7 +1954,8 @@ void read_ejecta_model() {
       // columns: cell number, outer velocity [km/s], log10 of the density
       double vout_kmps{NAN};
       double log_rho{NAN};
-      if (!(ssline >> cellnumberin >> vout_kmps >> log_rho)) {
+      if (!(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, vout_kmps) &&
+            parse_next_token(remainder, log_rho))) {
         printlnlog(
             "[error] model.txt cell {}: expected at least 3 values (inputcellid vel_r_max_kmps log10rho) but could "
             "not parse line: {}",
@@ -1974,7 +1971,8 @@ void read_ejecta_model() {
       // columns: cell number, r midpoint, z midpoint, density
       float cell_r_in{NAN};
       float cell_z_in{NAN};
-      assert_always(ssline >> cellnumberin >> cell_r_in >> cell_z_in >> rho_tmodel);
+      assert_always(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, cell_r_in) &&
+                    parse_next_token(remainder, cell_z_in) && parse_next_token(remainder, rho_tmodel));
 
       const int n_rcyl = (mgi % ncoord_model[0]);
       const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
@@ -1994,7 +1992,9 @@ void read_ejecta_model() {
       // columns: cell number, x midpoint, y midpoint, z midpoint, density
       std::array<float, 3> cellpos_in{};
       float rho_model_in{NAN};
-      assert_always(ssline >> cellnumberin >> cellpos_in[0] >> cellpos_in[1] >> cellpos_in[2] >> rho_model_in);
+      assert_always(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, cellpos_in[0]) &&
+                    parse_next_token(remainder, cellpos_in[1]) && parse_next_token(remainder, cellpos_in[2]) &&
+                    parse_next_token(remainder, rho_model_in));
       rho_tmodel = rho_model_in;
 
       if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
@@ -2035,7 +2035,7 @@ void read_ejecta_model() {
     const bool keepcell = (rho_tmodel > 0);
     set_rho_tmin(mgi, static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin)));
 
-    read_model_radioabundances(fmodel, ssline, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
+    read_model_radioabundances(fmodel, remainder, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
 
     mgi++;
   }

--- a/grid.cc
+++ b/grid.cc
@@ -33,6 +33,10 @@
 #include <utility>
 #include <vector>
 
+#pragma clang unsafe_buffer_usage begin
+#include <mpi.h>
+#pragma clang unsafe_buffer_usage end
+
 #include "artisoptions.h"
 #include "atomic.h"
 #include "constants.h"
@@ -1941,16 +1945,16 @@ void read_ejecta_model() {
 
   const auto [colnames, nucindexlist, one_line_per_cell] = read_model_columns(fmodel);
 
-  // 3D only: whether the input cell positions match the expected values in x-y-z or z-y-x
-  // column order (set false when a mismatch is detected)
-  bool posmatch_xyz = true;
-  bool posmatch_zyx = true;
-
-  int mgi = 0;
   // only global rank 0 parses the cell data. The node-shared arrays it fills are broadcast to the leaders of the
   // other nodes below, and the rank-local results are broadcast to all ranks, so that only one rank reads the
   // (potentially very large) file
   if (globals::my_rank == 0) {
+    // 3D only: whether the input cell positions match the expected values in x-y-z or z-y-x
+    // column order (set false when a mismatch is detected)
+    bool posmatch_xyz = true;
+    bool posmatch_zyx = true;
+
+    int mgi = 0;
     while (mgi < get_npts_model() && std::getline(fmodel, line)) {
       auto remainder = std::string_view{line};
       int cellnumberin = 0;

--- a/grid.cc
+++ b/grid.cc
@@ -147,26 +147,31 @@ void read_possible_yefile() {
     return;
   }
 
-  const auto filein = fopen_required_uniqueptr("Ye.txt", "r");
-  int nlines_in = 0;
-  assert_always(fscanf(filein.get(), "%d", &nlines_in) == 1);
+  // the electron fractions are written to node-shared memory, so only the node leaders read the file
+  // (synchronised by the barrier below)
+  if (globals::rank_in_node == 0) {
+    const auto filein = fopen_required_uniqueptr("Ye.txt", "r");
+    int nlines_in = 0;
+    assert_always(fscanf(filein.get(), "%d", &nlines_in) == 1);
 
-  int cells_set = 0;
-  int entries_ignored = 0;
-  for (int n = 0; n < nlines_in; n++) {
-    int mgiplusone = -1;
-    float initelecfrac = 0.;
-    assert_always(fscanf(filein.get(), "%d %g", &mgiplusone, &initelecfrac) == 2);
-    const int mgi = mgiplusone - 1;
-    if (mgi >= 0 && mgi < get_npts_model()) {
-      set_initelectronfrac(mgi, initelecfrac);
-      cells_set++;
-    } else {
-      entries_ignored++;
+    int cells_set = 0;
+    int entries_ignored = 0;
+    for (int n = 0; n < nlines_in; n++) {
+      int mgiplusone = -1;
+      float initelecfrac = 0.;
+      assert_always(fscanf(filein.get(), "%d %g", &mgiplusone, &initelecfrac) == 2);
+      const int mgi = mgiplusone - 1;
+      if (mgi >= 0 && mgi < get_npts_model()) {
+        set_initelectronfrac(mgi, initelecfrac);
+        cells_set++;
+      } else {
+        entries_ignored++;
+      }
     }
+    printlnlog("Ye.txt: set the initial electron fraction for {} of {} model cells ({} out-of-range entries ignored)",
+               cells_set, get_npts_model(), entries_ignored);
   }
-  printlnlog("Ye.txt: set the initial electron fraction for {} of {} model cells ({} out-of-range entries ignored)",
-             cells_set, get_npts_model(), entries_ignored);
+  MPI_Barrier_allranks();
 }
 
 [[gnu::pure]] DEVICE_FUNC auto get_propgridtype() -> GridType {
@@ -1942,122 +1947,143 @@ void read_ejecta_model() {
   bool posmatch_zyx = true;
 
   int mgi = 0;
-  while (mgi < get_npts_model() && std::getline(fmodel, line)) {
-    auto remainder = std::string_view{line};
-    int cellnumberin = 0;
-    double rho_tmodel{NAN};  // the cell density [g/cm3] at the model snapshot time t_model
+  // only global rank 0 parses the cell data. The node-shared arrays it fills are broadcast to the leaders of the
+  // other nodes below, and the rank-local results are broadcast to all ranks, so that only one rank reads the
+  // (potentially very large) file
+  if (globals::my_rank == 0) {
+    while (mgi < get_npts_model() && std::getline(fmodel, line)) {
+      auto remainder = std::string_view{line};
+      int cellnumberin = 0;
+      double rho_tmodel{NAN};  // the cell density [g/cm3] at the model snapshot time t_model
 
-    // parse the geometry-specific part of the cell line to get the density (and for 1D, the
-    // outer velocity), and check that any cell midpoint coordinates match the expected values
-    if (get_modelgridtype() == GridType::SPHERICAL1D) {
-      // columns: cell number, outer velocity [km/s], log10 of the density
-      double vout_kmps{NAN};
-      double log_rho{NAN};
-      if (!(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, vout_kmps) &&
-            parse_next_token(remainder, log_rho))) {
-        printlnlog(
-            "[error] model.txt cell {}: expected at least 3 values (inputcellid vel_r_max_kmps log10rho) but could "
-            "not parse line: {}",
-            mgi, line);
-        assert_always(false);
-      }
-      vout_model[mgi] = vout_kmps * 1.e5;
-      // the velocity grid is binary searched by int_index_lowerbound(), so it has to increase
-      // outwards. Without this check a non-monotonic model.txt gives silently wrong cell lookups.
-      assert_always(mgi == 0 || vout_model[mgi] > vout_model[mgi - 1]);
-      rho_tmodel = (log_rho > -90) ? pow(10., log_rho) : 0.;
-    } else if (get_modelgridtype() == GridType::CYLINDRICAL2D) {
-      // columns: cell number, r midpoint, z midpoint, density
-      float cell_r_in{NAN};
-      float cell_z_in{NAN};
-      assert_always(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, cell_r_in) &&
-                    parse_next_token(remainder, cell_z_in) && parse_next_token(remainder, rho_tmodel));
+      // parse the geometry-specific part of the cell line to get the density (and for 1D, the
+      // outer velocity), and check that any cell midpoint coordinates match the expected values
+      if (get_modelgridtype() == GridType::SPHERICAL1D) {
+        // columns: cell number, outer velocity [km/s], log10 of the density
+        double vout_kmps{NAN};
+        double log_rho{NAN};
+        if (!(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, vout_kmps) &&
+              parse_next_token(remainder, log_rho))) {
+          printlnlog(
+              "[error] model.txt cell {}: expected at least 3 values (inputcellid vel_r_max_kmps log10rho) but could "
+              "not parse line: {}",
+              mgi, line);
+          assert_always(false);
+        }
+        vout_model[mgi] = vout_kmps * 1.e5;
+        // the velocity grid is binary searched by int_index_lowerbound(), so it has to increase
+        // outwards. Without this check a non-monotonic model.txt gives silently wrong cell lookups.
+        assert_always(mgi == 0 || vout_model[mgi] > vout_model[mgi - 1]);
+        rho_tmodel = (log_rho > -90) ? pow(10., log_rho) : 0.;
+      } else if (get_modelgridtype() == GridType::CYLINDRICAL2D) {
+        // columns: cell number, r midpoint, z midpoint, density
+        float cell_r_in{NAN};
+        float cell_z_in{NAN};
+        assert_always(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, cell_r_in) &&
+                      parse_next_token(remainder, cell_z_in) && parse_next_token(remainder, rho_tmodel));
 
-      const int n_rcyl = (mgi % ncoord_model[0]);
-      const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
-      assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
-      const int n_z = (mgi / ncoord_model[0]);
-      if (((2 * n_z) + 1) == ncoord_model[1]) {
-        // an odd number of z rows puts the middle row at the origin, where a relative comparison
-        // has nothing to divide by. Compare against the cell size instead. The row is identified
-        // from the integer index rather than by testing the coordinate against zero, because the
-        // expression below is not required to evaluate to exactly zero under -ffast-math.
-        assert_always(fabs(cell_z_in) < (1e-3 * globals::vmax * t_model / ncoord_model[1]));
+        const int n_rcyl = (mgi % ncoord_model[0]);
+        const double pos_r_cyl_mid = (n_rcyl + 0.5) * globals::vmax * t_model / ncoord_model[0];
+        assert_always(fabs((cell_r_in / pos_r_cyl_mid) - 1) < 1e-3);
+        const int n_z = (mgi / ncoord_model[0]);
+        if (((2 * n_z) + 1) == ncoord_model[1]) {
+          // an odd number of z rows puts the middle row at the origin, where a relative comparison
+          // has nothing to divide by. Compare against the cell size instead. The row is identified
+          // from the integer index rather than by testing the coordinate against zero, because the
+          // expression below is not required to evaluate to exactly zero under -ffast-math.
+          assert_always(fabs(cell_z_in) < (1e-3 * globals::vmax * t_model / ncoord_model[1]));
+        } else {
+          const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
+          assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
+        }
       } else {
-        const double pos_z_mid = globals::vmax * t_model * (-1 + (2 * (n_z + 0.5) / ncoord_model[1]));
-        assert_always(fabs((cell_z_in / pos_z_mid) - 1) < 1e-3);
-      }
-    } else {
-      // columns: cell number, x midpoint, y midpoint, z midpoint, density
-      std::array<float, 3> cellpos_in{};
-      float rho_model_in{NAN};
-      assert_always(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, cellpos_in[0]) &&
-                    parse_next_token(remainder, cellpos_in[1]) && parse_next_token(remainder, cellpos_in[2]) &&
-                    parse_next_token(remainder, rho_model_in));
-      rho_tmodel = rho_model_in;
+        // columns: cell number, x midpoint, y midpoint, z midpoint, density
+        std::array<float, 3> cellpos_in{};
+        float rho_model_in{NAN};
+        assert_always(parse_next_token(remainder, cellnumberin) && parse_next_token(remainder, cellpos_in[0]) &&
+                      parse_next_token(remainder, cellpos_in[1]) && parse_next_token(remainder, cellpos_in[2]) &&
+                      parse_next_token(remainder, rho_model_in));
+        rho_tmodel = rho_model_in;
 
-      // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
-      // however, the cellindex always should increment X first, then Y, then Z
-      const double xmax_tmodel = globals::vmax * t_model;
-      for (int axis = 0; axis < 3; axis++) {
-        const double cellwidth = 2 * xmax_tmodel / ncoordgrid[axis];
-        const double cellpos_expected = -xmax_tmodel + (cellwidth * get_cellcoordindex(mgi, axis));
-        if (fabs(cellpos_expected - cellpos_in[axis]) > 0.5 * cellwidth) {
-          posmatch_xyz = false;
+        // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
+        // however, the cellindex always should increment X first, then Y, then Z
+        const double xmax_tmodel = globals::vmax * t_model;
+        for (int axis = 0; axis < 3; axis++) {
+          const double cellwidth = 2 * xmax_tmodel / ncoordgrid[axis];
+          const double cellpos_expected = -xmax_tmodel + (cellwidth * get_cellcoordindex(mgi, axis));
+          if (fabs(cellpos_expected - cellpos_in[axis]) > 0.5 * cellwidth) {
+            posmatch_xyz = false;
+          }
+          if (fabs(cellpos_expected - cellpos_in[2 - axis]) > 0.5 * cellwidth) {
+            posmatch_zyx = false;
+          }
         }
-        if (fabs(cellpos_expected - cellpos_in[2 - axis]) > 0.5 * cellwidth) {
-          posmatch_zyx = false;
+
+        if (min_den < 0. || min_den > rho_tmodel) {
+          min_den = rho_tmodel;
         }
       }
 
-      if (min_den < 0. || min_den > rho_tmodel) {
-        min_den = rho_tmodel;
+      if (mgi == 0) {
+        first_input_cellid = cellnumberin;
+        printlnlog("first_input_cellid {}", first_input_cellid);
+        assert_always(first_input_cellid == 0 || first_input_cellid == 1);
       }
+      assert_always(cellnumberin == mgi + first_input_cellid);
+
+      if (rho_tmodel < 0) {
+        printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model. aborting",
+                   mgi, cellnumberin, rho_tmodel);
+        std::abort();
+      }
+
+      const bool keepcell = (rho_tmodel > 0);
+      set_rho_tmin(mgi, static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin)));
+
+      read_model_radioabundances(fmodel, remainder, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
+
+      mgi++;
     }
 
-    if (mgi == 0) {
-      first_input_cellid = cellnumberin;
-      printlnlog("first_input_cellid {}", first_input_cellid);
-      assert_always(first_input_cellid == 0 || first_input_cellid == 1);
-    }
-    assert_always(cellnumberin == mgi + first_input_cellid);
-
-    if (rho_tmodel < 0) {
-      printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model. aborting",
-                 mgi, cellnumberin, rho_tmodel);
+    if (mgi != get_npts_model()) {
+      printlnlog("[error] model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
       std::abort();
     }
 
-    const bool keepcell = (rho_tmodel > 0);
-    set_rho_tmin(mgi, static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin)));
-
-    read_model_radioabundances(fmodel, remainder, mgi, keepcell, colnames, nucindexlist, one_line_per_cell);
-
-    mgi++;
-  }
-
-  if (mgi != get_npts_model()) {
-    printlnlog("[error] model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
-    std::abort();
-  }
-
-  if (get_modelgridtype() == GridType::SPHERICAL1D) {
-    // for 1D models, vmax is the outer velocity of the last cell
-    globals::vmax = vout_model[get_npts_model() - 1];
-  } else if (get_modelgridtype() == GridType::CARTESIAN3D) {
-    // posmatch_xyz and posmatch_zyx should be mutually exclusive: if both column orders matched, an
-    // infinity probably occurred in the calculated positions
-    if (posmatch_xyz) {
-      printlnlog("Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
-    } else if (posmatch_zyx) {
-      printlnlog("Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
-    } else {
-      printlnlog(
-          "[warning] Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
-          "order.");
+    if (get_modelgridtype() == GridType::SPHERICAL1D) {
+      // for 1D models, vmax is the outer velocity of the last cell
+      globals::vmax = vout_model[get_npts_model() - 1];
+    } else if (get_modelgridtype() == GridType::CARTESIAN3D) {
+      // posmatch_xyz and posmatch_zyx should be mutually exclusive: if both column orders matched, an
+      // infinity probably occurred in the calculated positions
+      if (posmatch_xyz) {
+        printlnlog(
+            "Cell positions in model.txt are consistent with calculated values when x-y-z column order is used.");
+      } else if (posmatch_zyx) {
+        printlnlog(
+            "Cell positions in model.txt are consistent with calculated values when z-y-x column order is used.");
+      } else {
+        printlnlog(
+            "[warning] Cell positions in model.txt are not consistent with calculated values in either x-y-z or z-y-x "
+            "order.");
+      }
+      printlnlog("minimum model density {:g} [g/cm3]", min_den);
     }
-    printlnlog("minimum model density {:g} [g/cm3]", min_den);
   }
+
+  // share the rank-local results of the cell parsing with the other ranks
+  MPI_Bcast_safe(first_input_cellid, 0, MPI_COMM_WORLD);
+  MPI_Bcast_safe(globals::vmax, 0, MPI_COMM_WORLD);
+  if (get_modelgridtype() == GridType::SPHERICAL1D) {
+    MPI_Bcast_safe(vout_model, 0, MPI_COMM_WORLD);
+  }
+
+  // send the node-shared model data filled by rank 0 to the node leaders of the other nodes
+  if (globals::rank_in_node == 0) {
+    MPI_Bcast_safe(modelgrid_input, 0, globals::mpi_comm_internode);
+    MPI_Bcast_safe(initnucmassfrac_allcells, 0, globals::mpi_comm_internode);
+  }
+  MPI_Barrier_allranks();
 
   assert_always(get_npts_model() ==
                 std::max(1, ncoord_model[0]) * std::max(1, ncoord_model[1]) * std::max(1, ncoord_model[2]));

--- a/grid.cc
+++ b/grid.cc
@@ -638,66 +638,65 @@ void read_elem_abundances() {
   printlnlog("reading abundances.txt...");
   const bool threedimensional = (get_modelgridtype() == GridType::CARTESIAN3D);
 
-  // Open the abundances file
-  auto abundance_file = fstream_required("abundances.txt", std::ios::in);
-
-  // and process through the grid to read in the abundances per cell
+  // Process through the grid to read in the abundances per cell.
   // The abundance file should only contain information for non-empty
   // cells. Its format must be cellnumber (integer), abundance for
   // element Z=1 (float) up to abundance for element Z=30 (float)
   // i.e. in total one integer and 30 floats.
 
-  static std::string line;
+  // the mass fraction arrays are in node-shared memory, so only the node leader of each node parses the file and
+  // writes the values (synchronised by the barrier below). The other ranks would just discard everything they read
+  if (globals::rank_in_node == 0) {
+    auto abundance_file = fstream_required("abundances.txt", std::ios::in);
+    std::string line;
 
-  // loop over propagation cells for 3D models, or modelgrid cells
-  for (int mgi = 0; mgi < get_npts_model(); mgi++) {
-    assert_always(get_noncommentline(abundance_file, line));
-    auto remainder = std::string_view{line};
+    // loop over propagation cells for 3D models, or modelgrid cells
+    for (int mgi = 0; mgi < get_npts_model(); mgi++) {
+      assert_always(get_noncommentline(abundance_file, line));
+      auto remainder = std::string_view{line};
 
-    int cellnumberinput = -1;
-    assert_always(parse_next_token(remainder, cellnumberinput));
-    assert_always(cellnumberinput == mgi + first_input_cellid);
+      int cellnumberinput = -1;
+      assert_always(parse_next_token(remainder, cellnumberinput));
+      assert_always(cellnumberinput == mgi + first_input_cellid);
 
-    // the abundances.txt file specifies the elemental mass fractions for each model cell
-    // (or proportional to mass frac, e.g. element densities, because they will be normalised anyway)
-    // The abundances begin with hydrogen, helium, etc, going as far up the atomic numbers as required
-    double normfactor = 0.;
-    std::array<float, 150> elem_massfracs_in{};
-    std::ranges::fill(elem_massfracs_in, 0.);
-    double abund_in = 0.;
-    for (int elem_z_index = 0; elem_z_index < std::ssize(elem_massfracs_in); elem_z_index++) {
-      const int atomic_number = elem_z_index + 1;
-      if (!parse_next_token(remainder, abund_in)) {
-        // at least one element (hydrogen) should have been specified for nonempty cells
-        assert_always(atomic_number > 1 || get_numpropcells(mgi) == 0);
-        break;
+      // the abundances.txt file specifies the elemental mass fractions for each model cell
+      // (or proportional to mass frac, e.g. element densities, because they will be normalised anyway)
+      // The abundances begin with hydrogen, helium, etc, going as far up the atomic numbers as required
+      double normfactor = 0.;
+      std::array<float, 150> elem_massfracs_in{};
+      double abund_in = 0.;
+      for (int elem_z_index = 0; elem_z_index < std::ssize(elem_massfracs_in); elem_z_index++) {
+        const int atomic_number = elem_z_index + 1;
+        if (!parse_next_token(remainder, abund_in)) {
+          // at least one element (hydrogen) should have been specified for nonempty cells
+          assert_always(atomic_number > 1 || get_numpropcells(mgi) == 0);
+          break;
+        }
+
+        if (abund_in < 0. || abund_in < std::numeric_limits<float>::min()) {
+          assert_always(abund_in > -1e-6);
+          abund_in = 0.;
+        }
+        elem_massfracs_in[elem_z_index] = static_cast<float>(abund_in);
+        normfactor += elem_massfracs_in[elem_z_index];
       }
 
-      if (abund_in < 0. || abund_in < std::numeric_limits<float>::min()) {
-        assert_always(abund_in > -1e-6);
-        abund_in = 0.;
-      }
-      elem_massfracs_in[elem_z_index] = static_cast<float>(abund_in);
-      normfactor += elem_massfracs_in[elem_z_index];
-    }
+      if (get_numpropcells(mgi) > 0) {
+        if (threedimensional || normfactor <= 0.) {
+          normfactor = 1.;
+        }
+        const int nonemptymgi = get_nonemptymgi_of_mgi(mgi);
 
-    if (get_numpropcells(mgi) > 0 && globals::rank_in_node == 0) {
-      // the mass fraction arrays are in node-shared memory, so only the node leader writes them
-      // (synchronised by the barrier below)
-      if (threedimensional || normfactor <= 0.) {
-        normfactor = 1.;
-      }
-      const int nonemptymgi = get_nonemptymgi_of_mgi(mgi);
+        for (int element = 0; element < get_nelements(); element++) {
+          // now set the abundances (by mass) of included elements, i.e.
+          // read out the abundances specified in the atomic data file
+          const int atomic_number = get_atomicnumber(element);
+          const auto elemmassfrac = static_cast<float>(elem_massfracs_in[atomic_number - 1] / normfactor);
+          assert_always(elemmassfrac >= 0.);
 
-      for (int element = 0; element < get_nelements(); element++) {
-        // now set the abundances (by mass) of included elements, i.e.
-        // read out the abundances specified in the atomic data file
-        const int atomic_number = get_atomicnumber(element);
-        const auto elemmassfrac = static_cast<float>(elem_massfracs_in[atomic_number - 1] / normfactor);
-        assert_always(elemmassfrac >= 0.);
-
-        // radioactive nuclide abundances should have already been set by read_??_model
-        set_elem_untrackedstable_massfrac(nonemptymgi, element, elemmassfrac);
+          // radioactive nuclide abundances should have already been set by read_??_model
+          set_elem_untrackedstable_massfrac(nonemptymgi, element, elemmassfrac);
+        }
       }
     }
   }

--- a/grid.cc
+++ b/grid.cc
@@ -68,7 +68,7 @@ double min_den{-1.};  // minimum model density
 
 double mfegroup{0.};  // Total mass of Fe group elements in ejecta
 
-int first_cellindex{-1};  // auto-determine first cell index in model.txt (usually 1 or 0)
+int first_input_cellid{-1};  // auto-determine first cell index in model.txt (usually 1 or 0)
 
 // Initial co-ordinates of inner most corner of cell.
 std::array<std::vector<double>, 3> coord_pos_min_tmin{};
@@ -656,7 +656,7 @@ void read_elem_abundances() {
 
     int cellnumberinput = -1;
     assert_always(parse_next_token(remainder, cellnumberinput));
-    assert_always(cellnumberinput == mgi + first_cellindex);
+    assert_always(cellnumberinput == mgi + first_input_cellid);
 
     // the abundances.txt file specifies the elemental mass fractions for each model cell
     // (or proportional to mass frac, e.g. element densities, because they will be normalised anyway)
@@ -1997,10 +1997,6 @@ void read_ejecta_model() {
                     parse_next_token(remainder, rho_model_in));
       rho_tmodel = rho_model_in;
 
-      if (mgi % (ncoord_model[1] * ncoord_model[2]) == 0) {
-        printlnlog("read up to cell mgi {}", mgi);
-      }
-
       // cell coordinates in the 3D model.txt file are sometimes reordered by the scaling script
       // however, the cellindex always should increment X first, then Y, then Z
       const double xmax_tmodel = globals::vmax * t_model;
@@ -2021,10 +2017,11 @@ void read_ejecta_model() {
     }
 
     if (mgi == 0) {
-      first_cellindex = cellnumberin;
-      printlnlog("first_cellindex {}", first_cellindex);
+      first_input_cellid = cellnumberin;
+      printlnlog("first_input_cellid {}", first_input_cellid);
+      assert_always(first_input_cellid == 0 || first_input_cellid == 1);
     }
-    assert_always(cellnumberin == mgi + first_cellindex);
+    assert_always(cellnumberin == mgi + first_input_cellid);
 
     if (rho_tmodel < 0) {
       printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model. aborting",

--- a/grid.cc
+++ b/grid.cc
@@ -1058,11 +1058,14 @@ void assign_initial_temperatures() {
   int cells_below_mintemp = 0;
   int cells_above_maxtemp = 0;
   int cells_nonfinite_temp = 0;
-  int first_nonfinite_mgi = -1;
+  int first_nonfinite_nonemptymgi = std::numeric_limits<int>::max();
   double first_nonfinite_rho_tmin = 0.;
   double first_nonfinite_endecay = 0.;
 
-  for (int nonemptymgi = 0; nonemptymgi < get_nonempty_npts_model(); nonemptymgi++) {
+  // the decayed energy calculation is expensive and the temperature arrays are in node-shared memory, so stripe
+  // the cells across the ranks of each node, with each rank writing its own disjoint subset of the shared arrays
+  for (int nonemptymgi = globals::rank_in_node; nonemptymgi < get_nonempty_npts_model();
+       nonemptymgi += globals::node_nprocs) {
     const int mgi = get_mgi_of_nonemptymgi(nonemptymgi);
 
     const auto q = (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? get_initenergyq(mgi) : 0.;
@@ -1075,8 +1078,8 @@ void assign_initial_temperatures() {
     if (!std::isfinite(T_initial)) {
       // check this first: a NaN would fall through every comparison below and be stored unclamped
       cells_nonfinite_temp++;
-      if (first_nonfinite_mgi < 0) {
-        first_nonfinite_mgi = mgi;
+      if (first_nonfinite_nonemptymgi == std::numeric_limits<int>::max()) {
+        first_nonfinite_nonemptymgi = nonemptymgi;
         first_nonfinite_rho_tmin = get_rho_tmin(mgi);
         first_nonfinite_endecay = decayedenergy_per_mass;
       }
@@ -1089,23 +1092,32 @@ void assign_initial_temperatures() {
       cells_above_maxtemp++;
     }
 
-    if (globals::rank_in_node == 0) {
-      // set the initial temperatures in the modelgrid
-      // this is only done by the node master, so that the values are shared in the node shared memory
-      Te_allcells[nonemptymgi] = T_initial;
-      TJ_allcells[nonemptymgi] = T_initial;
-      TR_allcells[nonemptymgi] = T_initial;
-      W_allcells[nonemptymgi] = 1.;
-      thick_allcells[nonemptymgi] = 0;
-    }
+    Te_allcells[nonemptymgi] = T_initial;
+    TJ_allcells[nonemptymgi] = T_initial;
+    TR_allcells[nonemptymgi] = T_initial;
+    W_allcells[nonemptymgi] = 1.;
+    thick_allcells[nonemptymgi] = 0;
   }
+
+  // combine the diagnostic counts over the node communicator (the ranks of each node together cover every cell
+  // exactly once)
+  MPI_Allreduce_safe(cells_below_mintemp, MPI_SUM, globals::mpi_comm_node);
+  MPI_Allreduce_safe(cells_above_maxtemp, MPI_SUM, globals::mpi_comm_node);
+  MPI_Allreduce_safe(cells_nonfinite_temp, MPI_SUM, globals::mpi_comm_node);
+
   printlnlog("  cells below MINTEMP {:g} [K]: {}. Above MAXTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp, MAXTEMP,
              cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
+    MPI_Allreduce_safe(first_nonfinite_nonemptymgi, MPI_MIN, globals::mpi_comm_node);
+    // get the details of the earliest example from the rank that computed that cell
+    const int ownerrank = first_nonfinite_nonemptymgi % globals::node_nprocs;
+    MPI_Bcast_safe(first_nonfinite_rho_tmin, ownerrank, globals::mpi_comm_node);
+    MPI_Bcast_safe(first_nonfinite_endecay, ownerrank, globals::mpi_comm_node);
     printlnlog(
         "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
         "rho_tmin {:g} [g/cm3] and decayed energy {:g} [erg/g])",
-        cells_nonfinite_temp, first_nonfinite_mgi, first_nonfinite_rho_tmin, first_nonfinite_endecay);
+        cells_nonfinite_temp, get_mgi_of_nonemptymgi(first_nonfinite_nonemptymgi), first_nonfinite_rho_tmin,
+        first_nonfinite_endecay);
   }
   MPI_Barrier_allranks();
 }

--- a/input.cc
+++ b/input.cc
@@ -837,56 +837,60 @@ void setup_phixs_list() {
   printlnlog("[info] mem_usage: photoionisation list occupies {:.3f} MB",
              globals::nbfcontinua * (sizeof(TempPhotoionTransitionInput)) / 1024. / 1024.);
   const auto groundcontindices = std::ranges::iota_view{0, globals::nbfcontinua_ground};
-  int allcontindex = 0;
-  for (int element = 0; element < get_nelements(); element++) {
-    const int nions = get_nions(element);
-    for (int ion = 0; ion < nions - 1; ion++) {
-      int groundcontindex =
-          static_cast<int>(std::ranges::find_if(groundcontindices,
-                                                [=](const auto& i) {
-                                                  return (globals::groundcont_element[i] == element) &&
-                                                         (globals::groundcont_ion[i] == ion);
-                                                }) -
-                           groundcontindices.begin());
-      if (groundcontindex >= globals::nbfcontinua_ground) {
-        groundcontindex = -1;
-      }
-      globals::elements[element].ions[ion].groundcontindex = groundcontindex;
-      const int nlevels = get_nlevels_ionising(element, ion);
-      for (int level = 0; level < nlevels; level++) {
-        const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-        const int nphixstargets = get_nphixstargets(uniquelevelindex);
+  // the continuum list, ion ground continuum indices, and closest ground level continua are all in node-shared
+  // memory, so only the node leaders fill them (synchronised by the barriers below)
+  if (globals::rank_in_node == 0) {
+    int allcontindex = 0;
+    for (int element = 0; element < get_nelements(); element++) {
+      const int nions = get_nions(element);
+      for (int ion = 0; ion < nions - 1; ion++) {
+        int groundcontindex =
+            static_cast<int>(std::ranges::find_if(groundcontindices,
+                                                  [=](const auto& i) {
+                                                    return (globals::groundcont_element[i] == element) &&
+                                                           (globals::groundcont_ion[i] == ion);
+                                                  }) -
+                             groundcontindices.begin());
+        if (groundcontindex >= globals::nbfcontinua_ground) {
+          groundcontindex = -1;
+        }
+        globals::elements[element].ions[ion].groundcontindex = groundcontindex;
+        const int nlevels = get_nlevels_ionising(element, ion);
+        for (int level = 0; level < nlevels; level++) {
+          const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
+          const int nphixstargets = get_nphixstargets(uniquelevelindex);
 
-        for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
-          assert_always(allcontindex < std::ssize(allcont));
+          for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
+            assert_always(allcontindex < std::ssize(allcont));
 
-          int index_in_groundphixslist = -1;
-          if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
-            const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
-            index_in_groundphixslist = search_groundphixslist(nu_edge_target0, element, ion, level);
+            int index_in_groundphixslist = -1;
+            if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
+              const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
+              index_in_groundphixslist = search_groundphixslist(nu_edge_target0, element, ion, level);
 
-            globals::alllevels.closestgroundlevelcont[uniquelevelindex] = index_in_groundphixslist;
+              globals::alllevels.closestgroundlevelcont[uniquelevelindex] = index_in_groundphixslist;
+            }
+
+            allcont[allcontindex] = {
+                .nu_edge = get_phixs_threshold(element, ion, level, phixstargetindex) / H,
+                .element = element,
+                .ion = ion,
+                .level = level,
+                .phixstargetindex = phixstargetindex,
+                .upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex),
+                .uniquelevelindex = uniquelevelindex,
+                .probability = get_phixsprobability(uniquelevelindex, phixstargetindex),
+                .index_in_groundphixslist = index_in_groundphixslist,
+            };
+
+            allcontindex++;
           }
-
-          allcont[allcontindex] = {
-              .nu_edge = get_phixs_threshold(element, ion, level, phixstargetindex) / H,
-              .element = element,
-              .ion = ion,
-              .level = level,
-              .phixstargetindex = phixstargetindex,
-              .upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex),
-              .uniquelevelindex = uniquelevelindex,
-              .probability = get_phixsprobability(uniquelevelindex, phixstargetindex),
-              .index_in_groundphixslist = index_in_groundphixslist,
-          };
-
-          allcontindex++;
         }
       }
     }
-  }
 
-  assert_always(allcontindex == globals::nbfcontinua);
+    assert_always(allcontindex == globals::nbfcontinua);
+  }
   assert_always(globals::nbfcontinua >= 0);  // was initialised as -1 before startup
   // just so that clang-tidy doesn't throw errors on the assumption that nbfcontinua is changing
   const auto nbfcontinua = globals::nbfcontinua;
@@ -937,20 +941,27 @@ void setup_phixs_list() {
 
     auto allcont_bfestimindex = MPI_shared_array<int>(nbfcontinua);
     std::vector<double> temp_bfestim_nu_edge;
-    for (int i = 0; i < nbfcontinua; i++) {
-      if (DETAILED_BF_ESTIMATORS_ON &&
-          LEVEL_HAS_BFEST(get_atomicnumber(globals::allcont.element[i]),
-                          get_ionstage(globals::allcont.element[i], globals::allcont.ion[i]),
-                          globals::allcont.level[i])) {
-        allcont_bfestimindex[i] = static_cast<int>(temp_bfestim_nu_edge.size());
-        temp_bfestim_nu_edge.push_back(globals::allcont.nu_edge[i]);
-      } else {
-        allcont_bfestimindex[i] = -1;
+    if (globals::rank_in_node == 0) {
+      for (int i = 0; i < nbfcontinua; i++) {
+        if (DETAILED_BF_ESTIMATORS_ON &&
+            LEVEL_HAS_BFEST(get_atomicnumber(globals::allcont.element[i]),
+                            get_ionstage(globals::allcont.element[i], globals::allcont.ion[i]),
+                            globals::allcont.level[i])) {
+          allcont_bfestimindex[i] = static_cast<int>(temp_bfestim_nu_edge.size());
+          temp_bfestim_nu_edge.push_back(globals::allcont.nu_edge[i]);
+        } else {
+          allcont_bfestimindex[i] = -1;
+        }
       }
     }
     globals::allcont.bfestimindex = std::move(allcont_bfestimindex);
-    auto bfestim_nu_edge = MPI_shared_array<double>(std::ssize(temp_bfestim_nu_edge));
-    std::ranges::copy(temp_bfestim_nu_edge, bfestim_nu_edge.begin());
+    auto bfestimcount = std::ssize(temp_bfestim_nu_edge);
+    MPI_Bcast_safe(bfestimcount, 0, globals::mpi_comm_node);
+    auto bfestim_nu_edge = MPI_shared_array<double>(bfestimcount);
+    if (globals::rank_in_node == 0) {
+      std::ranges::copy(temp_bfestim_nu_edge, bfestim_nu_edge.begin());
+    }
+    MPI_Barrier_node();
     globals::bfestim_nu_edge = std::move(bfestim_nu_edge);
 
     setup_photoion_luts();
@@ -967,119 +978,126 @@ void read_autoion_data() {
 
   std::vector<globals::LevelAutoion> temp_allautoion;
 
-  // every rank parses the file, so count transitions into rank-local arrays rather than doing
-  // concurrent read-modify-writes on the node-shared arrays; the node leader publishes them below
+  // only the node leaders parse the file, counting transitions into rank-local arrays and publishing them to the
+  // node-shared arrays below
   const auto uniquelevelcount = std::ssize(globals::alllevels.nautoiondowntrans);
   std::vector<int> temp_nautoiondowntrans;
-  reserve_resize(temp_nautoiondowntrans, uniquelevelcount);
-  std::ranges::fill(temp_nautoiondowntrans, 0);
   std::vector<int> temp_nautoionuptrans;
-  reserve_resize(temp_nautoionuptrans, uniquelevelcount);
-  std::ranges::fill(temp_nautoionuptrans, 0);
   std::vector<int> temp_allautoion_start;
-  reserve_resize(temp_allautoion_start, uniquelevelcount);
-  std::ranges::fill(temp_allautoion_start, -1);
+  ptrdiff_t nautoion_stored = 0;  // for the collective node-shared allocation below
 
-  printlnlog("Reading autoion.txt for autoionisation data.");
-  auto autoionfile = fstream_required("autoion.txt", std::ios::in);
-  std::string autoionline;
-  int Z = -1;
-  int upperionstage = -1;
-  int upperlevel_in = -1;
-  int lowerionstage = -1;
-  int lowerlevel_in = -1;
-  double autoion_A = -1;
-  bool allautoion_levels_are_not_nlte = true;
-  bool allautoion_levels_are_nlte = true;
-  int autoion_transitions_read = 0;
+  if (globals::rank_in_node == 0) {
+    reserve_resize(temp_nautoiondowntrans, uniquelevelcount);
+    std::ranges::fill(temp_nautoiondowntrans, 0);
+    reserve_resize(temp_nautoionuptrans, uniquelevelcount);
+    std::ranges::fill(temp_nautoionuptrans, 0);
+    reserve_resize(temp_allautoion_start, uniquelevelcount);
+    std::ranges::fill(temp_allautoion_start, -1);
 
-  // highest autoionising level index of each included ion as numbered in the file, before conversion
-  auto ion_max_autoionlevel_in = std::vector<int>(get_includedions(), -1);
+    printlnlog("Reading autoion.txt for autoionisation data.");
+    auto autoionfile = fstream_required("autoion.txt", std::ios::in);
+    std::string autoionline;
+    int Z = -1;
+    int upperionstage = -1;
+    int upperlevel_in = -1;
+    int lowerionstage = -1;
+    int lowerlevel_in = -1;
+    double autoion_A = -1;
+    bool allautoion_levels_are_not_nlte = true;
+    bool allautoion_levels_are_nlte = true;
+    int autoion_transitions_read = 0;
 
-  while (get_noncommentline(autoionfile, autoionline)) {
-    assert_always(std::istringstream(autoionline) >> Z >> upperionstage >> upperlevel_in >> lowerionstage >>
-                  lowerlevel_in >> autoion_A);
-    autoion_transitions_read++;
+    // highest autoionising level index of each included ion as numbered in the file, before conversion
+    auto ion_max_autoionlevel_in = std::vector<int>(get_includedions(), -1);
 
-    assert_always(Z > 0);
-    assert_always(upperionstage >= 2);
-    assert_always(lowerionstage >= 1);
+    while (get_noncommentline(autoionfile, autoionline)) {
+      assert_always(std::istringstream(autoionline) >> Z >> upperionstage >> upperlevel_in >> lowerionstage >>
+                    lowerlevel_in >> autoion_A);
+      autoion_transitions_read++;
 
-    const int element = get_elementindex(Z);
+      assert_always(Z > 0);
+      assert_always(upperionstage >= 2);
+      assert_always(lowerionstage >= 1);
 
-    if (element >= 0 && get_nions(element) > 0) {
-      // translate read-in ionstages to ion indices
+      const int element = get_elementindex(Z);
 
-      const int upperion = upperionstage - get_ionstage(element, 0);
-      const int lowerion = lowerionstage - get_ionstage(element, 0);
-      // store only for ions that are part of the current model atom
-      if (lowerion >= 0 && upperion < get_nions(element)) {
-        const auto lower_uniqueionindex = get_uniqueionindex(element, lowerion);
-        ion_max_autoionlevel_in[lower_uniqueionindex] =
-            std::max(ion_max_autoionlevel_in[lower_uniqueionindex], lowerlevel_in);
+      if (element >= 0 && get_nions(element) > 0) {
+        // translate read-in ionstages to ion indices
 
-        const int lowerlevel = lowerlevel_in - groundstate_index_in;
-        const int upperlevel = upperlevel_in - groundstate_index_in;
+        const int upperion = upperionstage - get_ionstage(element, 0);
+        const int lowerion = lowerionstage - get_ionstage(element, 0);
+        // store only for ions that are part of the current model atom
+        if (lowerion >= 0 && upperion < get_nions(element)) {
+          const auto lower_uniqueionindex = get_uniqueionindex(element, lowerion);
+          ion_max_autoionlevel_in[lower_uniqueionindex] =
+              std::max(ion_max_autoionlevel_in[lower_uniqueionindex], lowerlevel_in);
 
-        assert_always(upperion >= 0 && upperion < get_nions(element));
-        assert_always(lowerion >= 0 && lowerion < get_nions(element));
-        assert_always(lowerlevel >= 0 && lowerlevel < get_nlevels(element, lowerion));
-        assert_always(upperlevel >= 0 && upperlevel < get_nlevels(element, upperion));
-        assert_always(upperion > lowerion);
-        const bool level_is_nlte = is_nlte(element, lowerion, lowerlevel);
-        allautoion_levels_are_not_nlte = allautoion_levels_are_not_nlte && !level_is_nlte;
-        allautoion_levels_are_nlte = allautoion_levels_are_nlte && level_is_nlte;
+          const int lowerlevel = lowerlevel_in - groundstate_index_in;
+          const int upperlevel = upperlevel_in - groundstate_index_in;
 
-        const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
-        const auto upper_uniquelevelindex = get_uniquelevelindex(element, upperion, upperlevel);
+          assert_always(upperion >= 0 && upperion < get_nions(element));
+          assert_always(lowerion >= 0 && lowerion < get_nions(element));
+          assert_always(lowerlevel >= 0 && lowerlevel < get_nlevels(element, lowerion));
+          assert_always(upperlevel >= 0 && upperlevel < get_nlevels(element, upperion));
+          assert_always(upperion > lowerion);
+          const bool level_is_nlte = is_nlte(element, lowerion, lowerlevel);
+          allautoion_levels_are_not_nlte = allautoion_levels_are_not_nlte && !level_is_nlte;
+          allautoion_levels_are_nlte = allautoion_levels_are_nlte && level_is_nlte;
 
-        temp_nautoiondowntrans[lower_uniquelevelindex] += 1;
-        temp_nautoionuptrans[upper_uniquelevelindex] += 1;
+          const auto lower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
+          const auto upper_uniquelevelindex = get_uniquelevelindex(element, upperion, upperlevel);
 
-        if (temp_allautoion_start[lower_uniquelevelindex] < 0) {
-          assert_always(temp_nautoiondowntrans[lower_uniquelevelindex] == 1);
-          //  this is the first autoionizing transition for this level, so set the start index
-          temp_allautoion_start[lower_uniquelevelindex] = static_cast<int>(temp_allautoion.size());
+          temp_nautoiondowntrans[lower_uniquelevelindex] += 1;
+          temp_nautoionuptrans[upper_uniquelevelindex] += 1;
+
+          if (temp_allautoion_start[lower_uniquelevelindex] < 0) {
+            assert_always(temp_nautoiondowntrans[lower_uniquelevelindex] == 1);
+            //  this is the first autoionizing transition for this level, so set the start index
+            temp_allautoion_start[lower_uniquelevelindex] = static_cast<int>(temp_allautoion.size());
+          }
+
+          temp_allautoion.push_back({
+              .autoion_A = static_cast<float>(autoion_A),
+              .elementindex = element,
+              .lowerionindex = lowerion,
+              .lowerlevelindex = lowerlevel,
+              .upperionindex = upperion,
+              .upperlevelindex = upperlevel,
+          });
         }
-
-        temp_allautoion.push_back({
-            .autoion_A = static_cast<float>(autoion_A),
-            .elementindex = element,
-            .lowerionindex = lowerion,
-            .lowerlevelindex = lowerlevel,
-            .upperionindex = upperion,
-            .upperlevelindex = upperlevel,
-        });
       }
     }
-  }
 
-  assert_always(allautoion_levels_are_not_nlte || allautoion_levels_are_nlte);
+    assert_always(allautoion_levels_are_not_nlte || allautoion_levels_are_nlte);
 
-  // the autoionising levels of an ion must be a contiguous block ending at its highest level (asserted below), so
-  // for each ion with autoionisation data the highest autoionising level in the file must be the ion's top level.
-  // Checking the raw file indices detects an autoion.txt whose level numbering disagrees with adata.txt
-  for (int element = 0; element < get_nelements(); element++) {
-    const int nions = get_nions(element);
-    for (int ion = 0; ion < nions; ion++) {
-      const auto max_autoionlevel_in = ion_max_autoionlevel_in[get_uniqueionindex(element, ion)];
-      const auto toplevel_in = get_nlevels(element, ion) - 1 + groundstate_index_in;
-      if (max_autoionlevel_in >= 0 && max_autoionlevel_in != toplevel_in) {
-        printlnlog(
-            "[error] autoion.txt: Z={} ionstage {}: the highest autoionising level index {} is not the ion's highest "
-            "level index {}. The autoion.txt level numbering may not match the ground state index {} detected from "
-            "adata.txt",
-            get_atomicnumber(element), get_ionstage(element, ion), max_autoionlevel_in, toplevel_in,
-            groundstate_index_in);
-        assert_always(false);
+    // the autoionising levels of an ion must be a contiguous block ending at its highest level (asserted below), so
+    // for each ion with autoionisation data the highest autoionising level in the file must be the ion's top level.
+    // Checking the raw file indices detects an autoion.txt whose level numbering disagrees with adata.txt
+    for (int element = 0; element < get_nelements(); element++) {
+      const int nions = get_nions(element);
+      for (int ion = 0; ion < nions; ion++) {
+        const auto max_autoionlevel_in = ion_max_autoionlevel_in[get_uniqueionindex(element, ion)];
+        const auto toplevel_in = get_nlevels(element, ion) - 1 + groundstate_index_in;
+        if (max_autoionlevel_in >= 0 && max_autoionlevel_in != toplevel_in) {
+          printlnlog(
+              "[error] autoion.txt: Z={} ionstage {}: the highest autoionising level index {} is not the ion's highest "
+              "level index {}. The autoion.txt level numbering may not match the ground state index {} detected from "
+              "adata.txt",
+              get_atomicnumber(element), get_ionstage(element, ion), max_autoionlevel_in, toplevel_in,
+              groundstate_index_in);
+          assert_always(false);
+        }
       }
     }
+
+    printlnlog("autoion.txt: read {} autoionisation transitions, stored {} for the included ions",
+               autoion_transitions_read, temp_allautoion.size());
+
+    nautoion_stored = std::ssize(temp_allautoion);
   }
+  MPI_Bcast_safe(nautoion_stored, 0, globals::mpi_comm_node);
 
-  printlnlog("autoion.txt: read {} autoionisation transitions, stored {} for the included ions",
-             autoion_transitions_read, temp_allautoion.size());
-
-  globals::allautoion = MPI_shared_array<globals::LevelAutoion>(temp_allautoion.size());
+  globals::allautoion = MPI_shared_array<globals::LevelAutoion>(nautoion_stored);
   if (globals::rank_in_node == 0) {
     std::ranges::copy(temp_allautoion, globals::allautoion.begin());
     std::ranges::copy(temp_nautoiondowntrans, globals::alllevels.nautoiondowntrans.begin());
@@ -1091,33 +1109,37 @@ void read_autoion_data() {
   // Plan is that autoionizing levels will be explicitly included in the NLTE population solver, but that their level
   // populations do not need to be accurately known - so if the ion has a superlevel already, then we will try to attach
   // the autoionizing level populations to that for all purposes outside the NLTE solver. For this, the ions need to
-  // know how many autoionizing levels they have. So count those up now.
+  // know how many autoionizing levels they have. So count those up now (only the node leaders, since the counts are
+  // written to the node-shared ion data).
 
-  int nlevels_autoion_sum = 0;
-  for (int element = 0; element < get_nelements(); element++) {
-    const int nions = get_nions(element);
-    for (int ion = 0; ion < nions; ion++) {
-      const int nlevels = get_nlevels(element, ion);
-      int nlevels_autoion = 0;
-      bool found_autoion_level = false;
-      for (int level = 0; level < nlevels; level++) {
-        const auto level_is_autoionizing = get_nautoiondowntrans(element, ion, level) > 0;
+  if (globals::rank_in_node == 0) {
+    int nlevels_autoion_sum = 0;
+    for (int element = 0; element < get_nelements(); element++) {
+      const int nions = get_nions(element);
+      for (int ion = 0; ion < nions; ion++) {
+        const int nlevels = get_nlevels(element, ion);
+        int nlevels_autoion = 0;
+        bool found_autoion_level = false;
+        for (int level = 0; level < nlevels; level++) {
+          const auto level_is_autoionizing = get_nautoiondowntrans(element, ion, level) > 0;
 
-        if (level_is_autoionizing) {
-          nlevels_autoion++;
-          found_autoion_level = true;
+          if (level_is_autoionizing) {
+            nlevels_autoion++;
+            found_autoion_level = true;
+          }
+
+          // once we have found one autoionizing level, all higher levels should also be autoionizing
+          if (found_autoion_level) {
+            assert_always(level_is_autoionizing);
+          }
         }
-
-        // once we have found one autoionizing level, all higher levels should also be autoionizing
-        if (found_autoion_level) {
-          assert_always(level_is_autoionizing);
-        }
+        globals::elements[element].ions[ion].nlevels_autoion = nlevels_autoion;
+        nlevels_autoion_sum += nlevels_autoion;
       }
-      globals::elements[element].ions[ion].nlevels_autoion = nlevels_autoion;
-      nlevels_autoion_sum += nlevels_autoion;
     }
+    assert_always(nlevels_autoion_sum == nautoion_stored);
   }
-  assert_always(nlevels_autoion_sum == std::ssize(temp_allautoion));
+  MPI_Barrier_node();
 }
 
 void read_phixs_data() {
@@ -1147,47 +1169,59 @@ void read_phixs_data() {
     ion_minphixslevel_infile[v].assign(get_includedions(), std::numeric_limits<int>::max());
   }
 
-  if (phixs_file_version_exists[2]) {
-    read_phixs_file(2, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[2]);
-    MPI_Barrier_node();
-  }
+  // only the node leaders parse the phixs files: the level lists they populate are in node-shared memory, and the
+  // rank-local totals parsed from the files are broadcast within the node below
+  if (globals::rank_in_node == 0) {
+    if (phixs_file_version_exists[2]) {
+      read_phixs_file(2, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[2]);
+    }
 
-  if (phixs_file_version_exists[1]) {
-    read_phixs_file(1, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[1]);
-    MPI_Barrier_node();
-  }
+    if (phixs_file_version_exists[1]) {
+      read_phixs_file(1, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[1]);
+    }
 
-  // every ion with any photoionisation data must include a cross-section from the ground state, so an excited level
-  // having one without the ground state means the phixs data numbers levels differently from adata.txt. Checked on
-  // the raw file contents (recorded before filtering on retained levels) so that a misnumbered ground state table
-  // cannot be filtered out silently. A file relying on its companion phixs file for the ground state table is
-  // allowed with a warning, since the combined dataset satisfies the invariant
-  for (const int v : {1, 2}) {
-    const int othv = 3 - v;
-    for (int element = 0; element < get_nelements(); element++) {
-      const int nions = get_nions(element);
-      for (int ion = 0; ion < nions; ion++) {
-        const auto uniqueionindex = get_uniqueionindex(element, ion);
-        const auto minphixslevel = ion_minphixslevel_infile[v][uniqueionindex];
-        if (minphixslevel == std::numeric_limits<int>::max() || minphixslevel == 0) {
-          continue;  // the file has no tables for this ion, or it includes the ground state table
-        }
-        if (ion_minphixslevel_infile[othv][uniqueionindex] == 0) {
-          printlnlog(
-              "[warning] {}: Z={} ionstage {}: the file includes a cross-section for an excited level of this ion but "
-              "the ground state table comes from {}. Check that the two files use the same level numbering",
-              phixsdata_filenames[v], get_atomicnumber(element), get_ionstage(element, ion), phixsdata_filenames[othv]);
-        } else {
-          printlnlog(
-              "[error] {}: Z={} ionstage {}: the file includes a cross-section for an excited level of this ion but "
-              "none for the ground state. The phixs level numbering may not match the ground state index {} detected "
-              "from adata.txt",
-              phixsdata_filenames[v], get_atomicnumber(element), get_ionstage(element, ion), groundstate_index_in);
-          assert_always(false);
+    // every ion with any photoionisation data must include a cross-section from the ground state, so an excited
+    // level having one without the ground state means the phixs data numbers levels differently from adata.txt.
+    // Checked on the raw file contents (recorded before filtering on retained levels) so that a misnumbered ground
+    // state table cannot be filtered out silently. A file relying on its companion phixs file for the ground state
+    // table is allowed with a warning, since the combined dataset satisfies the invariant
+    for (const int v : {1, 2}) {
+      const int othv = 3 - v;
+      for (int element = 0; element < get_nelements(); element++) {
+        const int nions = get_nions(element);
+        for (int ion = 0; ion < nions; ion++) {
+          const auto uniqueionindex = get_uniqueionindex(element, ion);
+          const auto minphixslevel = ion_minphixslevel_infile[v][uniqueionindex];
+          if (minphixslevel == std::numeric_limits<int>::max() || minphixslevel == 0) {
+            continue;  // the file has no tables for this ion, or it includes the ground state table
+          }
+          if (ion_minphixslevel_infile[othv][uniqueionindex] == 0) {
+            printlnlog(
+                "[warning] {}: Z={} ionstage {}: the file includes a cross-section for an excited level of this ion "
+                "but the ground state table comes from {}. Check that the two files use the same level numbering",
+                phixsdata_filenames[v], get_atomicnumber(element), get_ionstage(element, ion),
+                phixsdata_filenames[othv]);
+          } else {
+            printlnlog(
+                "[error] {}: Z={} ionstage {}: the file includes a cross-section for an excited level of this ion but "
+                "none for the ground state. The phixs level numbering may not match the ground state index {} "
+                "detected from adata.txt",
+                phixsdata_filenames[v], get_atomicnumber(element), get_ionstage(element, ion), groundstate_index_in);
+            assert_always(false);
+          }
         }
       }
     }
   }
+
+  // share the values parsed from the phixs file headers and the continuum totals with the other ranks in the node
+  // (the node-shared level lists are synchronised by the barrier)
+  MPI_Bcast_safe(globals::NPHIXSPOINTS, 0, globals::mpi_comm_node);
+  MPI_Bcast_safe(globals::NPHIXSNUINCREMENT, 0, globals::mpi_comm_node);
+  MPI_Bcast_safe(last_phixs_nuovernuedge, 0, globals::mpi_comm_node);
+  MPI_Bcast_safe(globals::nbfcontinua, 0, globals::mpi_comm_node);
+  MPI_Bcast_safe(globals::nbfcontinua_ground, 0, globals::mpi_comm_node);
+  MPI_Barrier_node();
 
   int cont_index = 0;
   ptrdiff_t nbftables = 0;
@@ -1198,7 +1232,9 @@ void read_phixs_data() {
       for (int level = 0; level < nlevels; level++) {
         const int nphixstargets = get_nphixstargets(element, ion, level);
         const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
-        globals::alllevels.bflist_start[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
+        if (globals::rank_in_node == 0) {
+          globals::alllevels.bflist_start[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
+        }
         cont_index += nphixstargets;
         if (nphixstargets > 0) {
           nbftables++;
@@ -1206,17 +1242,18 @@ void read_phixs_data() {
       }
     }
   }
-  assert_always(cont_index == std::ssize(tmpallphixstargets));
+  if (globals::rank_in_node == 0) {
+    assert_always(cont_index == std::ssize(tmpallphixstargets));
+  }
 
-  if (!tmpallphixs.empty()) {
-    assert_always((nbftables * globals::NPHIXSPOINTS) == std::ssize(tmpallphixs));
-
+  if (cont_index > 0) {
     // copy the photoionisation tables into one contiguous block of memory
-    globals::allphixs = MPI_shared_array<float>(std::ssize(tmpallphixs));
-    auto allphixstargets_levelindex = MPI_shared_array<int>(std::ssize(tmpallphixstargets));
-    auto allphixstargets_probability = MPI_shared_array<double>(std::ssize(tmpallphixstargets));
+    globals::allphixs = MPI_shared_array<float>(nbftables * globals::NPHIXSPOINTS);
+    auto allphixstargets_levelindex = MPI_shared_array<int>(cont_index);
+    auto allphixstargets_probability = MPI_shared_array<double>(cont_index);
 
     if (globals::rank_in_node == 0) {
+      assert_always((nbftables * globals::NPHIXSPOINTS) == std::ssize(tmpallphixs));
       std::ranges::copy(tmpallphixs, globals::allphixs.begin());
 
       for (int i = 0; i < std::ssize(tmpallphixstargets); i++) {

--- a/input.cc
+++ b/input.cc
@@ -1553,7 +1553,7 @@ void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
   // make sure that all ranks can see the filled transition arrays before the striped loop below
   MPI_Barrier_node();
 
-  printlnlog("establishing connection between transitions and sorted linelist...");
+  printlog("establishing connection between transitions and sorted linelist...");
 
   const auto time_start_establish_linelist_connections = std::chrono::steady_clock::now();
 
@@ -1602,8 +1602,7 @@ void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
   const auto establish_linelist_connections_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - time_start_establish_linelist_connections)
           .count();
-  printlnlog("established connections between transitions and sorted linelist (took {:.1f} seconds)",
-             establish_linelist_connections_duration);
+  printlnlog(" (took {:.1f} seconds)", establish_linelist_connections_duration);
   MPI_Barrier_node();
 }
 

--- a/input.cc
+++ b/input.cc
@@ -5,10 +5,8 @@
 
 #include <algorithm>
 #include <array>
-#include <charconv>
 #include <chrono>
 #include <cmath>
-#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -22,7 +20,6 @@
 #include <istream>
 #include <iterator>
 #include <limits>
-#include <memory>
 #include <print>
 #include <ranges>
 #include <span>
@@ -440,52 +437,6 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
       }
     }
   }
-}
-
-// parse the next whitespace-delimited token of the line as a number and advance past it.
-// Returns false if there is no token left or the token is not fully numeric
-template <typename T>
-[[nodiscard]] auto parse_next_token(std::string_view& remainder, T& value) -> bool {
-  constexpr std::string_view whitespace = " \t\r";
-  const auto tokenstart = remainder.find_first_not_of(whitespace);
-  if (tokenstart == std::string_view::npos) {
-    return false;
-  }
-  const auto tokenend = std::min(remainder.find_first_of(whitespace, tokenstart), remainder.size());
-  auto token = remainder.substr(tokenstart, tokenend - tokenstart);
-  if (token.front() == '+') {  // stream extraction accepted a leading plus sign, but from_chars does not
-    token.remove_prefix(1);
-  }
-  const auto* const tokenfirst = token.data();
-  const auto* const tokenlast = std::to_address(token.cend());
-  const auto [ptr, ec] = std::from_chars(tokenfirst, tokenlast, value);
-  if (ptr != tokenlast) {
-    return false;
-  }
-  if constexpr (std::floating_point<T>) {
-    if (ec == std::errc{} && !std::isfinite(value)) {
-      // reject nan and inf spellings, which from_chars accepts but stream extraction did not
-      return false;
-    }
-    if (ec == std::errc::result_out_of_range) {
-      // a syntactically valid number outside the range of T. Stream extraction stored zero for underflow (even
-      // below double range, such as 1e-400) but rejected overflow, so use strtod, which returns zero for
-      // underflow, to distinguish the two (the token views a null-terminated getline buffer, and strtod stops
-      // at the whitespace or end of line that terminates the token)
-      char* parseend{};
-      const double dvalue = std::strtod(tokenfirst, &parseend);
-      if (parseend == tokenlast && std::fabs(dvalue) <= std::numeric_limits<T>::max()) {
-        value = static_cast<T>(dvalue);
-        remainder.remove_prefix(tokenend);
-        return true;
-      }
-    }
-  }
-  if (ec != std::errc{}) {
-    return false;
-  }
-  remainder.remove_prefix(tokenend);
-  return true;
 }
 
 void read_ion_transitions(std::istream& ftransitiondata, const int ion_transition_count_in_file,

--- a/input.cc
+++ b/input.cc
@@ -1577,31 +1577,24 @@ void create_shared_alltranslist(std::vector<TempAllTransInput>& temp_alltranslis
     const auto upperlevel = upper_uniquelevelindex - ionuniquelevelindexstart;
     const auto lowerlevel = lower_uniquelevelindex - ionuniquelevelindexstart;
 
-    // there is never more than one transition per pair of levels,
-    // so find the first up and the first down transition that match: element, ion, lowerlevel, upperlevel
+    // there is exactly one transition per pair of levels, and each level's down and up transition target lists
+    // are sorted in ascending order (add_transitions_to_unsorted_linelist fills them by iterating the transition
+    // table in (lower, upper) order), so the matching entries can be found by binary search
 
     const auto alltrans_startdown = get_alltrans_startdown(upper_uniquelevelindex);
     const auto ndowntrans = get_ndowntrans(upper_uniquelevelindex);
-    int downtransid = -1;
-    for (int i = alltrans_startdown; i < alltrans_startdown + ndowntrans; i++) {
-      if (globals::alltrans.targetlevelindex[i] == lowerlevel) {
-        downtransid = i;
-        break;
-      }
-    }
-    assert_always(downtransid != -1);
+    const auto downtargets = globals::alltrans.targetlevelindex.subspan(alltrans_startdown, ndowntrans);
+    const auto downit = std::ranges::lower_bound(downtargets, lowerlevel);
+    assert_always(downit != downtargets.end() && *downit == lowerlevel);
+    const auto downtransid = alltrans_startdown + static_cast<int>(downit - downtargets.begin());
     alltrans_lineindex[downtransid] = lineindex;
 
     const auto alltrans_startup = get_alltrans_startup(lower_uniquelevelindex);
     const auto nuptrans = get_nuptrans(lower_uniquelevelindex);
-    int uptransid = -1;
-    for (int i = alltrans_startup; i < alltrans_startup + nuptrans; i++) {
-      if (globals::alltrans.targetlevelindex[i] == upperlevel) {
-        uptransid = i;
-        break;
-      }
-    }
-    assert_always(uptransid != -1);
+    const auto uptargets = globals::alltrans.targetlevelindex.subspan(alltrans_startup, nuptrans);
+    const auto upit = std::ranges::lower_bound(uptargets, upperlevel);
+    assert_always(upit != uptargets.end() && *upit == upperlevel);
+    const auto uptransid = alltrans_startup + static_cast<int>(upit - uptargets.begin());
     alltrans_lineindex[uptransid] = lineindex;
   }
   globals::alltrans.lineindex = std::move(alltrans_lineindex);

--- a/input.h
+++ b/input.h
@@ -62,7 +62,9 @@ template <typename T>
   }
   const auto tokenend = std::min(remainder.find_first_of(whitespace, tokenstart), remainder.size());
   auto token = remainder.substr(tokenstart, tokenend - tokenstart);
-  if (token.front() == '+') {  // stream extraction accepted a leading plus sign, but from_chars does not
+  // stream extraction accepted a leading plus sign, but from_chars does not. Only remove the plus if it is not
+  // followed by another sign, so that malformed tokens like "+-0" stay rejected
+  if (token.size() >= 2 && token.front() == '+' && token[1] != '-' && token[1] != '+') {
     token.remove_prefix(1);
   }
   const auto* const tokenfirst = token.data();

--- a/input.h
+++ b/input.h
@@ -3,10 +3,18 @@
 #ifndef INPUT_H
 #define INPUT_H
 
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <concepts>
+#include <cstdlib>
 #include <istream>
+#include <limits>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 #include "packet.h"
 
@@ -39,6 +47,54 @@ inline auto get_noncommentline(std::istream& input, std::string& line) -> bool {
       return true;
     }
   }
+}
+
+// parse the next whitespace-delimited token of the line as a number and advance past it.
+// Returns false if there is no token left or the token is not fully numeric.
+// Accepts the same number spellings as stream extraction: leading plus signs are allowed, magnitudes below the
+// range of T (or of double) read as zero, and out-of-range magnitudes and nan/inf spellings are rejected
+template <typename T>
+[[nodiscard]] inline auto parse_next_token(std::string_view& remainder, T& value) -> bool {
+  constexpr std::string_view whitespace = " \t\r";
+  const auto tokenstart = remainder.find_first_not_of(whitespace);
+  if (tokenstart == std::string_view::npos) {
+    return false;
+  }
+  const auto tokenend = std::min(remainder.find_first_of(whitespace, tokenstart), remainder.size());
+  auto token = remainder.substr(tokenstart, tokenend - tokenstart);
+  if (token.front() == '+') {  // stream extraction accepted a leading plus sign, but from_chars does not
+    token.remove_prefix(1);
+  }
+  const auto* const tokenfirst = token.data();
+  const auto* const tokenlast = std::to_address(token.cend());
+  const auto [ptr, ec] = std::from_chars(tokenfirst, tokenlast, value);
+  if (ptr != tokenlast) {
+    return false;
+  }
+  if constexpr (std::floating_point<T>) {
+    if (ec == std::errc{} && !std::isfinite(value)) {
+      // reject nan and inf spellings, which from_chars accepts but stream extraction did not
+      return false;
+    }
+    if (ec == std::errc::result_out_of_range) {
+      // a syntactically valid number outside the range of T. Stream extraction stored zero for underflow (even
+      // below double range, such as 1e-400) but rejected overflow, so use strtod, which returns zero for
+      // underflow, to distinguish the two (the token views a null-terminated getline buffer, and strtod stops
+      // at the whitespace or end of line that terminates the token)
+      char* parseend{};
+      const double dvalue = std::strtod(tokenfirst, &parseend);
+      if (parseend == tokenlast && std::fabs(dvalue) <= std::numeric_limits<T>::max()) {
+        value = static_cast<T>(dvalue);
+        remainder.remove_prefix(tokenend);
+        return true;
+      }
+    }
+  }
+  if (ec != std::errc{}) {
+    return false;
+  }
+  remainder.remove_prefix(tokenend);
+  return true;
 }
 
 #endif  // INPUT_H

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -997,11 +997,11 @@ auto main(int argc, char* argv[]) -> int {
   const int ndo_nonempty = grid::get_ndo_nonempty(globals::my_rank);
   if (ndo > 0) {
     printlnlog(
-        "process rank {} (global max rank {}) assigned {} modelgrid cells ({} nonempty): cells [{}..{}] (model "
+        "process rank {} (of 0..{}) assigned {} modelgrid cells ({} nonempty): cells [{}..{}] (model "
         "has max mgi {})",
         globals::my_rank, globals::nprocs - 1, ndo, ndo_nonempty, nstart, nstart + ndo - 1, grid::get_npts_model() - 1);
   } else {
-    printlnlog("process rank {} (global max rank {}) assigned {} modelgrid cells ({} nonempty)", globals::my_rank,
+    printlnlog("process rank {} (of 0..{}) assigned {} modelgrid cells ({} nonempty)", globals::my_rank,
                globals::nprocs - 1, ndo, ndo_nonempty);
   }
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -19,8 +19,10 @@
 #include <format>
 #include <fstream>
 #include <ios>
+#include <iterator>
 #include <limits>
 #include <print>
+#include <string>
 #ifdef STDPAR_ON
 #include <ranges>
 #endif
@@ -165,36 +167,56 @@ void initialise_linestat_file() {
 
   auto linestat_file = fstream_required("linestat.out", std::ios::out | std::ios::trunc);
 
-  for (int i = 0; i < globals::nlines; i++) {
-    std::print(linestat_file, "{:g} ", CLIGHT / globals::linelist.nu[i]);  // wavelength in cm
-  }
-  std::println(linestat_file, "");
+  // with tens of millions of lines, per-value std::print calls to the stream are slow (each one re-checks whether
+  // the stream is a terminal), so format into a buffer and write it out in large chunks
+  std::string buffer;
+  constexpr auto flushsize = 1UZ << 22U;
+  buffer.reserve(flushsize + 64);
+  const auto flush_if_full = [&linestat_file, &buffer]() {
+    if (buffer.size() >= flushsize) {
+      linestat_file.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+      buffer.clear();
+    }
+  };
 
   for (int i = 0; i < globals::nlines; i++) {
-    std::print(linestat_file, "{} ", get_atomicnumber(globals::linelist.elementindex[i]));
+    std::format_to(std::back_inserter(buffer), "{:g} ", CLIGHT / globals::linelist.nu[i]);  // wavelength in cm
+    flush_if_full();
   }
-  std::println(linestat_file, "");
+  buffer += '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
-    std::print(linestat_file, "{} ", get_ionstage(globals::linelist.elementindex[i], globals::linelist.ionindex[i]));
+    std::format_to(std::back_inserter(buffer), "{} ", get_atomicnumber(globals::linelist.elementindex[i]));
+    flush_if_full();
   }
-  std::println(linestat_file, "");
+  buffer += '\n';
+
+  for (int i = 0; i < globals::nlines; i++) {
+    std::format_to(std::back_inserter(buffer), "{} ",
+                   get_ionstage(globals::linelist.elementindex[i], globals::linelist.ionindex[i]));
+    flush_if_full();
+  }
+  buffer += '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
     const auto ionuniquelevelindexstart =
         get_ionuniquelevelindexstart(globals::linelist.elementindex[i], globals::linelist.ionindex[i]);
     const auto upper = globals::linelist.uniquelevelindex_upper[i] - ionuniquelevelindexstart;
-    std::print(linestat_file, "{} ", (upper + 1));
+    std::format_to(std::back_inserter(buffer), "{} ", (upper + 1));
+    flush_if_full();
   }
-  std::println(linestat_file, "");
+  buffer += '\n';
 
   for (int i = 0; i < globals::nlines; i++) {
     const auto ionuniquelevelindexstart =
         get_ionuniquelevelindexstart(globals::linelist.elementindex[i], globals::linelist.ionindex[i]);
     const auto lower = globals::linelist.uniquelevelindex_lower[i] - ionuniquelevelindexstart;
-    std::print(linestat_file, "{} ", (lower + 1));
+    std::format_to(std::back_inserter(buffer), "{} ", (lower + 1));
+    flush_if_full();
   }
-  std::println(linestat_file, "");
+  buffer += '\n';
+
+  linestat_file.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
 }
 
 void write_deposition_file() {


### PR DESCRIPTION
Follow-up to #492: a set of startup speedups, benchmarked on a real 3D kilonova setup (125000 cells x 2473 nuclide columns: 2.1 GB `model.txt`, 1.5 GB `transitiondata.txt` with 48.8 million lines, 126 MB `abundances.txt`). **Total startup through the end of input reading on that setup drops from 151 s to 35 s (4.3x)** on an Apple M4 Pro with 4 MPI ranks. All outputs remain bit-identical, so no checksum regeneration is needed.

## model.txt and abundances.txt parsing

- `parse_next_token` moves from `input.cc`'s anonymous namespace to `input.h`, keeping the stream-extraction-compatible semantics established in #492 (leading `+` accepted unless followed by another sign, underflow reads as zero, overflow and `nan`/`inf` spellings rejected).
- The per-cell parsing of `model.txt` (geometry columns and the abundance columns in `read_model_radioabundances`) and `abundances.txt` threads a `std::string_view` remainder through `parse_next_token` instead of refilling a `std::istringstream` per cell and extracting through the locale-aware `operator>>`.
- Real-model measurement: `model.txt` + `Ye.txt` read 25 s -> 6 s; `abundances.txt` 9 s -> 7 s.

## One reader per file instead of every rank

Several readers had every MPI rank parse the same file and either discard the result or write identical values into node-shared memory. Now:

- **`model.txt` cell data — global rank 0 only.** Rank 0 fills its node's shared arrays (`modelgrid_input`, nuclide mass fractions), which are broadcast to the other node leaders over `mpi_comm_internode`; rank-local results (first cell id, vmax, 1D velocity grid) are broadcast to all ranks. One filesystem reader total, with the parsed binary data crossing the interconnect instead of every node re-reading a much larger text file.
- **`abundances.txt`, `Ye.txt`, phixs files, `autoion.txt` — node leaders only**, with the rank-local scalars (`NPHIXSPOINTS`, `NPHIXSNUINCREMENT`, `nbfcontinua`, `nbfcontinua_ground`, autoionisation transition count) broadcast within each node.
- **`setup_phixs_list`**: the node-shared continuum list, ion ground-continuum indices, closest-ground-level continua, and bf-estimator index arrays are now filled by node leaders only instead of every rank writing identical values.
- Left as-is: small files parsed into rank-local data that every rank genuinely needs (decay data, collision/Auger data, gamma spectra, vpkt config, `compositiondata.txt`, `input.txt`).

On clusters this also removes `nranks - 1` (model.txt) or `node_nprocs - 1` (per node, other files) concurrent reads of the same file from the shared filesystem.

## Transitions-to-linelist connection

Each level's down and up transition target lists are sorted in ascending order (they are filled from the `(lower, upper)`-sorted transition table), so the per-line lookups in `create_shared_alltranslist` binary search the block instead of linearly scanning it: O(sum of block sizes squared) -> O(nlines log blocksize). Real-model measurement: 6.3 s -> 2.5 s; the advantage grows linearly with block size. The per-line asserts still verify that every line finds its exact entry.

## linestat.out writing

Profiling showed the largest remaining startup phase was `initialise_linestat_file()`: five passes over the linelist with one `std::print` call per value (240+ million calls on the real dataset), with ~75% of samples inside libc++'s per-call is-this-a-terminal check. The output is now formatted into a string buffer and written in 4 MB chunks: **98 s -> 8 s** writing the full 1.3 GB file, byte-identical (linestat.out is required by the artistools plotting scripts and is always written on new runs, as before).

## Initial temperature assignment

Every rank was computing the decayed energy release and initial temperature of every non-empty cell, with only the node leader storing the results. The cells are now striped across the ranks of each node, each rank writing its own disjoint subset of the node-shared temperature arrays, with the diagnostic counts combined by node-communicator reductions. Real-model measurement (4 ranks): **35 s -> 8 s**, scaling with the number of ranks per node.

## Real-dataset benchmark summary (Apple M4 Pro, 4 MPI ranks, warm cache, two runs per binary)

| startup phase | before (merged #492) | after |
| --- | --- | --- |
| adata + transitiondata parse | 6 s | 6 s (optimised in #492) |
| transitions-to-linelist connection | 6.3 s | 2.5 s |
| `model.txt` + `Ye.txt` read | 25 s | 6 s |
| `linestat.out` write (1.3 GB) | 99 s | 8 s |
| `abundances.txt` read | 9 s | 7 s |
| **total to end of input reading** | **151 s** | **35 s** |

## Verification

Same-machine baseline-vs-changed checksum comparisons (`REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2`), baseline = merged #492, re-run after each change including the final state of the branch:

- kilonova_1d full sequence (newrun + resume + exspec): 1D spherical model, one-line-per-cell format, `abundances.txt`, and `linestat.out` — all output files checksum-identical.
- classicmode_3d first job: 3D Cartesian model in the two-line-per-cell format with the v1 `phixsdata.txt` and VPKT enabled — all output and checkpoint files checksum-identical.

Both runs use 4 MPI ranks with `MAX_NODE_SIZE=2` (two nodes of two ranks), so the internode model broadcast, the intra-node broadcasts, and the non-leader skip paths are all exercised. The real 3D setup also ran end-to-end through timestep 0 packet propagation as an integration check. **No checksum regeneration is needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
