### PR TITLE
Reuse decay path Bateman factors across cells for pellet energies, initial temperatures, and abundance updates

### DIFF
--- a/decay.cc
+++ b/decay.cc
@@ -545,6 +545,14 @@ auto get_nuc_massfrac(const int nonemptymgi, const int nucindex, const double ti
   return nuctotal;
 }
 
+// the chain-end abundance per unit chain-top initial abundance for one decaypath at the given time, with the
+// chain end treated as stable (so it counts the fraction of chain-top nuclei that decayed past the chain end)
+auto calc_decaypath_unitfactor(const int decaypathindex, const double time, const bool useexpansionfactor) -> double {
+  auto lambdas = decaypaths[decaypathindex].lambdas;
+  lambdas[lambdas.size() - 1] = 0.;
+  return calculate_decaychain(1., lambdas, time - grid::get_t_model(), useexpansionfactor);
+}
+
 // Get the decay energy [erg/g] that would be released from time tstart [s] to time infinity by a given decaypath
 // e.g. Ni56 -> Co56, represents the decays of Co56 nuclei that were produced from Ni56 in the initial abundance.
 // Decays from Co56 due to the initial abundance of Co56 are not counted here, nor is the energy from Ni56 decays
@@ -561,14 +569,8 @@ auto get_endecay_to_tinf_per_ejectamass_at_time(const int modelgridindex, const 
     return 0.;
   }
 
-  const double t_afterinit = time - grid::get_t_model();
-
   // count the number of chain-top nuclei that haven't decayed past the end of the chain
-  auto lambdas = decaypath.lambdas;
-  // treat the end nuclide as stable to count how many got produced
-  lambdas[lambdas.size() - 1] = 0.;
-
-  const double abund_endsink = calculate_decaychain(top_initabund, lambdas, t_afterinit, false);
+  const double abund_endsink = top_initabund * calc_decaypath_unitfactor(decaypathindex, time, false);
   const double ndecays_remaining = decaypath.branchproduct * (top_initabund - abund_endsink);
 
   const double endecay = ndecays_remaining * get_decaypath_lastdecayenergy(decaypath);
@@ -615,23 +617,6 @@ auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion_chain_numerical(con
   printlnlog("  expansion energy factor:    {:g}", chain_endecay / chain_endecay_noexpansion);
 
   return chain_endecay;
-}
-
-// get decay energy per mass [erg/g] released by a decaypath between times tlow [s] and thigh [s]
-auto get_endecay_per_ejectamass_between_times(const int mgi, const int decaypathindex, const double tlow,
-                                              const double thigh) -> double {
-  assert_testmodeonly(mgi < grid::get_npts_model());
-  assert_testmodeonly(tlow <= thigh);
-  const double energy_tlow = get_endecay_to_tinf_per_ejectamass_at_time(mgi, decaypathindex, tlow);
-  const double energy_thigh = get_endecay_to_tinf_per_ejectamass_at_time(mgi, decaypathindex, thigh);
-  const double endiff = energy_tlow - energy_thigh;
-  assert_always(std::isfinite(endiff));
-  if (endiff < 0.) {
-    // if the error is larger than just roundoff, this is a problem
-    assert_always((energy_tlow * (1 + 2e-5)) >= energy_thigh);
-    return 0.;
-  }
-  return endiff;
 }
 
 // Get the total decay power per mass [erg/s/g] for a given decaypath
@@ -1174,71 +1159,67 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   return alldecaytypes_is_used[decaytype];
 }
 
