### PR TITLE
Cut the sub-E_0 heating integral to nine nodes and tighten the frac_sum warning tolerance

### DIFF
--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1874,7 +1874,7 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
   nt_solution[nonemptymgi].frac_heating =
       static_cast<float>(std::clamp(1. - frac_excitation_nonheating - frac_ionisation_total, 0., 1.));
 
-  if (!ftol<0.02>(frac_sum, 1.0)) {
+  if (!ftol<0.002>(frac_sum, 1.0)) {
     printlnlog("[warning] frac_sum is {:g}, but should be 1.0", frac_sum);
     printlnlog("  (replacing calculated frac_heating_tot {:g} with {:g} to make frac_sum = 1.0)",
                frac_heating_calculated, nt_solution[nonemptymgi].frac_heating);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -61,7 +61,16 @@ constexpr int NPTS_EPSILON_SUBGRID = 64;
 // number of nodes for the integral over E in [0, SF_EMIN] in the third term of Kozma & Fransson equation 3.
 // This is a property of that integral alone, not of the solution energy grid. Each node costs a full N_e()
 // over every ion and shell, so it dominates the cost of calculate_frac_heating().
-constexpr int NPTS_SUB_E0_INTEGRAL = 17;
+//
+// Nine is far more than the term needs. Measured on nebular_1d_3dgrid by recomputing this integral at node
+// counts from 3 to 513 on one unchanged yfunc, so that only the quadrature varied: frac_heating moved by at
+// most 6e-9 relative even at three nodes, against the 1.2e-7 relative precision of the float it is stored
+// in, so every count in that range gives a bit-identical result. The term carries only about 2e-5 of
+// frac_heating, because the source is injected near SF_EMAX while this integral covers [0, 0.1 eV], so even
+// a wildly wrong value could not move the total. Raising the count does not help in any case: the error is
+// not monotonic in the node count (17 measured worse than 5, and 129 worse than 65), because N_e(E) steps
+// discontinuously wherever 2E + I crosses a solution grid point.
+constexpr int NPTS_SUB_E0_INTEGRAL = 9;
 static_assert(NPTS_SUB_E0_INTEGRAL > 1);
 
 // set true to divide up the mean Auger energy by the number of electrons that come out


### PR DESCRIPTION
Follow-up to #498. Two independent changes to the Spencer-Fano diagnostics, both **log-only** — nothing here leaves `calculate_frac_heating()` or the warning it gates, so no results change.

# 1. Sub-`E_0` integral: 17 nodes -> 9


### Why

`NPTS_SUB_E0_INTEGRAL` was set to 17 by analogy with the reference Python implementation rather than from a measurement in this code. That left `calculate_frac_heating()` calling `N_e()` **16 times per cell** where the code before #498 called it 9 times. Each call loops ~4000 grid points for every shell of every ion, so it was a ~78% cost increase on a routine that runs on every Spencer-Fano solve and produces nothing but diagnostics.

### Measurement

Instrumented `calculate_frac_heating()` to recompute the third term at eight node counts **on one unchanged `yfunc` within a single call**, so only the quadrature varied and cell state, populations and solution vector were held identical. Separate runs would not work here — MC noise and differing cell states swamp the effect. Fresh `nebular_1d_3dgrid` run to timestep 5, 4 ranks, 10 complete sweeps.

| npts | `N_e()` calls | third-term rel. err | **frac_heating rel. err** |
|---|---|---|---|
| 3 | 2 | 1.65e-04 | **6.05e-09** |
| 5 | 4 | 8.71e-05 | **3.19e-09** |
| **9 (this PR)** | **8** | 1.50e-04 | **5.50e-09** |
| 17 (before) | 16 | 9.73e-05 | **3.56e-09** |
| 33 | 32 | 2.75e-05 | 1.01e-09 |
| 65 | 64 | 6.36e-06 | 2.33e-10 |
| 513 | 512 | — (ref) | — (ref) |

Two things make this conclusive:

- **`frac_heating` is stored as a `float`**, relative precision 1.19e-07 — about 20x larger than the worst error at 3 nodes. The stored value is bit-identical for every count in this range.
- **The term carries only 2.1e-05 of `frac_heating`.** `E_init_ev` comes out at 1.57e4 eV because the source is injected near `SF_EMAX = 16000 eV`, while this integral covers only [0, 0.1 eV]. Even a 100% error in the term would move `frac_heating` by 2e-5 relative, still far under the 2% tolerance on the `frac_sum` warning.

### Why not more nodes, and why not a higher-order rule

The error is **not monotonic** in the node count — 17 measured worse than 5, and 129 worse than 65. `N_e(E)` steps discontinuously wherever `2E + I` crosses a solution grid point (the second eq. 6 integral's start index drops a node), and its excitation term is only piecewise linear in `E` where `get_y()` interpolates across a node. A step discontinuity caps any rule at first order and a kink caps it at second, so Simpson would not reach its O(h^4) and would gain nothing measurable over trapezoid here — while adding a weight pattern and an even-interval constraint to maintain.

Trapezoid was never chosen for its order in the first place: it is there to include the half node at `SF_EMIN` that the old interior-node sum dropped, which is a correctness fix rather than an accuracy one. That is retained.

Nine nodes means eight `N_e()` calls — fewer than the nine the code made before these integrals were touched, with the better rule.

# 2. `frac_sum` warning tolerance: 2% -> 0.2%

`frac_sum` is the only check that the Spencer-Fano solution conserves energy, and at a 2% tolerance it was not doing that job.

Measured on `nebular_1d_3dgrid` by logging every `frac_sum`:

```
min    1.000248        worst |frac_sum - 1| = 1.238%
median 1.001047
max    1.012380

  2%   (before)   ->  0 / 10 warn
  1%               ->  3 / 10 warn
  0.5%             ->  3 / 10 warn
  0.2% (this PR)   ->  3 / 10 warn   (30%)
  0.1%             ->  5 / 10 warn   (50%)
```

The worst solution missed unity by 1.24% and the warning still never fired. At 0.2% it catches three of ten.

That is signal, not a noise floor: 1%, 0.5% and 0.2% all select the *same three* solves, so the threshold sits in a gap in the distribution rather than cutting into a cluster. Only below 0.1% does it start picking up the merely slightly off.

Worth flagging for whoever meets the new warnings: **every value measured was above one**, by between 0.02% and 1.2%. The imbalance is one-sided, consistent with the error cancellation that the #498 eq. 6 fixes removed — the deficit those errors were offsetting is now visible, which is the point of having the check.

Caveat: n = 10, one timestep at reduced packet count. Indicative of the rate, not a precise figure for a production run.

# Testing

`make OPTIMIZE=OFF` clean under `-Werror`; `./unittests` 79/79; pre-commit clean on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
