### PR TITLE
Guard estimator renormalisation divisions against zero analytic rates

### DIFF
--- a/update_grid.cc
+++ b/update_grid.cc
@@ -296,10 +296,26 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
         titer_average(globals::gammaestimator[ionestimindex], globals::gammaestimator_save[ionestimindex]);
 #endif
 
-        globals::corrphotoionrenorm[ionestimindex] =
-            globals::gammaestimator[ionestimindex] / (W * get_corrphotoioncoeff_ana(element, ion, 0, 0, T_R));
-
-        assert_always(std::isfinite(globals::corrphotoionrenorm[ionestimindex]));
+        // renormalisation factor of the MC photoionisation rate estimate over the analytic rate for the cell's
+        // dilute-blackbody radiation field. In cold and/or dilute cells the analytic rate can underflow to zero
+        // for high-threshold continua, making the ratio inf (or NaN if the estimator is also zero). Fall back to
+        // no renormalisation (factor 1) there, matching the initialisation value and the LTE/grey-cell treatment,
+        // so the uncorrected analytic LUT rate is used for such continua.
+        const double gammacorr_ana = W * get_corrphotoioncoeff_ana(element, ion, 0, 0, T_R);
+        const double renorm = globals::gammaestimator[ionestimindex] / gammacorr_ana;
+        if (std::isfinite(renorm)) {
+          globals::corrphotoionrenorm[ionestimindex] = renorm;
+        } else {
+          // a non-finite estimator would be a bug upstream, not an underflowing denominator
+          assert_always(std::isfinite(globals::gammaestimator[ionestimindex]));
+          printlnlog(
+              "[warning] update_grid cell {} timestep {} Z={} ionstage {}: gammaestimator {:g} cannot be "
+              "renormalised by W * corrphotoioncoeff_ana = {:g} (W {:g}, T_R {:g}). Setting corrphotoionrenorm = 1 "
+              "(no renormalisation)",
+              grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, get_atomicnumber(element),
+              get_ionstage(element, ion), globals::gammaestimator[ionestimindex], gammacorr_ana, W, T_R);
+          globals::corrphotoionrenorm[ionestimindex] = 1.;
+        }
       }
 
       // 2012-01-11. These loops should terminate here to precalculate *ALL* corrphotoionrenorm
@@ -333,10 +349,22 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
         // Now convert bfheatingestimator into the bfheating renormalisation coefficient used in
         // for the remaining part of update_grid. At the start of the next update_packets, it will be reset
 
+        // as for corrphotoionrenorm above, the analytic bf heating coefficient can be exactly zero in cells where
+        // the radiation field model gives no flux above a continuum's threshold (e.g. empty radfield bins), so
+        // guard the renormalisation and fall back to no renormalisation (factor 1) if the ratio is not finite
         const double bfheatingcoeff_ground = calculate_bfheatingcoeff(element, ion, 0, 0, nonemptymgi);
-        globals::bfheatingestimator[ionestimindex] /= bfheatingcoeff_ground;
-
-        assert_always(std::isfinite(globals::bfheatingestimator[ionestimindex]));
+        const double bfheatingrenorm = globals::bfheatingestimator[ionestimindex] / bfheatingcoeff_ground;
+        if (std::isfinite(bfheatingrenorm)) {
+          globals::bfheatingestimator[ionestimindex] = bfheatingrenorm;
+        } else {
+          assert_always(std::isfinite(globals::bfheatingestimator[ionestimindex]));
+          printlnlog(
+              "[warning] update_grid cell {} timestep {} Z={} ionstage {}: bfheatingestimator {:g} cannot be "
+              "renormalised by bfheatingcoeff_ground = {:g}. Setting bfheating renormalisation factor = 1",
+              grid::get_mgi_of_nonemptymgi(nonemptymgi), globals::timestep, get_atomicnumber(element),
+              get_ionstage(element, ion), globals::bfheatingestimator[ionestimindex], bfheatingcoeff_ground);
+          globals::bfheatingestimator[ionestimindex] = 1.;
+        }
       }
     }
   }

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdlib>
+#include <limits>
 #include <ostream>
 #include <print>
 #include <vector>