-// calculate the decay energy per unit mass [erg/g] released from time t_model (can be before tmin) to tstart,
-// accounting for the photon energy loss due to expansion between time of decays and tstart (equation 18 of Lucy 2005)
-auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(const int nonemptymgi, const double tstart) -> double {
+// precompute the abundance-independent Bateman factors for every decaypath at the given time (with the chain ends
+// treated as stable), so that the same decay chain calculations can be applied to every cell's initial abundances
+auto calc_decaypath_factors(const double time, const bool useexpansionfactor) -> std::vector<double> {
+  const auto num_decaypaths = get_num_decaypaths();
+  std::vector<double> decaypathfactors(num_decaypaths);
+  for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
+    decaypathfactors[decaypathindex] = calc_decaypath_unitfactor(decaypathindex, time, useexpansionfactor);
+  }
+  return decaypathfactors;
+}
+
+// calculate the decay energy per unit mass [erg/g] released from time t_model (can be before tmin) to the time of
+// the precomputed expansion factors (from calc_decaypath_factors(tstart, true)), accounting for the photon energy
+// loss due to expansion between time of decays and tstart (equation 18 of Lucy 2005)
+auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(const int nonemptymgi,
+                                                             const std::span<const double> decaypathfactors) -> double {
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-  const double t_afterinit = tstart - grid::get_t_model();
   double tot_endecay = 0.;
-  for (const auto& decaypath : decaypaths) {
+  for (int decaypathindex = 0; decaypathindex < std::ssize(decaypathfactors); decaypathindex++) {
+    const auto& decaypath = decaypaths[decaypathindex];
     const int nucindex_top = decaypath.nucindex[0];
 
     const double top_initabund = grid::get_modelinitnucmassfrac(modelgridindex, nucindex_top) / nucmass(nucindex_top);
-    auto lambdas = decaypath.lambdas;
-    // treat the end nuclide as stable to count how many got produced by the chain
-    lambdas[lambdas.size() - 1] = 0.;
 
-    const double chain_endecay =
-        (decaypath.branchproduct * calculate_decaychain(top_initabund, lambdas, t_afterinit, true) *
-         get_decaypath_lastdecayenergy(decaypath));
-
-    tot_endecay += chain_endecay;
+    tot_endecay += (decaypath.branchproduct * top_initabund * decaypathfactors[decaypathindex] *
+                    get_decaypath_lastdecayenergy(decaypath));
   }
 
   return tot_endecay;
 }
 
-// get the decay energy that will be released during the simulation time [(tmodel if initial packets else tmin) to tmax]
-// indexed by nonemptymgi and decaypathindex [erg/g]
+// get the decay energy per unit ejecta mass [erg/g] that will be released by a model cell during the simulation
+// time [(tmodel if initial packets else tmin) to tmax]
 auto get_modelcell_simtime_endecay_per_mass(const int nonemptymgi,
-                                            const std::span<const double> energy_per_mass_nonemptymgi_decaypath)
-    -> double {
-  const auto num_decaypaths = get_num_decaypaths();
+                                            const std::span<const double> energy_per_massoftopnuc_decaypath) -> double {
+  const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   double endecay_per_mass = 0.;
-  for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
-    endecay_per_mass += energy_per_mass_nonemptymgi_decaypath[(nonemptymgi * num_decaypaths) + decaypathindex];
+  for (int decaypathindex = 0; decaypathindex < std::ssize(energy_per_massoftopnuc_decaypath); decaypathindex++) {
+    endecay_per_mass += grid::get_modelinitnucmassfrac(mgi, decaypaths[decaypathindex].nucindex[0]) *
+                        energy_per_massoftopnuc_decaypath[decaypathindex];
   }
   return endecay_per_mass;
 }
 
-// energy_per_mass_nonemptymgi_decaypath is an array indexed by [nonemptymgi * num_decaypaths + i] will hold the
-// decay energy per mass [erg/g] released by chain i in cell mgi during the simulation time range tmin to tmax
-auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const double> {
-  const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
-  printlnlog(
-      "[info] mem_usage: energy_per_mass_nonemptymgi_decaypath[nonempty_npts_model*num_decaypaths] occupies {:.1f} "
-      "MB (node shared memory).",
-      nonempty_npts_model * get_num_decaypaths() * sizeof(double) / 1024. / 1024.);
-  auto energy_per_mass_nonemptymgi_decaypath = MPI_shared_array<double>{nonempty_npts_model * get_num_decaypaths(), 0.};
-
-  MPI_Barrier_allranks();
+// decay energy per unit mass of the chain-top nuclide [erg/(g of chain-top nuclide)] released by each decaypath
+// during the simulation time [(tmodel if initial packets else tmin) to tmax]. Multiplying by a cell's initial
+// mass fraction of the chain-top nuclide gives the decay energy per unit ejecta mass
+auto calc_energy_per_massoftopnuc_decaypath() -> std::vector<double> {
   const auto time_min_decay = INITIAL_PACKETS_ON ? grid::get_t_model() : globals::tmin;
-  const ptrdiff_t num_decaypaths = get_num_decaypaths();
-  for (int nonemptymgi = 0; nonemptymgi < nonempty_npts_model; nonemptymgi++) {
-    if (nonemptymgi % globals::node_nprocs == globals::rank_in_node) {
-      const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-      for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
-        const double energy_per_mass =
-            get_endecay_per_ejectamass_between_times(mgi, decaypathindex, time_min_decay, globals::tmax);
-        assert_testmodeonly(energy_per_mass >= 0.);
-        assert_testmodeonly(std::isfinite(energy_per_mass));
-        energy_per_mass_nonemptymgi_decaypath[(nonemptymgi * num_decaypaths) + decaypathindex] = energy_per_mass;
-      }
-    }
+  const auto num_decaypaths = get_num_decaypaths();
+  std::vector<double> energy_per_massoftopnuc(num_decaypaths);
+  for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
+    const auto& decaypath = decaypaths[decaypathindex];
+    // fraction of chain-top nuclei that decay past the end of the chain between the two times
+    const double fdecayed = std::max(0., calc_decaypath_unitfactor(decaypathindex, globals::tmax, false) -
+                                             calc_decaypath_unitfactor(decaypathindex, time_min_decay, false));
+    energy_per_massoftopnuc[decaypathindex] =
+        decaypath.branchproduct * fdecayed * get_decaypath_lastdecayenergy(decaypath) / nucmass(decaypath.nucindex[0]);
+    assert_always(std::isfinite(energy_per_massoftopnuc[decaypathindex]));
   }
-
-  MPI_Barrier_allranks();
-  return energy_per_mass_nonemptymgi_decaypath;
+  return energy_per_massoftopnuc;
 }
 
 // energy release rate in form of kinetic energy of positrons, electrons, and alpha particles in [erg/s/g]
@@ -1388,8 +1369,9 @@ void output_isotopic_densities(std::ostream& estimators_file, const int nonempty
 }
 
 void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptymgi, Packet& pkt,
-                              const std::span<const double> energy_per_mass_nonemptymgi_decaypath) {
+                              const std::span<const double> energy_per_massoftopnuc_decaypath) {
   const int num_decaypaths = get_num_decaypaths();
+  const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
   // decay channels include all radioactive decay paths, and possibly also an initial cell energy channel
   const int num_decaychannels = num_decaypaths + ((INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? 1 : 0);
@@ -1399,14 +1381,14 @@ void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptym
 
   // add the radioactive decay paths
   for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
-    energysum += energy_per_mass_nonemptymgi_decaypath[(nonemptymgi * num_decaypaths) + decaypathindex];
+    energysum += grid::get_modelinitnucmassfrac(mgi, decaypaths[decaypathindex].nucindex[0]) *
+                 energy_per_massoftopnuc_decaypath[decaypathindex];
     cumulative_en_sum[decaypathindex] = energysum;
   }
 
   if (num_decaychannels > num_decaypaths) {
     // the t_model / tmin expansion factor was already applied at model read in
     // so "init" here means at tmin
-    const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
     energysum += grid::get_initenergyq(mgi);
     cumulative_en_sum[num_decaychannels - 1] = energysum;
   }
@@ -1457,8 +1439,8 @@ void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptym
     // we need to scale the packet energy up or down according to decay rate at the randomly selected time.
     // e_cmf_average is the average energy per packet for this cell and decaypath, so we scale this up or down
     // according to: decay power at this time relative to the average decay power
-    const double avgpower = energy_per_mass_nonemptymgi_decaypath[(nonemptymgi * num_decaypaths) + decaypathindex] /
-                            (globals::tmax - tdecaymin);
+    const double avgpower = grid::get_modelinitnucmassfrac(mgi, decaypaths[decaypathindex].nucindex[0]) *
+                            energy_per_massoftopnuc_decaypath[decaypathindex] / (globals::tmax - tdecaymin);
     assert_always(avgpower > 0.);
     pkt.e_cmf =
         e_cmf_per_packet * get_decaypath_power_per_ejectamass(decaypathindex, nonemptymgi, pkt.tdecay) / avgpower;

--- a/decay.cc
+++ b/decay.cc
@@ -1112,11 +1112,14 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
 
   printlnlog("Number of nuclides before filtering: {}", std::ssize(nuclides));
   decaypaths = find_decaypaths(custom_zlist, custom_alist, standard_nuclides);
+  abort_if_decaypath_has_duplicate_lambdas();
+  filter_unused_nuclides(custom_zlist, custom_alist, standard_nuclides);
+
+  // cache the chain-top nuclide index of every decaypath (only after filter_unused_nuclides, which remaps the
+  // nuclide indices)
   decaypath_topnucindex.resize(decaypaths.size());
   std::ranges::transform(decaypaths, decaypath_topnucindex.begin(),
                          [](const auto& decaypath) { return decaypath.nucindex[0]; });
-  abort_if_decaypath_has_duplicate_lambdas();
-  filter_unused_nuclides(custom_zlist, custom_alist, standard_nuclides);
 
   printlnlog("Number of nuclides: {}", std::ssize(nuclides));
 
@@ -1167,6 +1170,7 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
 // per-decaypath energy coefficients (each an energy per unit mass of that decaypath's chain-top nuclide)
 auto get_modelcell_endecay_per_mass(const int nonemptymgi,
                                     const std::span<const double> energy_per_massoftopnuc_decaypath) -> double {
+  assert_testmodeonly(std::ssize(energy_per_massoftopnuc_decaypath) == get_num_decaypaths());
   const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   double endecay_per_mass = 0.;
   for (int decaypathindex = 0; decaypathindex < std::ssize(energy_per_massoftopnuc_decaypath); decaypathindex++) {
@@ -1346,6 +1350,7 @@ void update_abundances(const int nonemptymgi_start, const int nonemptymgi_count,
     // alpha decay through the last step of the chain is counted
     const auto last_decaytype = decaypath.decaytypes[decaypath.decaytypes.size() - 2];
     if (he4_nucindex >= 0 && last_decaytype == DecayType::DECAYTYPE_ALPHA && nucindex_end != he4_nucindex) {
+      // NOLINTNEXTLINE(readability-suspicious-call-argument)
       add_contribution(he4_nucindex, nucindex_top,
                        decaypath.branchproduct * calc_decaypath_unitfactor(decaypathindex, t_current, false) *
                            nucmass(he4_nucindex) / nucmass(nucindex_top));
@@ -1420,6 +1425,7 @@ void output_isotopic_densities(std::ostream& estimators_file, const int nonempty
 
 void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptymgi, Packet& pkt,
                               const std::span<const double> energy_per_massoftopnuc_decaypath) {
+  assert_testmodeonly(std::ssize(energy_per_massoftopnuc_decaypath) == get_num_decaypaths());
   const int num_decaypaths = static_cast<int>(std::ssize(energy_per_massoftopnuc_decaypath));
   const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 

--- a/decay.cc
+++ b/decay.cc
@@ -1305,35 +1305,92 @@ auto get_global_etot_tmodel_tinf() -> double {
   return etot_tinf;
 }
 
-// Update the mass fractions of elements using the current abundances of nuclides
-void update_abundances(const int nonemptymgi, const double t_current) {
-  for (int element = get_nelements() - 1; element >= 0; element--) {
-    const int atomic_number = get_atomicnumber(element);
+// Update the mass fractions of elements from the decayed nuclide abundances for a contiguous range of cells at
+// time t_current. Each nuclide's mass fraction is a linear function of the cell's initial nuclide mass fractions,
+// with coefficients from the Bateman solution that depend only on the elapsed time, so the coefficients are
+// computed once and applied to every cell
+void update_abundances(const int nonemptymgi_start, const int nonemptymgi_count, const double t_current) {
+  const double t_afterinit = t_current - grid::get_t_model();
+  const auto num_nuclides = std::ssize(nuclides);
+  const auto nelements = get_nelements();
 
-    // the mass fraction sum of radioactive isotopes, and stable nuclei coming from other decays for the current element
-    double isomassfracsum = 0.;
-    double isomassfrac_on_nucmass_sum = 0.;
-    const auto num_nuclides = std::ssize(nuclides);
-    for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
-      if (get_nuc_z(nucindex) == atomic_number) {
-        const double nuc_massfrac = get_nuc_massfrac(nonemptymgi, nucindex, t_current);
-        isomassfracsum += nuc_massfrac;
-        isomassfrac_on_nucmass_sum += nuc_massfrac / nucmass(nucindex);
-      }
-    }
+  // for each nuclide, the (source nuclide, coefficient) contributions such that the nuclide's mass fraction is
+  // the sum over contributions of coeff * (cell's initial mass fraction of the source nuclide)
+  auto contributions = std::vector<std::vector<std::pair<int, double>>>(num_nuclides);
 
-    const double otherstablemassfrac = grid::get_elem_untrackedstable_initmassfrac(nonemptymgi, element);
-    isomassfracsum += otherstablemassfrac;
-    isomassfrac_on_nucmass_sum += otherstablemassfrac / globals::elements[element].initstablemeannucmass;
-
-    grid::set_elem_massfrac(nonemptymgi, element, static_cast<float>(isomassfracsum));
-    const auto meanweight = static_cast<float>(isomassfracsum / isomassfrac_on_nucmass_sum);
-    grid::set_element_meanweight(
-        nonemptymgi, element,
-        (std::isfinite(meanweight) && meanweight > 0.) ? meanweight : globals::elements[element].initstablemeannucmass);
+  // exponential decay of each nuclide's own initial abundance
+  for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
+    const auto meanlife = get_meanlife(nucindex);
+    const auto lambda = (meanlife > 0.) ? 1. / meanlife : 0.;
+    contributions[nucindex].emplace_back(nucindex, exp(-t_afterinit * lambda));
   }
 
-  grid::set_nnetot(nonemptymgi);
+  // decay chain contributions to each chain-end nuclide from the chain-top nuclide's initial abundance
+  const int he4_nucindex = nuc_exists(2, 4) ? get_nucindex(2, 4) : -1;
+  for (const auto& decaypath : decaypaths) {
+    const int nucindex_top = decaypath.nucindex[0];
+    const int nucindex_end = decaypath.nucindex.back();
+
+    contributions[nucindex_end].emplace_back(
+        nucindex_top, decaypath.branchproduct * calculate_decaychain(1., decaypath.lambdas, t_afterinit, false) *
+                          nucmass(nucindex_end) / nucmass(nucindex_top));
+
+    // match He4 production to alpha decay of any nucleus, with the chain end treated as stable so that every
+    // alpha decay through the last step of the chain is counted
+    const auto last_decaytype = decaypath.decaytypes[decaypath.decaytypes.size() - 2];
+    if (he4_nucindex >= 0 && last_decaytype == DecayType::DECAYTYPE_ALPHA && nucindex_end != he4_nucindex) {
+      auto lambdas = decaypath.lambdas;
+      lambdas[lambdas.size() - 1] = 0.;
+      contributions[he4_nucindex].emplace_back(nucindex_top, decaypath.branchproduct *
+                                                                 calculate_decaychain(1., lambdas, t_afterinit, false) *
+                                                                 nucmass(he4_nucindex) / nucmass(nucindex_top));
+    }
+  }
+
+  // element of each nuclide, or -1 if the element is not in the simulation
+  auto elementindex_of_nuc = std::vector<int>(num_nuclides);
+  for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
+    elementindex_of_nuc[nucindex] = get_elementindex(get_nuc_z(nucindex));
+  }
+
+  // the mass fraction sums of radioactive isotopes, and stable nuclei coming from other decays, for each element
+  auto elem_isomassfracsum = std::vector<double>(nelements);
+  auto elem_isomassfrac_on_nucmass_sum = std::vector<double>(nelements);
+
+  for (int nonemptymgi = nonemptymgi_start; nonemptymgi < (nonemptymgi_start + nonemptymgi_count); nonemptymgi++) {
+    const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+    std::ranges::fill(elem_isomassfracsum, 0.);
+    std::ranges::fill(elem_isomassfrac_on_nucmass_sum, 0.);
+
+    for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
+      const int element = elementindex_of_nuc[nucindex];
+      if (element < 0) {
+        continue;
+      }
+      double nuc_massfrac = 0.;
+      for (const auto& [source_nucindex, coeff] : contributions[nucindex]) {
+        nuc_massfrac += coeff * grid::get_modelinitnucmassfrac(mgi, source_nucindex);
+      }
+      elem_isomassfracsum[element] += nuc_massfrac;
+      elem_isomassfrac_on_nucmass_sum[element] += nuc_massfrac / nucmass(nucindex);
+    }
+
+    for (int element = 0; element < nelements; element++) {
+      const double otherstablemassfrac = grid::get_elem_untrackedstable_initmassfrac(nonemptymgi, element);
+      const double isomassfracsum = elem_isomassfracsum[element] + otherstablemassfrac;
+      const double isomassfrac_on_nucmass_sum =
+          elem_isomassfrac_on_nucmass_sum[element] +
+          (otherstablemassfrac / globals::elements[element].initstablemeannucmass);
+
+      grid::set_elem_massfrac(nonemptymgi, element, static_cast<float>(isomassfracsum));
+      const auto meanweight = static_cast<float>(isomassfracsum / isomassfrac_on_nucmass_sum);
+      grid::set_element_meanweight(nonemptymgi, element,
+                                   (std::isfinite(meanweight) && meanweight > 0.)
+                                       ? meanweight
+                                       : globals::elements[element].initstablemeannucmass);
+    }
+    // note: the caller must call grid::set_nnetot() for each cell after the cell densities have been updated
+  }
 }
 
 void output_isotopic_densities(std::ostream& estimators_file, const int nonemptymgi, const double t_current,

--- a/decay.cc
+++ b/decay.cc
@@ -103,6 +103,7 @@ struct DecayPath {
 
 std::vector<Nuclide> nuclides;
 std::vector<DecayPath> decaypaths;
+std::vector<int> decaypath_topnucindex;  // the chain-top nuclide index of each decaypath (flat copy for fast access)
 std::vector<bool> alldecaytypes_is_used;
 
 [[nodiscard]] constexpr auto decay_daughters_z_a_prob(const int z_parent, const int a_parent, const DecayType decaytype)
@@ -1111,6 +1112,9 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
 
   printlnlog("Number of nuclides before filtering: {}", std::ssize(nuclides));
   decaypaths = find_decaypaths(custom_zlist, custom_alist, standard_nuclides);
+  decaypath_topnucindex.resize(decaypaths.size());
+  std::ranges::transform(decaypaths, decaypath_topnucindex.begin(),
+                         [](const auto& decaypath) { return decaypath.nucindex[0]; });
   abort_if_decaypath_has_duplicate_lambdas();
   filter_unused_nuclides(custom_zlist, custom_alist, standard_nuclides);
 
@@ -1159,45 +1163,14 @@ void init_nuclides(const std::span<const int> custom_zlist, const std::span<cons
   return alldecaytypes_is_used[decaytype];
 }
 
-// precompute the abundance-independent Bateman factors for every decaypath at the given time (with the chain ends
-// treated as stable), so that the same decay chain calculations can be applied to every cell's initial abundances
-auto calc_decaypath_factors(const double time, const bool useexpansionfactor) -> std::vector<double> {
-  const auto num_decaypaths = get_num_decaypaths();
-  std::vector<double> decaypathfactors(num_decaypaths);
-  for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
-    decaypathfactors[decaypathindex] = calc_decaypath_unitfactor(decaypathindex, time, useexpansionfactor);
-  }
-  return decaypathfactors;
-}
-
-// calculate the decay energy per unit mass [erg/g] released from time t_model (can be before tmin) to the time of
-// the precomputed expansion factors (from calc_decaypath_factors(tstart, true)), accounting for the photon energy
-// loss due to expansion between time of decays and tstart (equation 18 of Lucy 2005)
-auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(const int nonemptymgi,
-                                                             const std::span<const double> decaypathfactors) -> double {
-  const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-  double tot_endecay = 0.;
-  for (int decaypathindex = 0; decaypathindex < std::ssize(decaypathfactors); decaypathindex++) {
-    const auto& decaypath = decaypaths[decaypathindex];
-    const int nucindex_top = decaypath.nucindex[0];
-
-    const double top_initabund = grid::get_modelinitnucmassfrac(modelgridindex, nucindex_top) / nucmass(nucindex_top);
-
-    tot_endecay += (decaypath.branchproduct * top_initabund * decaypathfactors[decaypathindex] *
-                    get_decaypath_lastdecayenergy(decaypath));
-  }
-
-  return tot_endecay;
-}
-
-// get the decay energy per unit ejecta mass [erg/g] that will be released by a model cell during the simulation
-// time [(tmodel if initial packets else tmin) to tmax]
-auto get_modelcell_simtime_endecay_per_mass(const int nonemptymgi,
-                                            const std::span<const double> energy_per_massoftopnuc_decaypath) -> double {
+// get the decay energy per unit ejecta mass [erg/g] that a model cell releases over the time range of the given
+// per-decaypath energy coefficients (each an energy per unit mass of that decaypath's chain-top nuclide)
+auto get_modelcell_endecay_per_mass(const int nonemptymgi,
+                                    const std::span<const double> energy_per_massoftopnuc_decaypath) -> double {
   const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
   double endecay_per_mass = 0.;
   for (int decaypathindex = 0; decaypathindex < std::ssize(energy_per_massoftopnuc_decaypath); decaypathindex++) {
-    endecay_per_mass += grid::get_modelinitnucmassfrac(mgi, decaypaths[decaypathindex].nucindex[0]) *
+    endecay_per_mass += grid::get_modelinitnucmassfrac(mgi, decaypath_topnucindex[decaypathindex]) *
                         energy_per_massoftopnuc_decaypath[decaypathindex];
   }
   return endecay_per_mass;
@@ -1217,6 +1190,22 @@ auto calc_energy_per_massoftopnuc_decaypath() -> std::vector<double> {
                                              calc_decaypath_unitfactor(decaypathindex, time_min_decay, false));
     energy_per_massoftopnuc[decaypathindex] =
         decaypath.branchproduct * fdecayed * get_decaypath_lastdecayenergy(decaypath) / nucmass(decaypath.nucindex[0]);
+    assert_always(std::isfinite(energy_per_massoftopnuc[decaypathindex]));
+  }
+  return energy_per_massoftopnuc;
+}
+
+// decay energy per unit mass of the chain-top nuclide [erg/(g of chain-top nuclide)] released by each decaypath
+// from time t_model to tstart, weighted for the photon energy loss due to expansion between the time of decay and
+// tstart (equation 18 of Lucy 2005)
+auto calc_energy_per_massoftopnuc_decaypath_withexpansion(const double tstart) -> std::vector<double> {
+  const auto num_decaypaths = get_num_decaypaths();
+  std::vector<double> energy_per_massoftopnuc(num_decaypaths);
+  for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
+    const auto& decaypath = decaypaths[decaypathindex];
+    energy_per_massoftopnuc[decaypathindex] = decaypath.branchproduct *
+                                              calc_decaypath_unitfactor(decaypathindex, tstart, true) *
+                                              get_decaypath_lastdecayenergy(decaypath) / nucmass(decaypath.nucindex[0]);
     assert_always(std::isfinite(energy_per_massoftopnuc[decaypathindex]));
   }
   return energy_per_massoftopnuc;
@@ -1314,65 +1303,69 @@ void update_abundances(const int nonemptymgi_start, const int nonemptymgi_count,
   const auto num_nuclides = std::ssize(nuclides);
   const auto nelements = get_nelements();
 
-  // for each nuclide, the (source nuclide, coefficient) contributions such that the nuclide's mass fraction is
-  // the sum over contributions of coeff * (cell's initial mass fraction of the source nuclide)
-  auto contributions = std::vector<std::vector<std::pair<int, double>>>(num_nuclides);
+  // Each nuclide's mass fraction is a linear function of the cell's initial nuclide mass fractions, so build a
+  // flat list of contributions (each a coefficient to multiply by the cell's initial mass fraction of a source
+  // nuclide and add to the element sums) that depends only on the elapsed time, then apply it to every cell.
+  struct MassFracContribution {
+    int elementindex;
+    int source_nucindex;
+    double massfrac_coeff;  // contribution to the element mass fraction sum
+    double numberfrac_coeff;  // massfrac_coeff / (mass of the contributing nuclide), for the mean weight
+  };
+  std::vector<MassFracContribution> contributions;
+
+  const auto add_contribution = [&contributions](const int nucindex, const int source_nucindex, const double coeff) {
+    const int element = get_elementindex(get_nuc_z(nucindex));
+    if (element >= 0 && coeff > 0.) {
+      contributions.push_back({.elementindex = element,
+                               .source_nucindex = source_nucindex,
+                               .massfrac_coeff = coeff,
+                               .numberfrac_coeff = coeff / nucmass(nucindex)});
+    }
+  };
 
   // exponential decay of each nuclide's own initial abundance
   for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
     const auto meanlife = get_meanlife(nucindex);
     const auto lambda = (meanlife > 0.) ? 1. / meanlife : 0.;
-    contributions[nucindex].emplace_back(nucindex, exp(-t_afterinit * lambda));
+    add_contribution(nucindex, nucindex, exp(-t_afterinit * lambda));
   }
 
   // decay chain contributions to each chain-end nuclide from the chain-top nuclide's initial abundance
   const int he4_nucindex = nuc_exists(2, 4) ? get_nucindex(2, 4) : -1;
-  for (const auto& decaypath : decaypaths) {
+  for (int decaypathindex = 0; decaypathindex < get_num_decaypaths(); decaypathindex++) {
+    const auto& decaypath = decaypaths[decaypathindex];
     const int nucindex_top = decaypath.nucindex[0];
     const int nucindex_end = decaypath.nucindex.back();
 
-    contributions[nucindex_end].emplace_back(
-        nucindex_top, decaypath.branchproduct * calculate_decaychain(1., decaypath.lambdas, t_afterinit, false) *
-                          nucmass(nucindex_end) / nucmass(nucindex_top));
+    add_contribution(nucindex_end, nucindex_top,
+                     decaypath.branchproduct * calculate_decaychain(1., decaypath.lambdas, t_afterinit, false) *
+                         nucmass(nucindex_end) / nucmass(nucindex_top));
 
     // match He4 production to alpha decay of any nucleus, with the chain end treated as stable so that every
     // alpha decay through the last step of the chain is counted
     const auto last_decaytype = decaypath.decaytypes[decaypath.decaytypes.size() - 2];
     if (he4_nucindex >= 0 && last_decaytype == DecayType::DECAYTYPE_ALPHA && nucindex_end != he4_nucindex) {
-      auto lambdas = decaypath.lambdas;
-      lambdas[lambdas.size() - 1] = 0.;
-      contributions[he4_nucindex].emplace_back(nucindex_top, decaypath.branchproduct *
-                                                                 calculate_decaychain(1., lambdas, t_afterinit, false) *
-                                                                 nucmass(he4_nucindex) / nucmass(nucindex_top));
+      add_contribution(he4_nucindex, nucindex_top,
+                       decaypath.branchproduct * calc_decaypath_unitfactor(decaypathindex, t_current, false) *
+                           nucmass(he4_nucindex) / nucmass(nucindex_top));
     }
   }
 
-  // element of each nuclide, or -1 if the element is not in the simulation
-  auto elementindex_of_nuc = std::vector<int>(num_nuclides);
-  for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
-    elementindex_of_nuc[nucindex] = get_elementindex(get_nuc_z(nucindex));
-  }
-
-  // the mass fraction sums of radioactive isotopes, and stable nuclei coming from other decays, for each element
-  auto elem_isomassfracsum = std::vector<double>(nelements);
-  auto elem_isomassfrac_on_nucmass_sum = std::vector<double>(nelements);
-
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
   for (int nonemptymgi = nonemptymgi_start; nonemptymgi < (nonemptymgi_start + nonemptymgi_count); nonemptymgi++) {
     const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-    std::ranges::fill(elem_isomassfracsum, 0.);
-    std::ranges::fill(elem_isomassfrac_on_nucmass_sum, 0.);
 
-    for (int nucindex = 0; nucindex < num_nuclides; nucindex++) {
-      const int element = elementindex_of_nuc[nucindex];
-      if (element < 0) {
-        continue;
-      }
-      double nuc_massfrac = 0.;
-      for (const auto& [source_nucindex, coeff] : contributions[nucindex]) {
-        nuc_massfrac += coeff * grid::get_modelinitnucmassfrac(mgi, source_nucindex);
-      }
-      elem_isomassfracsum[element] += nuc_massfrac;
-      elem_isomassfrac_on_nucmass_sum[element] += nuc_massfrac / nucmass(nucindex);
+    // the mass fraction sums of radioactive isotopes, and stable nuclei coming from other decays, for each element
+    auto elem_isomassfracsum = std::vector<double>(nelements, 0.);
+    auto elem_isomassfrac_on_nucmass_sum = std::vector<double>(nelements, 0.);
+
+    for (const auto& contrib : contributions) {
+      const double source_initmassfrac = grid::get_modelinitnucmassfrac(mgi, contrib.source_nucindex);
+      elem_isomassfracsum[contrib.elementindex] += contrib.massfrac_coeff * source_initmassfrac;
+      elem_isomassfrac_on_nucmass_sum[contrib.elementindex] += contrib.numberfrac_coeff * source_initmassfrac;
     }
 
     for (int element = 0; element < nelements; element++) {
@@ -1427,7 +1420,7 @@ void output_isotopic_densities(std::ostream& estimators_file, const int nonempty
 
 void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptymgi, Packet& pkt,
                               const std::span<const double> energy_per_massoftopnuc_decaypath) {
-  const int num_decaypaths = get_num_decaypaths();
+  const int num_decaypaths = static_cast<int>(std::ssize(energy_per_massoftopnuc_decaypath));
   const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
 
   // decay channels include all radioactive decay paths, and possibly also an initial cell energy channel
@@ -1438,7 +1431,7 @@ void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptym
 
   // add the radioactive decay paths
   for (int decaypathindex = 0; decaypathindex < num_decaypaths; decaypathindex++) {
-    energysum += grid::get_modelinitnucmassfrac(mgi, decaypaths[decaypathindex].nucindex[0]) *
+    energysum += grid::get_modelinitnucmassfrac(mgi, decaypath_topnucindex[decaypathindex]) *
                  energy_per_massoftopnuc_decaypath[decaypathindex];
     cumulative_en_sum[decaypathindex] = energysum;
   }
@@ -1496,7 +1489,7 @@ void setup_radioactive_pellet(const double e_cmf_per_packet, const int nonemptym
     // we need to scale the packet energy up or down according to decay rate at the randomly selected time.
     // e_cmf_average is the average energy per packet for this cell and decaypath, so we scale this up or down
     // according to: decay power at this time relative to the average decay power
-    const double avgpower = grid::get_modelinitnucmassfrac(mgi, decaypaths[decaypathindex].nucindex[0]) *
+    const double avgpower = grid::get_modelinitnucmassfrac(mgi, decaypath_topnucindex[decaypathindex]) *
                             energy_per_massoftopnuc_decaypath[decaypathindex] / (globals::tmax - tdecaymin);
     assert_always(avgpower > 0.);
     pkt.e_cmf =

--- a/decay.h
+++ b/decay.h
@@ -131,7 +131,7 @@ void init_nuclides(std::span<const int> custom_zlist, std::span<const int> custo
 [[nodiscard]] auto nucdecayenergygamma(int z, int a) -> double;
 [[nodiscard]] auto get_decay_neutrino_frac(int nucindex, DecayType decaytype) -> double;
 void set_nucdecayenergygamma(int nucindex, double value);
-void update_abundances(int nonemptymgi, double t_current);
+void update_abundances(int nonemptymgi_start, int nonemptymgi_count, double t_current);
 // precompute for each decaypath the chain-end abundance per unit chain-top initial abundance at the given time
 // (with the chain end treated as stable), for applying the same decay chain calculations to every cell
 [[nodiscard]] auto calc_decaypath_factors(double time, bool useexpansionfactor) -> std::vector<double>;

--- a/decay.h
+++ b/decay.h
@@ -132,19 +132,14 @@ void init_nuclides(std::span<const int> custom_zlist, std::span<const int> custo
 [[nodiscard]] auto get_decay_neutrino_frac(int nucindex, DecayType decaytype) -> double;
 void set_nucdecayenergygamma(int nucindex, double value);
 void update_abundances(int nonemptymgi_start, int nonemptymgi_count, double t_current);
-// precompute for each decaypath the chain-end abundance per unit chain-top initial abundance at the given time
-// (with the chain end treated as stable), for applying the same decay chain calculations to every cell
-[[nodiscard]] auto calc_decaypath_factors(double time, bool useexpansionfactor) -> std::vector<double>;
-[[nodiscard]] auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(int nonemptymgi,
-                                                                           std::span<const double> decaypathfactors)
-    -> double;
-[[nodiscard]] auto get_modelcell_simtime_endecay_per_mass(int nonemptymgi,
-                                                          std::span<const double> energy_per_massoftopnuc_decaypath)
-    -> double;
-// decay energy per unit mass of the chain-top nuclide [erg/(g of chain-top nuclide)] released by each decaypath
-// during the simulation time. Multiplying by a cell's initial mass fraction of the chain-top nuclide gives the
-// decay energy per unit ejecta mass, so this small per-decaypath array replaces a per-cell-per-decaypath array
+// the calc_energy_per_massoftopnuc_* functions return the decay energy per unit mass of the chain-top nuclide
+// [erg/(g of chain-top nuclide)] released by each decaypath over some time range. Multiplying by a cell's initial
+// mass fraction of the chain-top nuclide (via get_modelcell_endecay_per_mass) gives the cell's decay energy per
+// unit ejecta mass, so these small per-decaypath arrays replace per-cell-per-decaypath calculations
 [[nodiscard]] auto calc_energy_per_massoftopnuc_decaypath() -> std::vector<double>;
+[[nodiscard]] auto calc_energy_per_massoftopnuc_decaypath_withexpansion(double tstart) -> std::vector<double>;
+[[nodiscard]] auto get_modelcell_endecay_per_mass(int nonemptymgi,
+                                                  std::span<const double> energy_per_massoftopnuc_decaypath) -> double;
 [[nodiscard]] auto get_qdot_modelcell(int nonemptymgi, double t, DecayType decaytype) -> double;
 [[nodiscard]] auto get_particle_injection_rate(int nonemptymgi, double t, DecayType decaytype) -> double;
 [[nodiscard]] auto get_gamma_emission_rate(int nonemptymgi, double t) -> double;

--- a/decay.h
+++ b/decay.h
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <span>
 #include <string>
+#include <vector>
 
 #include "mpi_logging.h"
 #include "packet.h"
@@ -131,11 +132,19 @@ void init_nuclides(std::span<const int> custom_zlist, std::span<const int> custo
 [[nodiscard]] auto get_decay_neutrino_frac(int nucindex, DecayType decaytype) -> double;
 void set_nucdecayenergygamma(int nucindex, double value);
 void update_abundances(int nonemptymgi, double t_current);
-[[nodiscard]] auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(int nonemptymgi, double tstart) -> double;
-[[nodiscard]] auto get_modelcell_simtime_endecay_per_mass(int nonemptymgi,
-                                                          std::span<const double> energy_per_mass_nonemptymgi_decaypath)
+// precompute for each decaypath the chain-end abundance per unit chain-top initial abundance at the given time
+// (with the chain end treated as stable), for applying the same decay chain calculations to every cell
+[[nodiscard]] auto calc_decaypath_factors(double time, bool useexpansionfactor) -> std::vector<double>;
+[[nodiscard]] auto get_endecay_per_ejectamass_tmodel_to_time_withexpansion(int nonemptymgi,
+                                                                           std::span<const double> decaypathfactors)
     -> double;
-auto get_energy_per_mass_nonemptymgi_decaypath() -> MPI_shared_array<const double>;
+[[nodiscard]] auto get_modelcell_simtime_endecay_per_mass(int nonemptymgi,
+                                                          std::span<const double> energy_per_massoftopnuc_decaypath)
+    -> double;
+// decay energy per unit mass of the chain-top nuclide [erg/(g of chain-top nuclide)] released by each decaypath
+// during the simulation time. Multiplying by a cell's initial mass fraction of the chain-top nuclide gives the
+// decay energy per unit ejecta mass, so this small per-decaypath array replaces a per-cell-per-decaypath array
+[[nodiscard]] auto calc_energy_per_massoftopnuc_decaypath() -> std::vector<double>;
 [[nodiscard]] auto get_qdot_modelcell(int nonemptymgi, double t, DecayType decaytype) -> double;
 [[nodiscard]] auto get_particle_injection_rate(int nonemptymgi, double t, DecayType decaytype) -> double;
 [[nodiscard]] auto get_gamma_emission_rate(int nonemptymgi, double t) -> double;
@@ -145,7 +154,7 @@ void output_isotopic_densities(std::ostream& estimators_file, int nonemptymgi, d
 // channel, then sample its release time and record the emitting nuclide and decay type.
 // Lucy (2005), doi:10.1051/0004-6361:20041656.
 void setup_radioactive_pellet(double e_cmf_per_packet, int nonemptymgi, Packet& pkt,
-                              std::span<const double> energy_per_mass_nonemptymgi_decaypath);
+                              std::span<const double> energy_per_massoftopnuc_decaypath);
 
 }  // namespace decay
 

--- a/grid.cc
+++ b/grid.cc
@@ -1066,11 +1066,10 @@ void assign_initial_temperatures() {
   // cell's initial abundances
   const auto endecay_per_massoftopnuc = decay::calc_energy_per_massoftopnuc_decaypath_withexpansion(tstart);
 
-  // each rank assigns the temperatures of its own update_grid cell block, and the blocks of ranks on other nodes
-  // are broadcast into this node's shared arrays below
-  const int nstart_nonempty = get_nstart_nonempty(globals::my_rank);
-  const int ndo_nonempty = get_ndo_nonempty(globals::my_rank);
-  for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+  // the decayed energy calculation is expensive and the temperature arrays are in node-shared memory, so stripe
+  // the cells across the ranks of each node, with each rank writing its own disjoint subset of the shared arrays
+  for (int nonemptymgi = globals::rank_in_node; nonemptymgi < get_nonempty_npts_model();
+       nonemptymgi += globals::node_nprocs) {
     const int mgi = get_mgi_of_nonemptymgi(nonemptymgi);
 
     const auto q = (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? get_initenergyq(mgi) : 0.;
@@ -1104,49 +1103,20 @@ void assign_initial_temperatures() {
     thick_allcells[nonemptymgi] = 0;
   }
 
-  // make every cell's initial state available on every node (later startup steps such as the grey opacity
-  // calculation can read the temperatures of cells belonging to other ranks' blocks)
-  MPI_Barrier_allranks();
-  for (int root = 0; root < globals::nprocs; root++) {
-    int root_node_id = globals::node_id;
-    MPI_Bcast_safe(root_node_id, root, MPI_COMM_WORLD);
-    const int root_ndo_nonempty = get_ndo_nonempty(root);
-    if (root_ndo_nonempty <= 0) {
-      continue;
-    }
-    const int root_nstart_nonempty = get_nstart_nonempty(root);
-    if (globals::rank_in_node == 0) {
-      MPI_Bcast_safe(Te_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
-                     globals::mpi_comm_internode);
-      MPI_Bcast_safe(TJ_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
-                     globals::mpi_comm_internode);
-      MPI_Bcast_safe(TR_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
-                     globals::mpi_comm_internode);
-      MPI_Bcast_safe(W_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
-                     globals::mpi_comm_internode);
-      MPI_Bcast_safe(thick_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
-                     globals::mpi_comm_internode);
-    }
-  }
-
-  // combine the diagnostic counts over all ranks (each cell belongs to exactly one rank's block)
-  MPI_Allreduce_safe(cells_below_mintemp, MPI_SUM, MPI_COMM_WORLD);
-  MPI_Allreduce_safe(cells_above_maxtemp, MPI_SUM, MPI_COMM_WORLD);
-  MPI_Allreduce_safe(cells_nonfinite_temp, MPI_SUM, MPI_COMM_WORLD);
+  // combine the diagnostic counts over the node communicator (the ranks of each node together cover every cell
+  // exactly once)
+  MPI_Allreduce_safe(cells_below_mintemp, MPI_SUM, globals::mpi_comm_node);
+  MPI_Allreduce_safe(cells_above_maxtemp, MPI_SUM, globals::mpi_comm_node);
+  MPI_Allreduce_safe(cells_nonfinite_temp, MPI_SUM, globals::mpi_comm_node);
 
   printlnlog("  cells below MINTEMP {:g} [K]: {}. Above MAXTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp, MAXTEMP,
              cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
-    MPI_Allreduce_safe(first_nonfinite_nonemptymgi, MPI_MIN, MPI_COMM_WORLD);
-    // get the details of the earliest example from the rank whose cell block contains it
-    int ownerrank = 0;
-    while (first_nonfinite_nonemptymgi >= (get_nstart_nonempty(ownerrank) + get_ndo_nonempty(ownerrank)) ||
-           get_ndo_nonempty(ownerrank) == 0) {
-      ownerrank++;
-      assert_always(ownerrank < globals::nprocs);
-    }
-    MPI_Bcast_safe(first_nonfinite_rho_tmin, ownerrank, MPI_COMM_WORLD);
-    MPI_Bcast_safe(first_nonfinite_endecay, ownerrank, MPI_COMM_WORLD);
+    MPI_Allreduce_safe(first_nonfinite_nonemptymgi, MPI_MIN, globals::mpi_comm_node);
+    // get the details of the earliest example from the rank that computed that cell
+    const int ownerrank = first_nonfinite_nonemptymgi % globals::node_nprocs;
+    MPI_Bcast_safe(first_nonfinite_rho_tmin, ownerrank, globals::mpi_comm_node);
+    MPI_Bcast_safe(first_nonfinite_endecay, ownerrank, globals::mpi_comm_node);
     printlnlog(
         "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
         "rho_tmin {:g} [g/cm3] and decayed energy {:g} [erg/g])",

--- a/grid.cc
+++ b/grid.cc
@@ -1064,7 +1064,7 @@ void assign_initial_temperatures() {
 
   // the Bateman factors depend only on the decay path and time, so compute them once and apply them to every
   // cell's initial abundances
-  const auto decaypathfactors = decay::calc_decaypath_factors(tstart, true);
+  const auto endecay_per_massoftopnuc = decay::calc_energy_per_massoftopnuc_decaypath_withexpansion(tstart);
 
   // the decayed energy calculation is expensive and the temperature arrays are in node-shared memory, so stripe
   // the cells across the ranks of each node, with each rank writing its own disjoint subset of the shared arrays
@@ -1074,7 +1074,7 @@ void assign_initial_temperatures() {
 
     const auto q = (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? get_initenergyq(mgi) : 0.;
     const double decayedenergy_per_mass =
-        decay::get_endecay_per_ejectamass_tmodel_to_time_withexpansion(nonemptymgi, decaypathfactors) + q;
+        decay::get_modelcell_endecay_per_mass(nonemptymgi, endecay_per_massoftopnuc) + q;
 
     auto T_initial = static_cast<float>(std::pow(
         CLIGHT / 4 / STEBO * pow3(globals::tmin / tstart) * get_rho_tmin(mgi) * decayedenergy_per_mass, 1. / 4.));

--- a/grid.cc
+++ b/grid.cc
@@ -1062,6 +1062,10 @@ void assign_initial_temperatures() {
   double first_nonfinite_rho_tmin = 0.;
   double first_nonfinite_endecay = 0.;
 
+  // the Bateman factors depend only on the decay path and time, so compute them once and apply them to every
+  // cell's initial abundances
+  const auto decaypathfactors = decay::calc_decaypath_factors(tstart, true);
+
   // the decayed energy calculation is expensive and the temperature arrays are in node-shared memory, so stripe
   // the cells across the ranks of each node, with each rank writing its own disjoint subset of the shared arrays
   for (int nonemptymgi = globals::rank_in_node; nonemptymgi < get_nonempty_npts_model();
@@ -1070,7 +1074,7 @@ void assign_initial_temperatures() {
 
     const auto q = (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? get_initenergyq(mgi) : 0.;
     const double decayedenergy_per_mass =
-        decay::get_endecay_per_ejectamass_tmodel_to_time_withexpansion(nonemptymgi, tstart) + q;
+        decay::get_endecay_per_ejectamass_tmodel_to_time_withexpansion(nonemptymgi, decaypathfactors) + q;
 
     auto T_initial = static_cast<float>(std::pow(
         CLIGHT / 4 / STEBO * pow3(globals::tmin / tstart) * get_rho_tmin(mgi) * decayedenergy_per_mass, 1. / 4.));

--- a/grid.cc
+++ b/grid.cc
@@ -1066,9 +1066,8 @@ void assign_initial_temperatures() {
   // cell's initial abundances
   const auto endecay_per_massoftopnuc = decay::calc_energy_per_massoftopnuc_decaypath_withexpansion(tstart);
 
-  // each rank assigns the temperatures of its own update_grid cell block. The cells of ranks on other nodes are
-  // filled in on this node's shared arrays by mpi_communicate_grid_properties() after the first update_grid(),
-  // and nothing reads them before then
+  // each rank assigns the temperatures of its own update_grid cell block, and the blocks of ranks on other nodes
+  // are broadcast into this node's shared arrays below
   const int nstart_nonempty = get_nstart_nonempty(globals::my_rank);
   const int ndo_nonempty = get_ndo_nonempty(globals::my_rank);
   for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
@@ -1103,6 +1102,31 @@ void assign_initial_temperatures() {
     TR_allcells[nonemptymgi] = T_initial;
     W_allcells[nonemptymgi] = 1.;
     thick_allcells[nonemptymgi] = 0;
+  }
+
+  // make every cell's initial state available on every node (later startup steps such as the grey opacity
+  // calculation can read the temperatures of cells belonging to other ranks' blocks)
+  MPI_Barrier_allranks();
+  for (int root = 0; root < globals::nprocs; root++) {
+    int root_node_id = globals::node_id;
+    MPI_Bcast_safe(root_node_id, root, MPI_COMM_WORLD);
+    const int root_ndo_nonempty = get_ndo_nonempty(root);
+    if (root_ndo_nonempty <= 0) {
+      continue;
+    }
+    const int root_nstart_nonempty = get_nstart_nonempty(root);
+    if (globals::rank_in_node == 0) {
+      MPI_Bcast_safe(Te_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(TJ_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(TR_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(W_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(thick_allcells.subspan(root_nstart_nonempty, root_ndo_nonempty), root_node_id,
+                     globals::mpi_comm_internode);
+    }
   }
 
   // combine the diagnostic counts over all ranks (each cell belongs to exactly one rank's block)

--- a/grid.cc
+++ b/grid.cc
@@ -1066,10 +1066,12 @@ void assign_initial_temperatures() {
   // cell's initial abundances
   const auto endecay_per_massoftopnuc = decay::calc_energy_per_massoftopnuc_decaypath_withexpansion(tstart);
 
-  // the decayed energy calculation is expensive and the temperature arrays are in node-shared memory, so stripe
-  // the cells across the ranks of each node, with each rank writing its own disjoint subset of the shared arrays
-  for (int nonemptymgi = globals::rank_in_node; nonemptymgi < get_nonempty_npts_model();
-       nonemptymgi += globals::node_nprocs) {
+  // each rank assigns the temperatures of its own update_grid cell block. The cells of ranks on other nodes are
+  // filled in on this node's shared arrays by mpi_communicate_grid_properties() after the first update_grid(),
+  // and nothing reads them before then
+  const int nstart_nonempty = get_nstart_nonempty(globals::my_rank);
+  const int ndo_nonempty = get_ndo_nonempty(globals::my_rank);
+  for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
     const int mgi = get_mgi_of_nonemptymgi(nonemptymgi);
 
     const auto q = (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? get_initenergyq(mgi) : 0.;
@@ -1103,20 +1105,24 @@ void assign_initial_temperatures() {
     thick_allcells[nonemptymgi] = 0;
   }
 
-  // combine the diagnostic counts over the node communicator (the ranks of each node together cover every cell
-  // exactly once)
-  MPI_Allreduce_safe(cells_below_mintemp, MPI_SUM, globals::mpi_comm_node);
-  MPI_Allreduce_safe(cells_above_maxtemp, MPI_SUM, globals::mpi_comm_node);
-  MPI_Allreduce_safe(cells_nonfinite_temp, MPI_SUM, globals::mpi_comm_node);
+  // combine the diagnostic counts over all ranks (each cell belongs to exactly one rank's block)
+  MPI_Allreduce_safe(cells_below_mintemp, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce_safe(cells_above_maxtemp, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Allreduce_safe(cells_nonfinite_temp, MPI_SUM, MPI_COMM_WORLD);
 
   printlnlog("  cells below MINTEMP {:g} [K]: {}. Above MAXTEMP {:g} [K]: {}", MINTEMP, cells_below_mintemp, MAXTEMP,
              cells_above_maxtemp);
   if (cells_nonfinite_temp > 0) {
-    MPI_Allreduce_safe(first_nonfinite_nonemptymgi, MPI_MIN, globals::mpi_comm_node);
-    // get the details of the earliest example from the rank that computed that cell
-    const int ownerrank = first_nonfinite_nonemptymgi % globals::node_nprocs;
-    MPI_Bcast_safe(first_nonfinite_rho_tmin, ownerrank, globals::mpi_comm_node);
-    MPI_Bcast_safe(first_nonfinite_endecay, ownerrank, globals::mpi_comm_node);
+    MPI_Allreduce_safe(first_nonfinite_nonemptymgi, MPI_MIN, MPI_COMM_WORLD);
+    // get the details of the earliest example from the rank whose cell block contains it
+    int ownerrank = 0;
+    while (first_nonfinite_nonemptymgi >= (get_nstart_nonempty(ownerrank) + get_ndo_nonempty(ownerrank)) ||
+           get_ndo_nonempty(ownerrank) == 0) {
+      ownerrank++;
+      assert_always(ownerrank < globals::nprocs);
+    }
+    MPI_Bcast_safe(first_nonfinite_rho_tmin, ownerrank, MPI_COMM_WORLD);
+    MPI_Bcast_safe(first_nonfinite_endecay, ownerrank, MPI_COMM_WORLD);
     printlnlog(
         "[warning] {} cells had a non-finite initial temperature and were set to MINTEMP (first was mgi {} with "
         "rho_tmin {:g} [g/cm3] and decayed energy {:g} [erg/g])",

--- a/packet.cc
+++ b/packet.cc
@@ -52,7 +52,7 @@ constexpr auto get_packets_text_header() -> std::string {
 // Sample a grid cell (weighted by its cumulative energy in en_cumulative), then place packet pkt as a radioactive
 // pellet at a random position within that cell at t=tmin, assigning its decay time and initial rest-frame energy.
 void place_pellet(const double e_cmf_per_packet, const std::span<const double> en_cumulative, const int pktnumber,
-                  Packet& pkt, const std::span<const double> energy_per_mass_nonemptymgi_decaypath) {
+                  Packet& pkt, const std::span<const double> energy_per_massoftopnuc_decaypath) {
   const auto etot_simtime = en_cumulative.back();
   const double targetval = rng_uniform(get_rngstate(pkt)) * etot_simtime;
 
@@ -74,7 +74,7 @@ void place_pellet(const double e_cmf_per_packet, const std::span<const double> e
 
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(cellindex);
 
-  decay::setup_radioactive_pellet(e_cmf_per_packet, nonemptymgi, pkt, energy_per_mass_nonemptymgi_decaypath);
+  decay::setup_radioactive_pellet(e_cmf_per_packet, nonemptymgi, pkt, energy_per_massoftopnuc_decaypath);
 
   // initial e_rf is probably never needed (e_rf is set at pellet decay time), but we
   // might as well give it a correct value since this code is fast and runs only once
@@ -103,7 +103,7 @@ void packet_init(std::span<Packet> packets)
 
   printlnlog("e_cmf per packet (t_model to t_inf) {:g} [erg]", etot_tmodel_tinf / MPKTS);
 
-  const auto energy_per_mass_nonemptymgi_decaypath = decay::get_energy_per_mass_nonemptymgi_decaypath();
+  const auto energy_per_massoftopnuc_decaypath = decay::calc_energy_per_massoftopnuc_decaypath();
 
   // Need to get a normalisation factor
   auto en_cumulative = std::vector<double>(grid::ngrid);
@@ -115,7 +115,7 @@ void packet_init(std::span<Packet> packets)
     if (mgi >= 0) {
       const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
       const double decay_en_per_mass =
-          decay::get_modelcell_simtime_endecay_per_mass(nonemptymgi, energy_per_mass_nonemptymgi_decaypath.span());
+          decay::get_modelcell_simtime_endecay_per_mass(nonemptymgi, energy_per_massoftopnuc_decaypath);
       const auto initial_en_per_mass =
           (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? grid::get_initenergyq(mgi) : 0.;
 
@@ -138,7 +138,7 @@ void packet_init(std::span<Packet> packets)
   printlnlog("Placing pellets...");
   const auto allpktindices = std::ranges::iota_view{0, static_cast<int>(std::ssize(packets))};
   std::ranges::for_each(allpktindices, [&, e_cmf_per_packet](const int n) {
-    place_pellet(e_cmf_per_packet, en_cumulative, n, packets[n], energy_per_mass_nonemptymgi_decaypath.span());
+    place_pellet(e_cmf_per_packet, en_cumulative, n, packets[n], energy_per_massoftopnuc_decaypath);
   });
 
   double e_cmf_total =

--- a/packet.cc
+++ b/packet.cc
@@ -105,6 +105,14 @@ void packet_init(std::span<Packet> packets)
 
   const auto energy_per_massoftopnuc_decaypath = decay::calc_energy_per_massoftopnuc_decaypath();
 
+  // decay energy per unit ejecta mass of each model cell (computed once per model cell, since many propagation
+  // cells can map to the same model cell)
+  auto cell_endecay_per_mass = std::vector<double>(grid::get_nonempty_npts_model());
+  for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
+    cell_endecay_per_mass[nonemptymgi] =
+        decay::get_modelcell_endecay_per_mass(nonemptymgi, energy_per_massoftopnuc_decaypath);
+  }
+
   // Need to get a normalisation factor
   auto en_cumulative = std::vector<double>(grid::ngrid);
 
@@ -114,13 +122,11 @@ void packet_init(std::span<Packet> packets)
     // some grid cells are empty
     if (mgi >= 0) {
       const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
-      const double decay_en_per_mass =
-          decay::get_modelcell_simtime_endecay_per_mass(nonemptymgi, energy_per_massoftopnuc_decaypath);
       const auto initial_en_per_mass =
           (INITIAL_PACKETS_ON && USE_MODEL_INITIAL_ENERGY) ? grid::get_initenergyq(mgi) : 0.;
 
       etot_simtime += grid::get_propcell_volume_tmin(propcellindex) * grid::get_rho_tmin(mgi) *
-                      (decay_en_per_mass + initial_en_per_mass);
+                      (cell_endecay_per_mass[nonemptymgi] + initial_en_per_mass);
     }
     en_cumulative[propcellindex] = etot_simtime;
   }

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -977,21 +977,11 @@ auto main(int argc, char* argv[]) -> int {
 
   grid::init_grid();
 
-  printlnlog("Simulation propagates {:g} packets per process (total {:g} with nprocs {})", 1. * MPKTS,
-             1. * MPKTS * globals::nprocs, globals::nprocs);
-
-  printlnlog("[info] mem_usage: packets occupy {:.3f} MB", MPKTS * sizeof(Packet) / 1024. / 1024.);
-
-  if (!globals::simulation_continued_from_saved) {
-    std::remove("deposition.out");
-    packet_init(packets);
-    zero_estimators();
-  }
-
   // For the parallelisation of update_grid, the process needs to be told which cells belong to it.
   // The next loop is over all grid cells. For parallelisation, we want to split this loop between
   // processes. This is done by assigning each MPI process nblock cells. The residual n_leftover
   // cells are sent to processes 0 ... process n_leftover -1.
+  // (the cell assignments are already needed within grid::init_grid() for the initial temperatures)
   const int nstart = grid::get_nstart(globals::my_rank);
   const int ndo = grid::get_ndo(globals::my_rank);
   const int ndo_nonempty = grid::get_ndo_nonempty(globals::my_rank);
@@ -1003,6 +993,17 @@ auto main(int argc, char* argv[]) -> int {
   } else {
     printlnlog("process rank {} (of 0..{}) assigned {} modelgrid cells ({} nonempty)", globals::my_rank,
                globals::nprocs - 1, ndo, ndo_nonempty);
+  }
+
+  printlnlog("Simulation propagates {:g} packets per process (total {:g} with nprocs {})", 1. * MPKTS,
+             1. * MPKTS * globals::nprocs, globals::nprocs);
+
+  printlnlog("[info] mem_usage: packets occupy {:.3f} MB", MPKTS * sizeof(Packet) / 1024. / 1024.);
+
+  if (!globals::simulation_continued_from_saved) {
+    std::remove("deposition.out");
+    packet_init(packets);
+    zero_estimators();
   }
 
   MPI_Barrier_allranks();

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -977,11 +977,21 @@ auto main(int argc, char* argv[]) -> int {
 
   grid::init_grid();
 
+  printlnlog("Simulation propagates {:g} packets per process (total {:g} with nprocs {})", 1. * MPKTS,
+             1. * MPKTS * globals::nprocs, globals::nprocs);
+
+  printlnlog("[info] mem_usage: packets occupy {:.3f} MB", MPKTS * sizeof(Packet) / 1024. / 1024.);
+
+  if (!globals::simulation_continued_from_saved) {
+    std::remove("deposition.out");
+    packet_init(packets);
+    zero_estimators();
+  }
+
   // For the parallelisation of update_grid, the process needs to be told which cells belong to it.
   // The next loop is over all grid cells. For parallelisation, we want to split this loop between
   // processes. This is done by assigning each MPI process nblock cells. The residual n_leftover
   // cells are sent to processes 0 ... process n_leftover -1.
-  // (the cell assignments are already needed within grid::init_grid() for the initial temperatures)
   const int nstart = grid::get_nstart(globals::my_rank);
   const int ndo = grid::get_ndo(globals::my_rank);
   const int ndo_nonempty = grid::get_ndo_nonempty(globals::my_rank);
@@ -993,17 +1003,6 @@ auto main(int argc, char* argv[]) -> int {
   } else {
     printlnlog("process rank {} (of 0..{}) assigned {} modelgrid cells ({} nonempty)", globals::my_rank,
                globals::nprocs - 1, ndo, ndo_nonempty);
-  }
-
-  printlnlog("Simulation propagates {:g} packets per process (total {:g} with nprocs {})", 1. * MPKTS,
-             1. * MPKTS * globals::nprocs, globals::nprocs);
-
-  printlnlog("[info] mem_usage: packets occupy {:.3f} MB", MPKTS * sizeof(Packet) / 1024. / 1024.);
-
-  if (!globals::simulation_continued_from_saved) {
-    std::remove("deposition.out");
-    packet_init(packets);
-    zero_estimators();
   }
 
   MPI_Barrier_allranks();

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
@@ -17,12 +17,12 @@ f2d19fae7c33ca36abb873b31597c9cd  packets00_0001.out
 5429db075a064aa9b6bf9986df4681c4  packets00_0003.out
 e5f92402aa33200d9ad126d23f594846  spec.out
 cc34b452ecfeee0499dfb18f1f884818  timesteps.out
-ee335c3ef9ebf67d012077c843dcb596  job1/estimators_0000.out
+a3a7403950cd0316649ee67936449c5f  job1/estimators_0000.out
 daf3e8ba1cdbc43fcda7cbe15139ba75  job1/estimators_0001.out
 10520df567e2474d54fdbde276c8cedf  job1/estimators_0002.out
-181db090a6144fb2901e0bf79aa092ca  job1/nlte_0000.out
-387045fbafa0ca02ba8baf91757e4ce7  job1/nlte_0001.out
+0e8ca4dcfd3989de4d386b110b42ac30  job1/nlte_0000.out
+53ed64680008eb2e6cd88d975170139f  job1/nlte_0001.out
 800005413a1d3ea9995398b89861380f  job1/nlte_0002.out
-252a1f3bea44c683a69674d944441629  job1/radfield_0000.out
+65c938ef8bf89e77fb636c06d4e5d2d3  job1/radfield_0000.out
 13987e28b3140fc6cb80652352bda245  job1/radfield_0001.out
 2298e6c1bc34459dfd9d1b4f82af49b3  job1/radfield_0002.out

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
@@ -16,12 +16,12 @@ e00859a426c5c386e8a27c9139445a3e  packets00_0001.out
 631a09885d587c926a893c168e171c7a  packets00_0003.out
 1c7e44f71d56b9451b3ab10f158e65f0  spec.out
 cc34b452ecfeee0499dfb18f1f884818  timesteps.out
-33d5c1acaee1035814c191aefbb4bde9  job0/estimators_0000.out
+9a0ac0be58ef9e8459e22b48c305f51a  job0/estimators_0000.out
 174e2d262333a3ed3ca5b8c4b2c2a0cb  job0/estimators_0001.out
 02b43842ee1d05bf439f0cb100b992cf  job0/estimators_0002.out
-759eaf481bb6439bb01edc68a5a2ab3f  job0/nlte_0000.out
-1920ffe47d05b55dea605d9943b787e4  job0/nlte_0001.out
+dff98f1faf43d931b067797419a63311  job0/nlte_0000.out
+2add37b878e74849ee07146f72239625  job0/nlte_0001.out
 2ead5fb7941a97f6dafb714d2dbfa694  job0/nlte_0002.out
-158f806935200173dc25f1f095820622  job0/radfield_0000.out
-f7e4245a0736406aad0d1fd637b90708  job0/radfield_0001.out
+976d3bf585d8fa12cab94c117b40ac1f  job0/radfield_0000.out
+2c6d85b332be7bb4e52a24257897133f  job0/radfield_0001.out
 0047938bae5f1cabb3ea38a75d73a1d7  job0/radfield_0002.out

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -597,14 +597,12 @@ void update_grid(std::ostream& estimators_file, const int nts, const int nts_pre
 
   const auto nstart_nonempty = grid::get_nstart_nonempty(my_rank);
 
-  // for this rank's cells: update the mass densities, then the elemental abundances (with radioactive decays to
-  // the timestep midpoint), and then the total ion number densities that depend on both
+  // for this rank's cells: update the elemental abundances (with radioactive decays to the timestep midpoint),
+  // then the mass densities and the total ion number densities that depend on both
+  decay::update_abundances(nstart_nonempty, ndo_nonempty, globals::timesteps[nts].mid);
   for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
     const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
     grid::set_rho(nonemptymgi, static_cast<float>(grid::get_rho_tmin(mgi) / pow3(tratmid)));
-  }
-  decay::update_abundances(nstart_nonempty, ndo_nonempty, globals::timesteps[nts].mid);
-  for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
     grid::set_nnetot(nonemptymgi);
   }
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -359,10 +359,6 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
       grid::get_modelcell_assocvolume_tmin(mgi) * pow3(globals::timesteps[nts_prev].mid / globals::tmin);
   const auto sys_time_start_update_cell = std::chrono::steady_clock::now();
 
-  // Update current mass density of cell
-  const auto rho = static_cast<float>(grid::get_rho_tmin(mgi) / pow3(tratmid));
-  grid::set_rho(nonemptymgi, rho);
-
   const auto tmid = globals::timesteps[nts].mid;
 
   // Update clumping factors
@@ -373,8 +369,6 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
     grid::set_clumpfactor(nonemptymgi, clumpfactor);
   }
 
-  // Update elemental abundances with radioactive decays
-  decay::update_abundances(nonemptymgi, tmid);
   nonthermal::calculate_deposition_rate_density(nonemptymgi, nts, heatingcoolingrates);
 
   const double estimator_normfactor = 1 / deltaV / deltat / globals::nprocs;
@@ -602,6 +596,17 @@ void update_grid(std::ostream& estimators_file, const int nts, const int nts_pre
   std::ranges::fill(heatingcoolingrates_thisrankcells, HeatingCoolingRates{});
 
   const auto nstart_nonempty = grid::get_nstart_nonempty(my_rank);
+
+  // for this rank's cells: update the mass densities, then the elemental abundances (with radioactive decays to
+  // the timestep midpoint), and then the total ion number densities that depend on both
+  for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+    const int mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);
+    grid::set_rho(nonemptymgi, static_cast<float>(grid::get_rho_tmin(mgi) / pow3(tratmid)));
+  }
+  decay::update_abundances(nstart_nonempty, ndo_nonempty, globals::timesteps[nts].mid);
+  for (int nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+    grid::set_nnetot(nonemptymgi);
+  }
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic)


### PR DESCRIPTION
The Bateman solution for a decay chain factorises into (chain-top initial abundance) x (abundance-independent chain factor), so per-decaypath factors that depend only on the elapsed time can be computed once and applied to every cell's initial abundances. This PR applies that idea to three places that were repeating the same chain calculations for every cell, benchmarked on a real 3D kilonova model (125000 cells, 2484 nuclides, 6803 decay paths, Apple M4 Pro, 4 MPI ranks):

## Initial temperatures

`assign_initial_temperatures()` precomputes the expansion-weighted chain factors once via `decay::calc_decaypath_factors(tstart, true)` instead of every cell recomputing every chain's Bateman sum inside `get_endecay_per_ejectamass_tmodel_to_time_withexpansion()`.

## Pellet energy array replaced by a tiny per-decaypath array

The `[nonempty cells x decay paths]` node-shared array of pellet energies (**~6.6 GB** for the benchmark model) is replaced by `energy_per_massoftopnuc_decaypath`: the decay energy per unit mass of the chain-top nuclide for each decaypath (**53 KB**), applied to each cell's initial mass fraction of that nuclide in `get_modelcell_simtime_endecay_per_mass()` and `setup_radioactive_pellet()`. The array fill, its striping, barriers, and node-shared allocation all disappear.

## Abundance updates for all cells at once

`update_abundances()` now takes a contiguous range of cells (each rank's assigned block) instead of a single cell. Each nuclide's mass fraction is a linear function of the cell's initial nuclide mass fractions, so the per-decaypath coefficients (including the He4-from-alpha-decays rule and each nuclide's own exponential decay factor) are computed once per timestep and applied to every cell as a short list of multiply-adds per nuclide. The cell density and total ion number density updates are hoisted out of `update_grid_cell()` so the rho -> abundances -> nnetot ordering is explicit in `update_grid()`.

**First-timestep `update_grid` on the real model: 787 s -> 537 s** (rank-0 compute 671 s -> 525 s, MPI wait 116 s -> 12 s), recurring every timestep.

## Simplification pass

A review pass unified the two energy-coefficient paths (the initial-temperature path now uses the same per-decaypath energy-per-chain-top-mass array and `get_modelcell_endecay_per_mass` dot product as the pellet path), flattened the abundance contribution table (element filtering and zero pruning at build time, per-nuclide mass division folded into a second coefficient), restored OpenMP threading on the per-cell abundance loop, added a flat chain-top nuclide index array for the per-pellet loops, and computed each model cell's decay energy once instead of once per propagation cell during packet initialisation.

## Verification

`calculate_decaychain()` itself is unchanged (unit tests pass). Verified with the kilonova_1d full sequence (newrun + resume + exspec) and classicmode_3d first job (`REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2`, 4 ranks as two nodes):

- classicmode_3d outputs are **bit-identical** to the pre-change code.
- kilonova_1d abundances are identical at output precision (all 5771 timestep-0 elemental and isotopic abundance values match exactly), but the reformulated summation order shifts ion population tails below 1e-30 by roundoff, which seeds Monte Carlo divergence — so the **kilonova test checksums will need to be regenerated** via the Update checksums workflow after CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
