### PR TITLE
Add a CPU stdpar smoke test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,59 @@ jobs:
               working-directory: tests/kilonova_1d_testrun/
               run: cat output_0-0.txt
 
+    # Runs the same small model with C++ standard parallelism on multicore CPUs (no GPU offload), which
+    # reaches the same shared-state code paths as the OpenMP job but through std::execution::par_unseq and
+    # std::atomic_ref instead of OpenMP pragmas. As for the OpenMP job, there is no checksum comparison
+    # because multithreaded runs are not reproducible. The thread count is whatever libtbb picks from the
+    # runner's hardware concurrency: unlike OpenMP there is no environment variable to cap it.
+    stdpar_smoke:
+        runs-on: ubuntu-26.04-arm
+        timeout-minutes: ${{ inputs.testmode == 'ON' && 360 || 40 }}
+        name: kilonova_1d_stdpar_norun_checksums
+        env:
+            OMPI_MCA_memory: ${{ inputs.testmode == 'ON' && '^patcher' || '' }}
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  fetch-depth: 0
+
+            - name: Install Open MPI and TBB and set compiler to g++-15
+              run: |
+                  echo "CXX=g++-15" >> $GITHUB_ENV
+                  echo "OMPI_CXX=g++-15" >> $GITHUB_ENV
+                  sudo apt-get update
+                  sudo apt-get install -y openmpi-bin libopenmpi-dev libtbb-dev
+
+            - name: Cache test atomic data
+              uses: actions/cache@v6
+              id: cache-testatomicdata
+              with:
+                  path: tests/atomicdata_feconi.tar.xz
+                  key: tests/atomicdata_feconi.tar.xz
+
+            - name: Download/extract test data
+              working-directory: tests/
+              run: |
+                  source ./setup_kilonova_1d.sh
+
+            - name: Compile
+              run: |
+                  cp tests/kilonova_1d_testrun/artisoptions.h .
+                  make STDPAR=ON TESTMODE=${{ inputs.testmode }} MAX_NODE_SIZE=2 FASTMATH=OFF -j$(nproc) sn3d exspec
+                  cp sn3d exspec tests/kilonova_1d_testrun/
+
+            - name: Run test job0 with stdpar threads
+              working-directory: tests/kilonova_1d_testrun/
+              run: |
+                  cp input-newrun.txt input.txt
+                  touch output_0-0.txt
+                  time mpirun -np 2 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d
+
+            - name: cat output log
+              if: always()
+              working-directory: tests/kilonova_1d_testrun/
+              run: cat output_0-0.txt
+
     combine_checksums:
         needs: testmodels
         if: always() && inputs.testmode != 'ON'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,10 @@ next to their definitions. The main coverage is end-to-end regression runs
 (`.github/workflows/ci.yml`): each test in `tests/` runs a small model with
 `REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2` and compares `md5sum` checksums of
 the output files against `tests/<testname>_inputfiles/results_md5_*.txt` (all
-`*.out` files are checksummed; `output_*.txt` logs are not). A separate CI job
-runs one model with `OPENMP=ON` and no checksum comparison to exercise the
-threaded code paths. To run a regression test locally (downloads atomic data on
-first use):
+`*.out` files are checksummed; `output_*.txt` logs are not). Two separate smoke
+test jobs run one model with `OPENMP=ON` and with `STDPAR=ON` (multicore CPU),
+both without checksum comparison, to exercise the threaded code paths. To run a
+regression test locally (downloads atomic data on first use):
 
 ```sh
 cd tests


### PR DESCRIPTION
## What

Adds a `stdpar_smoke` job to `ci.yml`, alongside the existing `openmp_smoke` job, that actually *runs* a small model built with `STDPAR=ON` (multicore CPU, no GPU offload).

## Why

`STDPAR=ON` was only ever compile-tested in CI. The multicore standard-parallelism code paths were never executed:

- the `std::for_each(EXEC_PAR ...)` packet-propagation dispatch in `update_packets.cc`
- the `std::atomic_ref` based `atomicadd` in `constants.h` (the OpenMP build uses `#pragma omp atomic` instead)
- the `THREADLOCALONHOST` per-thread scratch state and the stdpar per-thread log-file handling in `sn3d.cc`

These are genuinely different code from the OpenMP paths, so the OpenMP smoke test does not cover them.

## Details

The new job mirrors `openmp_smoke` as closely as possible: same `kilonova_1d` model, same runner (`ubuntu-26.04-arm`) and compiler (g++-15), same `mpirun -np 2` invocation, and likewise **no checksum comparison** since multithreaded runs are not reproducible.

Two differences from the OpenMP job:

- It additionally installs `libtbb-dev`, which the Makefile's gcc `STDPAR` branch links against (`LDFLAGS += -ltbb`).
- There is no `OMP_NUM_THREADS` equivalent. `get_max_threads()` falls back to `std::thread::hardware_concurrency()` in stdpar mode and libtbb has no thread-count environment variable, so the job runs with whatever concurrency the runner offers. This is noted in a comment on the job.

The testing section of `AGENTS.md` is updated to describe both smoke jobs.

No source changes, so no checksum regeneration is needed.

## Testing

Verified locally on macOS/arm64 (Homebrew clang 23, libc++ PSTL — so this exercises the run path, not the gcc/TBB link, which the existing `ci-checks.yml` compile jobs already cover):

```
make STDPAR=ON MAX_NODE_SIZE=2 FASTMATH=OFF -j8 sn3d exspec
mpirun -np 2 --oversubscribe ./sn3d
```

Completed in 10.5 s at 542% CPU, exit 0, with the expected job0 ending. The log confirms real threading:

```
C++ standard parallelism (stdpar) is enabled with up to 14 CPU threads
...
sn3d finished (job: pktprop ts 0 to ts 8 grid-preprop, 0.003 wallclock hours * 2 processes * 14 threads = 0.079 core hours)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)