@@ -298,16 +299,18 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
 
         // renormalisation factor of the MC photoionisation rate estimate over the analytic rate for the cell's
         // dilute-blackbody radiation field. In cold and/or dilute cells the analytic rate can underflow to zero
-        // for high-threshold continua, making the ratio inf (or NaN if the estimator is also zero). Fall back to
+        // for high-threshold continua (and the ratio can overflow for subnormal denominators). Fall back to
         // no renormalisation (factor 1) there, matching the initialisation value and the LTE/grey-cell treatment,
         // so the uncorrected analytic LUT rate is used for such continua.
         const double gammacorr_ana = W * get_corrphotoioncoeff_ana(element, ion, 0, 0, T_R);
-        const double renorm = globals::gammaestimator[ionestimindex] / gammacorr_ana;
+        // a non-finite analytic rate or MC estimator would be an upstream bug, not an underflowing denominator
+        assert_always(std::isfinite(gammacorr_ana));
+        assert_always(std::isfinite(globals::gammaestimator[ionestimindex]));
+        const double renorm = (gammacorr_ana > 0.) ? globals::gammaestimator[ionestimindex] / gammacorr_ana
+                                                   : std::numeric_limits<double>::infinity();
         if (std::isfinite(renorm)) {
           globals::corrphotoionrenorm[ionestimindex] = renorm;
         } else {
-          // a non-finite estimator would be a bug upstream, not an underflowing denominator
-          assert_always(std::isfinite(globals::gammaestimator[ionestimindex]));
           printlnlog(
               "[warning] update_grid cell {} timestep {} Z={} ionstage {}: gammaestimator {:g} cannot be "
               "renormalised by W * corrphotoioncoeff_ana = {:g} (W {:g}, T_R {:g}). Setting corrphotoionrenorm = 1 "
@@ -353,11 +356,15 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
         // the radiation field model gives no flux above a continuum's threshold (e.g. empty radfield bins), so
         // guard the renormalisation and fall back to no renormalisation (factor 1) if the ratio is not finite
         const double bfheatingcoeff_ground = calculate_bfheatingcoeff(element, ion, 0, 0, nonemptymgi);
-        const double bfheatingrenorm = globals::bfheatingestimator[ionestimindex] / bfheatingcoeff_ground;
+        // a non-finite analytic coefficient or MC estimator would be an upstream bug, not an underflow
+        assert_always(std::isfinite(bfheatingcoeff_ground));
+        assert_always(std::isfinite(globals::bfheatingestimator[ionestimindex]));
+        const double bfheatingrenorm = (bfheatingcoeff_ground > 0.)
+                                           ? globals::bfheatingestimator[ionestimindex] / bfheatingcoeff_ground
+                                           : std::numeric_limits<double>::infinity();
         if (std::isfinite(bfheatingrenorm)) {
           globals::bfheatingestimator[ionestimindex] = bfheatingrenorm;
         } else {
-          assert_always(std::isfinite(globals::bfheatingestimator[ionestimindex]));
           printlnlog(
               "[warning] update_grid cell {} timestep {} Z={} ionstage {}: bfheatingestimator {:g} cannot be "
               "renormalised by bfheatingcoeff_ground = {:g}. Setting bfheating renormalisation factor = 1",

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -301,7 +301,9 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
         // dilute-blackbody radiation field. In cold and/or dilute cells the analytic rate can underflow to zero
         // for high-threshold continua (and the ratio can overflow for subnormal denominators). Fall back to
         // no renormalisation (factor 1) there, matching the initialisation value and the LTE/grey-cell treatment,
-        // so the uncorrected analytic LUT rate is used for such continua.
+        // so the uncorrected analytic LUT rate is used for such continua. This drops any positive MC estimator
+        // for the continuum, but no finite factor could preserve it: get_corrphotoioncoeff multiplies this factor
+        // by the same analytic rate, so the product stays zero wherever that rate still underflows.
         const double gammacorr_ana = W * get_corrphotoioncoeff_ana(element, ion, 0, 0, T_R);
         // a non-finite analytic rate or MC estimator would be an upstream bug, not an underflowing denominator
         assert_always(std::isfinite(gammacorr_ana));
@@ -354,7 +356,10 @@ void update_gamma_corrphotoionrenorm_bfheating_estimators(const int nonemptymgi,
 
         // as for corrphotoionrenorm above, the analytic bf heating coefficient can be exactly zero in cells where
         // the radiation field model gives no flux above a continuum's threshold (e.g. empty radfield bins), so
-        // guard the renormalisation and fall back to no renormalisation (factor 1) if the ratio is not finite
+        // guard the renormalisation and fall back to no renormalisation (factor 1) if the ratio is not finite.
+        // A positive MC estimator over a zero analytic coefficient is dropped: calculate_bfheatingcoeffs multiplies
+        // this factor by per-level coefficients from the same radiation field model, which are then zero too, so
+        // no finite factor could carry the estimator's contribution through.
         const double bfheatingcoeff_ground = calculate_bfheatingcoeff(element, ion, 0, 0, nonemptymgi);
         // a non-finite analytic coefficient or MC estimator would be an upstream bug, not an underflow
         assert_always(std::isfinite(bfheatingcoeff_ground));


### PR DESCRIPTION
## What

Guards the two estimator renormalisation divisions in `update_gamma_corrphotoionrenorm_bfheating_estimators` (update_grid.cc):

- `corrphotoionrenorm = gammaestimator / (W * corrphotoioncoeff_ana(T_R))`
- `bfheatingestimator /= bfheatingcoeff_ground`

If the ratio is non-finite, the renormalisation factor now falls back to **1** (no renormalisation — the same value used at initialisation and for LTE/grey cells, so the uncorrected analytic LUT rate is used), with a `[warning]` log line recording the cell, timestep, Z, ionstage, estimator value, and denominator. A non-finite *estimator* itself (an upstream bug, not an underflowing denominator) still triggers `assert_always`.

## Why

On macOS (Apple clang 21), the classicmode_3d test aborted at timestep 5 (the LTE→nebular transition) with `assert_always(std::isfinite(globals::corrphotoionrenorm[ionestimindex]))`, while the identical code passed Linux CI with unchanged checksums. The denominators can be exactly zero:

- `W * corrphotoioncoeff_ana(T_R)` underflows for high-threshold continua in cold and/or dilute cells (the `exp(-hν/kT_R)` factor in the LUT integrand collapses).
- From `FIRST_NLTE_RADFIELD_TIMESTEP` (12) onwards, `calculate_bfheatingcoeff` integrates the *binned* radiation field, which is exactly 0 wherever the covering bins saw no packets (or ν is above the T_e superbin).

Whether a zero-denominator cell also has a nonzero MC estimator (→ inf) or a zero one (→ NaN) is Monte Carlo noise, which is why the abort was platform/realisation-dependent. Consistent with that, the crash could not be reproduced locally at 8131c0d1 in four build configs (Homebrew clang 23 / Apple clang 21, ±TESTMODE, fresh job + resume job); in passing runs the renorm factor distribution spikes exactly at timestep 5 (up to 3.3e9 for Fe/Co II→III in outer cells) — the abort is the tail of that distribution.

## Numerical results unchanged

The guard only activates where the old code called `abort()`, so results are unchanged by construction. Verified empirically with baseline-vs-changed runs on the same machine (Apple clang 21, `REPRODUCIBLE=ON MAX_NODE_SIZE=2 FASTMATH=OFF`, full CI sequence job0 → resume job1 → exspec):

- classicmode_3d: all 1367 output-file md5 checksums identical
- kilonova_1d: all 45 output-file md5 checksums identical

No checksum regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)