### PR TITLE
Fix latent defects from a code review and resolve the Kozma & Fransson eq. 6 integrals

### DIFF
--- a/decay.cc
+++ b/decay.cc
@@ -547,12 +547,6 @@ auto write_nuclides_list() {
 
 }  // anonymous namespace
 
-[[nodiscard]] auto get_decay_neutrino_frac(const int nucindex, const DecayType decaytype) -> double {
-  // subtract fraction of other decay products, nucdecayenergy() excludes neutrinos!
-  const double nu_frac = 1. - (nucdecayenergy(nucindex, decaytype) / nuclides[nucindex].endecay_q[decaytype]);
-  return nu_frac;
-}
-
 [[gnu::pure]] [[nodiscard]] auto get_num_nuclides() -> ptrdiff_t { return std::ssize(nuclides); }
 
 [[nodiscard]] auto get_elname(const int z) -> std::string {

--- a/decay.h
+++ b/decay.h
@@ -140,7 +140,6 @@ void init_nuclides(std::span<const int> custom_zlist, std::span<const int> custo
 [[nodiscard]] auto nuc_exists(int z, int a) -> bool;
 [[nodiscard]] auto nucdecayenergygamma(int nucindex) -> double;
 [[nodiscard]] auto nucdecayenergygamma(int z, int a) -> double;
-[[nodiscard]] auto get_decay_neutrino_frac(int nucindex, DecayType decaytype) -> double;
 void set_nucdecayenergygamma(int nucindex, double value);
 void update_abundances(int nonemptymgi_start, int nonemptymgi_count, const NucMassFracCoeffs& nuc_massfrac_coeffs);
 // the calc_energy_per_massoftopnuc_* functions return the decay energy per unit mass of the chain-top nuclide

--- a/grid.cc
+++ b/grid.cc
@@ -2299,9 +2299,15 @@ void init_grid() {
     assign_initial_temperatures();
   }
 
-  // when mapping 1D spherical or 2D cylindrical model onto cubic grid, scale up the
-  // radioactive abundances to account for the missing masses in
-  // the model cells that are not associated with any propagation cells
+  // when mapping a 1D spherical model onto a cubic grid, rescale the nuclide abundances so that each nuclide's
+  // total mass matches the input model again. Every propagation cell takes the model shell that its centre falls
+  // in, so the volume associated with a shell is a staircase approximation of the true shell volume and the
+  // mapped mass of each nuclide differs from the input.
+  //
+  // NB: a 2D cylindrical model is mapped onto the cubic grid by the same centre-of-cell rule
+  // (map_2dmodelto3dgrid) and loses mass the same way, but is deliberately not corrected here, because doing so
+  // would change existing results. The "Total grid-mapped mass" line logged below shows the size of the
+  // discrepancy for any model.
   if (prop_gridtype == GridType::CARTESIAN3D && get_modelgridtype() == GridType::SPHERICAL1D &&
       globals::rank_in_node == 0) {
     for (int nucindex = 0; nucindex < decay::get_num_nuclides(); nucindex++) {

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -722,7 +722,8 @@ void macroatom_open_file() {
     }
 
     // forbidden transitions: magnetic dipole, electric quadrupole... Axelrod's approximation (thesis 1980),
-    // i.e. the effective-collision-strength form below with an assumed Omega = 0.01 * lowerstatweight.
+    // i.e. the effective-collision-strength form below with an assumed Omega = 0.01 * lowerstatweight *
+    // upperstatweight, so that Omega / g_upper leaves the 0.01 * lowerstatweight below.
     // This is the detailed-balance reverse of the branch in col_excitation_ratecoeff().
     return clumpednne * 8.629e-6 * 0.01 * lowerstatweight / std::sqrt(T_e);
   }
@@ -764,7 +765,10 @@ void macroatom_open_file() {
     }
 
     // forbidden transitions: magnetic dipole, electric quadrupole... Axelrod's approximation (thesis 1980),
-    // i.e. the effective-collision-strength form below with an assumed Omega = 0.01 * upperstatweight
+    // i.e. the effective-collision-strength form below with an assumed Omega = 0.01 * lowerstatweight *
+    // upperstatweight, so that Omega / g_lower leaves the 0.01 * upperstatweight below. The same Omega is
+    // assumed by the matching branch of col_deexcitation_ratecoeff(), which is what makes the pair satisfy
+    // detailed balance: C_lu / C_ul = (g_upper / g_lower) * exp(-eoverkt).
     return clumpednne * 8.629e-6 * 0.01 * std::exp(-eoverkt) * upperstatweight / std::sqrt(T_e);
   }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1483,7 +1483,9 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 // assembly) only weaken that guarantee locally; any resulting invalid populations are policed by the caller.
 // rate_matrix is overwritten. On success, returns std::nullopt and fills vec_x with the stationary distribution
 // normalised to a sum of one. On failure, returns the index of a state with no departure rate into the remaining
-// chain (a reducible/disconnected matrix) and leaves vec_x untouched.
+// chain (a reducible/disconnected matrix) and leaves vec_x untouched. An off-diagonal that grows to infinity
+// during the elimination is not a failure here: it is passed through as a non-finite distribution for the
+// caller's population validity check to handle, rather than being rescued (see the back-substitution below).
 // Defined with external linkage (declared in nltepop.h) so that unittests.cc can exercise it.
 auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double> vec_x)
     -> std::optional<std::ptrdiff_t> {
@@ -1532,7 +1534,15 @@ auto gth_stationary_distribution(std::span<double> rate_matrix, std::span<double
     // preserved, weights that underflow to zero are at least ~1e58 times smaller than the largest weight and
     // physically negligible, and capping every stored weight at 1e250 keeps the normalising sum below from
     // overflowing.
-    while (!std::isfinite(inflow) || inflow > departure_sum * 1e250) {
+    //
+    // The number of passes is capped because rescaling cannot rescue every non-finite inflow. Once a weight has
+    // underflowed to zero, an infinite rate out of that state gives inflow = 0 * inf = NaN, which survives any
+    // number of further passes, so an uncapped loop would spin here forever. Three passes already span the whole
+    // dynamic range of a double, so the cap never cuts a rescue that would have succeeded. Giving up leaves a
+    // non-finite population for solution_pops_are_valid() to reject or replace, as for any other unusable solve.
+    constexpr int max_rescale_passes = 8;
+    for (int pass = 0; pass < max_rescale_passes && (!std::isfinite(inflow) || inflow > departure_sum * 1e250);
+         pass++) {
       for (auto j = 0Z; j < k; j++) {
         vec_x[j] *= 1e-200;
       }

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -53,6 +53,17 @@ constexpr int SFPTS = 4096;
 constexpr double SF_EMIN = 0.1;
 constexpr double SF_EMAX = 16000;
 
+// number of nodes resolving the integral over the secondary energy epsilon in the first term of Kozma &
+// Fransson equation 6. That integral spans at most SF_EMIN, far narrower than one cell of the solution
+// energy grid, so it needs a sub-grid of its own rather than being sampled on that grid.
+constexpr int NPTS_EPSILON_SUBGRID = 64;
+
+// number of nodes for the integral over E in [0, SF_EMIN] in the third term of Kozma & Fransson equation 3.
+// This is a property of that integral alone, not of the solution energy grid. Each node costs a full N_e()
+// over every ion and shell, so it dominates the cost of calculate_frac_heating().
+constexpr int NPTS_SUB_E0_INTEGRAL = 17;
+static_assert(NPTS_SUB_E0_INTEGRAL > 1);
+
 // set true to divide up the mean Auger energy by the number of electrons that come out
 constexpr bool SF_AUGER_CONTRIBUTION_DISTRIBUTE_EN = false;
 
@@ -1037,23 +1048,47 @@ auto N_e(const int nonemptymgi, const double energy, const std::array<double, SF
             const double J = get_J(Z, ionstage, ionpot_ev);
             const double lambda = std::min(SF_EMAX - energy_ev, energy_ev + ionpot_ev);
 
-            const int integral1startindex = get_energyindex_ev_lteq(ionpot_ev);
-            const int integral1stopindex = get_energyindex_ev_lteq(lambda);
+            // integral from ionpot up to lambda, over its own sub-grid. This domain is only
+            // (lambda - ionpot_ev) <= energy_ev < SF_EMIN wide, some forty times narrower than one cell of
+            // the solution grid, so sampling it on that grid was wrong twice over: it gave a full DELTA_E of
+            // weight to the whole domain, and it snapped the limits down onto the grid point at or below
+            // ionpot_ev, where Psecondary() sees a negative secondary energy and returns zero. The term was
+            // therefore dropped entirely for most shells, and for the few whose threshold sits just below a
+            // grid point it instead contributed that oversized weight next to the 1/atan((e_p - I) / 2J)
+            // normalisation pole. Midpoint sampling keeps every node strictly inside the domain, away from
+            // both of those edges.
+            if (lambda > ionpot_ev) {
+              const double delta_epsilon = (lambda - ionpot_ev) / NPTS_EPSILON_SUBGRID;
+              for (int i = 0; i < NPTS_EPSILON_SUBGRID; i++) {
+                const double endash = ionpot_ev + ((i + 0.5) * delta_epsilon);
 
-            // integral from ionpot up to lambda
-            for (int i = integral1startindex; i <= integral1stopindex; i++) {
-              const double endash = engrid(i);
-
-              N_e_ion += get_y(yfunc, energy_ev + endash) * xs_impactionisation(energy_ev + endash, collionrow) *
-                         Psecondary(energy_ev + endash, endash, ionpot_ev, J) * DELTA_E;
+                N_e_ion += get_y(yfunc, energy_ev + endash) * xs_impactionisation(energy_ev + endash, collionrow) *
+                           Psecondary(energy_ev + endash, endash, ionpot_ev, J) * delta_epsilon;
+              }
             }
 
-            // integral from 2E + I up to E_max
-            const int integral2startindex = get_energyindex_ev_lteq((2 * energy_ev) + ionpot_ev);
-            for (int i = integral2startindex; i < SFPTS; i++) {
-              const double endash = engrid(i);
-              N_e_ion += yfunc[i] * xs_impactionisation(endash, collionrow) *
-                         Psecondary(endash, energy_ev + ionpot_ev, ionpot_ev, J) * DELTA_E;
+            // integral from 2E + I up to E_max. The lower limit falls between grid points, so the
+            // grid-aligned sum starts at the first point at or above it and the leading partial cell is
+            // added separately. Starting at the point at or below the limit instead placed a node under the
+            // ionisation threshold: usually harmless because Psecondary() returns zero there, but for a
+            // shell whose threshold falls within 2E of a grid point that node cleared the e_p > I guard and
+            // contributed a spike near the normalisation pole in place of a finite value.
+            const double integral2_min = (2 * energy_ev) + ionpot_ev;
+            if (integral2_min < SF_EMAX) {
+              const int integral2startindex = get_energyindex_ev_gteq(integral2_min);
+
+              const double partialcellwidth = engrid(integral2startindex) - integral2_min;
+              if (partialcellwidth > 0.) {
+                const double endash = integral2_min + (partialcellwidth / 2.);
+                N_e_ion += get_y(yfunc, endash) * xs_impactionisation(endash, collionrow) *
+                           Psecondary(endash, energy_ev + ionpot_ev, ionpot_ev, J) * partialcellwidth;
+              }
+
+              for (int i = integral2startindex; i < SFPTS; i++) {
+                const double endash = engrid(i);
+                N_e_ion += yfunc[i] * xs_impactionisation(endash, collionrow) *
+                           Psecondary(endash, energy_ev + ionpot_ev, ionpot_ev, J) * DELTA_E;
+              }
             }
           }
         }
@@ -1088,13 +1123,16 @@ auto calculate_frac_heating(const int nonemptymgi, const std::array<double, SFPT
   frac_heating_Einit += SF_EMIN * get_y(yfunc, SF_EMIN) * (electron_loss_rate(SF_EMIN * EV, nne) / EV);
 
   double N_e_contrib_Einit = 0.;
-  // third term (integral from zero to SF_EMIN)
-  constexpr int nsteps = (static_cast<int>(SF_EMIN / DELTA_E) + 1) * 10;
-  static_assert(nsteps > 0);
-  constexpr double delta_endash = SF_EMIN / nsteps;
-  for (int j = 1; j < nsteps; j++) {
+  // third term (integral from zero to SF_EMIN), on a sub-grid of its own. Sizing the node count from
+  // DELTA_E tied it to the solution energy grid, which this integral has nothing to do with, and left only
+  // nine interior nodes. Integrating by trapezoid rather than by summing interior nodes also recovers the
+  // half node that was dropped at the SF_EMIN end; the zero end costs nothing, since the integrand carries
+  // a factor of endash and so vanishes there.
+  constexpr double delta_endash = SF_EMIN / (NPTS_SUB_E0_INTEGRAL - 1);
+  for (int j = 1; j < NPTS_SUB_E0_INTEGRAL; j++) {
     const double endash = delta_endash * j;
-    N_e_contrib_Einit += N_e(nonemptymgi, endash * EV, yfunc) * endash * delta_endash;
+    const double weight = (j == (NPTS_SUB_E0_INTEGRAL - 1)) ? 0.5 : 1.;
+    N_e_contrib_Einit += weight * N_e(nonemptymgi, endash * EV, yfunc) * endash * delta_endash;
   }
   frac_heating_Einit += N_e_contrib_Einit;
 

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -145,7 +145,8 @@ void precalculate_rate_coefficient_integrals() {
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-    for (int ion = 0; ion < nions; ion++) {
+    // the topmost ion has no continua to ionise into, so it has no rate coefficients to integrate
+    for (int ion = 0; ion < nions - 1; ion++) {
       const int nlevels = get_nlevels_ionising(element, ion);
 
       for (int level = 0; level < nlevels; level++) {

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -769,9 +769,17 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
             photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
 
         double corrfactor = 1.;  // default to no subtraction of stimulated recombination
-        double modified_departure_ratio = get_cellcache(nonemptymgi).allcont_modified_departureratios[i];
 
-        if (!USECELLHISTANDUPDATEPHIXSLIST || modified_departure_ratio < 0) {
+        // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
+        // cache with. Only the cellcache path has a stored ratio to reuse: without it there is no cache entry
+        // belonging to this cell to read, because in single-slot mode get_cellcache() returns the calling
+        // rank's one shared slot, which generally holds a different cell entirely.
+        double modified_departure_ratio = -1.;
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          modified_departure_ratio = get_cellcache(nonemptymgi).allcont_modified_departureratios[i];
+        }
+
+        if (modified_departure_ratio < 0) {
           const int upper = allcont_upperlevel[i];
           const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
                                              ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)

--- a/unittests.cc
+++ b/unittests.cc
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <print>
 #include <span>
@@ -591,6 +592,25 @@ void test_gth_solver() {
     std::vector<double> vec_x(4, 0.);
     const auto result = gth_stationary_distribution(matrix, vec_x);
     check(result.has_value() && result.value() == 2, "GTH detects decoupled blocks of states");
+  }
+
+  {
+    // an infinite rate reaching a weight that the overflow rescaling has already driven to zero gives an inflow of
+    // 0 * inf = NaN, which no further rescaling can clear. The rescue must give up after a bounded number of
+    // passes and hand the non-finite result to the caller's population check: an unbounded loop hangs here rather
+    // than returning a wrong answer, so reaching the checks below at all is most of what this pins down.
+    // States 0 and 1 carry the beyond-range ratio that forces a rescale, and the rate from 0 to 2 is infinite.
+    // Row 2 is never rewritten by the elimination (it is eliminated first), so that infinity survives into the
+    // back-substitution for state 2.
+    std::vector<double> matrix(3 * 3, 0.);
+    set_rate(matrix, 3, 0, 1, 1e200);
+    set_rate(matrix, 3, 1, 0, 1e-200);
+    set_rate(matrix, 3, 2, 0, 1.);
+    set_rate(matrix, 3, 0, 2, std::numeric_limits<double>::infinity());
+    std::vector<double> vec_x(3, 0.);
+    const auto result = gth_stationary_distribution(matrix, vec_x);
+    check(!result.has_value(), "GTH terminates on an unrescuable non-finite inflow");
+    check(!std::isfinite(vec_x[2]), "GTH passes the unrescuable inflow through as a non-finite population");
   }
 
   {


### PR DESCRIPTION
> [!WARNING]
> **Correction, added after merge.** Two claims below are wrong. Found in a follow-up review of this PR; a follow-up change corrects the code comments that repeat them.
>
> 1. **There is no spike at the `Psecondary` pole.** The body and the code comments describe the old code as landing an oversized weight next to the `1/atan((e_p - I) / 2J)` normalisation pole. That cannot happen: `xs_impactionisation()` returns 0 for `u = energy_ev / ionpot_ev <= 1`, and above threshold both `(1 - 1/u)` and `log(u)` vanish linearly in `(u - 1)` — the same rate at which `Psecondary ~ 2/(e_p - I)` diverges — so their product tends to a finite constant. The real defects are that `Psecondary`'s `e_s < 0` guard drops the first eq. 6 term *entirely* for the great majority of shells, and that the survivors arrive over-weighted by `DELTA_E / energy_ev`, about 43x on the default grid.
>
> 2. **The second eq. 6 integral should not have gained a leading partial cell.** Unlike the epsilon integral, it runs over the solution grid variable and reads `yfunc[i]` directly, so it belongs to the left-endpoint rectangle convention documented at the top of `nonthermal.cc` — the same convention `E_init_ev`, `rhsvec`, `sfmatrix_add_excitation()` and `sfmatrix_add_ionisation()` share, and the one the matrix `yfunc` was solved from uses. `frac_sum` only tests energy conservation to the extent that `calculate_frac_heating()` and that matrix share a discretisation, so refining one term below cell resolution breaks the cancellation the diagnostic depends on. The partial cell is removed in the follow-up; the `gteq` start index stays, matching what `get_xs_ionisation_vector()` already does for its own threshold.
>
> The epsilon sub-grid — the main fix — is unaffected. That integral is over the secondary energy and samples `y` by interpolation rather than at nodes, so the rectangle convention never applied to it.

---

Found by reading the code, not from a failing run. **No tested result changes** — no `*.out` file is affected by anything here, so no checksums need regenerating. Log output does change (see the last section).

## Latent defects

- **`nltepop.cc` — the GTH overflow-rescue loop could spin forever.** Rescaling cannot clear a NaN inflow: an infinite rate meeting a weight that has already underflowed to zero gives `0 * inf`, which survives every further pass. The loop is now capped at eight passes. Three already span the dynamic range of a double, so the cap never cuts a rescue that would have succeeded, and a non-finite result is left for `solution_pops_are_valid()` to reject or replace, as for any other unusable solve. I bounded the loop rather than adding a failure return because the function documents "leaves `vec_x` untouched on failure" and a test pins that with a sentinel-filled vector; returning mid-back-substitution would have violated it. A regression test covers it — against the old code it **hangs** rather than failing a check.

- **`ratecoeff.cc` — loop bound silently widened.** When `nions` in `precalculate_rate_coefficient_integrals()` changed meaning from `get_nions(element) - 1` to `get_nions(element)`, the print loop kept the `-1` but the work loop did not, so it now runs over the topmost ion too. Harmless only because that ion happens to have no ionising levels — it relies on an unrelated invariant, and the two adjacent loops disagree.

- **`rpkt.cc` — cell cache read on the path that does not use it.** `calculate_chi_bf_gammacontr()` read `allcont_modified_departureratios` unconditionally; in single-slot mode `get_cellcache()` returns the rank's one shared slot, which generally holds a different cell. The value was always discarded via short-circuit, so this is not a behaviour change, but reordering the condition would have turned it into a silent wrong-cell error. The guard now keys off the `-1` sentinel alone and no longer depends on the template parameter.

- **`grid.cc` — comment claimed coverage the code does not have.** The 1D-to-3D nuclide mass rescale says it covers 2D cylindrical models. It does not. `map_2dmodelto3dgrid()` assigns propagation cells by cell centre exactly as the 1D mapping does, so 2D loses mass the same way. Rewritten to describe the actual behaviour and to record the gap; correcting it would change `kilonova_2d*` results, so it is left for a separate change.

- **`macroatom.cc` — Axelrod collision strength comments.** The two branches named different values of Omega, neither matching the code. Both implement `Omega = 0.01 * g_lower * g_upper`, which is what makes the pair satisfy detailed balance (`C_lu / C_ul = (g_upper / g_lower) * exp(-eoverkt)`). The physics was right; the comments would have misled anyone "fixing" one branch.

- **`decay.cc` — `get_decay_neutrino_frac()` removed.** No callers, and it would divide by zero for a decay type with no Q value.

## Kozma & Fransson eq. 6

`N_e()` evaluated both eq. 6 integrals on the Spencer-Fano solution grid, but neither belongs there. `N_e()` is only ever called below `SF_EMIN`, so the first integral spans at most 0.09 eV against a `DELTA_E` of 3.9 eV — about forty times narrower than one cell.

Sampling it there was wrong twice over: it gave a full `DELTA_E` of weight to the whole domain, and it snapped both limits down onto the grid point at or below `ionpot_ev`, where `Psecondary()` sees a negative secondary energy. The guard there returns zero, so **for most shells the entire first term of eq. 6 was silently dropped**. For the ~2% of shells whose threshold sits just below a grid point the guard does not fire and the term instead arrives with that oversized weight next to the `1/atan((e_p - I) / 2J)` pole. It now has a midpoint sub-grid of its own, every node strictly inside the domain and away from both edges.

The second integral had the same defect for a different reason: its `2E + I` lower limit was snapped down onto the grid point below, which for the small energies involved lands just under the ionisation threshold. It now starts at the first grid point at or above the limit and adds the leading partial cell separately. The rectangle rule over grid points is otherwise unchanged, since that is the quadrature the solution vector itself is built with.

The eq. 3 integral over `[0, SF_EMIN]` took its node count from `DELTA_E`, tying it to a grid it has nothing to do with and leaving nine interior nodes. It now has a fixed count and is integrated by trapezoid rather than by summing interior nodes, recovering the half node dropped at the `SF_EMIN` end.

## Why this changes no result

`calculate_frac_heating()` is the only caller of `N_e()`, and is itself called once — its result reaches only `frac_sum`, which feeds two `printlnlog` lines. The heating fraction the physics actually uses is `nt_solution[].frac_heating`, computed independently as `clamp(1 - frac_excitation - frac_ionisation)`. `nonthermal.cc` opens no output files.

**The logged `frac_sum` will move**, and that is the point: it is the only check that the Spencer-Fano solution conserves energy, and a systematically dropped term plus occasional near-pole spikes made it unreliable as one. Expect it to rise, since the first integral now contributes roughly `1.386 * y * sigma` per shell where it previously contributed zero.

Cost: `N_e()` is called 16 times per cell instead of 9, and the first integral runs 64 nodes instead of ~1. The second integral already runs ~4000, so the added work is minor.

## Provenance

Found in a review of [lukeshingles/pynonthermal#78](https://github.com/lukeshingles/pynonthermal/pull/78), which fixes the same integrals in the standalone Python implementation. Its other findings were checked against this code and **do not apply**: `get_y()` already returns zero above the grid rather than clamping to the last bin, the Lotz cross section is already relativistic, the plasma frequency is already computed exactly, and the deposition rate density is already asserted non-negative. That PR is still open, so its numbers are a proposal rather than settled.

## Testing

`make OPTIMIZE=OFF` clean under `-Werror`; `./unittests` 79/79 including the new GTH regression test; pre-commit (clang-format, whitespace, `make`) clean on both commits. No regression md5 comparison was run — neutrality is established by tracing every consumer of the affected values, which is short enough to be conclusive.

## Still outstanding from the same review

Three result-changing items, deliberately not included here:

1. `assign_initial_temperatures()` runs *before* the 1D-to-3D abundance rescale, so initial temperatures use un-boosted nuclide mass fractions while everything else uses boosted ones (~0.4% in the shipped tests, larger on coarser grids).
2. Extending that rescale to 2D models, per the `grid.cc` comment above.
3. `find_uppermost_ion()`'s non-thermal test is hardcoded to initial Ni56/Cr48, which is stale for the r-process networks this code now supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

