### PR TITLE
Push the checksum update with the GH_TOKEN organisation secret

### DIFF
--- a/.github/workflows/updatechecksums.yml
+++ b/.github/workflows/updatechecksums.yml
@@ -12,10 +12,10 @@ jobs:
         steps:
             - name: Check checksum update token
               env:
-                  CHECKSUM_UPDATE_TOKEN: ${{ secrets.CHECKSUM_UPDATE_TOKEN }}
+                  CHECKSUM_PUSH_TOKEN: ${{ secrets.GH_TOKEN }}
               run: |
-                  if [ -z "$CHECKSUM_UPDATE_TOKEN" ]; then
-                      echo "::error::Configure the CHECKSUM_UPDATE_TOKEN repository secret with Contents read/write access."
+                  if [ -z "$CHECKSUM_PUSH_TOKEN" ]; then
+                      echo "::error::The GH_TOKEN organisation secret is not available to this repository. It needs Contents read/write access."
                       exit 1
                   fi
 
@@ -23,7 +23,10 @@ jobs:
               with:
                   # A push authenticated with github.token does not trigger workflows.
                   # Use a separate token so the checksum commit gets normal push checks.
-                  token: ${{ secrets.CHECKSUM_UPDATE_TOKEN }}
+                  # NB: this is the GH_TOKEN *organisation secret*, which is not the same thing as the GH_TOKEN
+                  # environment variable that the gh CLI reads in the steps below. Those deliberately keep the
+                  # job's own github.token, which is all the read-only API calls there need.
+                  token: ${{ secrets.GH_TOKEN }}
 
             - name: Find latest CI checksums artifact for this branch
               id: findartifact


### PR DESCRIPTION
The `CHECKSUM_UPDATE_TOKEN` repository secret no longer authenticates, so the Update checksums workflow cannot run at all.

## Evidence

Two runs today, [31252908551](https://github.com/artis-mcrt/artis/actions/runs/31252908551) and [31253061861](https://github.com/artis-mcrt/artis/actions/runs/31253061861), both died in `actions/checkout`:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
The process '/usr/bin/git' failed with exit code 128
```

Three retries each, identical — expired or revoked, not transient. Nothing downstream ran, so no checksum file was touched and nothing was pushed.

The secret is still *present*, which is why the guard step passed: it only tests that the value is non-empty, never that it works.

## Change

Use the `GH_TOKEN` organisation secret for the checkout, which is already shared with this repository:

```
$ gh api repos/artis-mcrt/artis/actions/organization-secrets --jq '.secrets[].name'
GH_TOKEN
```

That removes the per-repository token as a thing that can quietly expire.

**Naming trap, called out in a code comment:** `secrets.GH_TOKEN` is not the same as the `GH_TOKEN` *environment variable* that the `gh` CLI reads in the two steps below the checkout. Those keep the job's own `github.token`, which is all their read-only API calls need — deliberately not the org secret, to avoid handing a write-capable token to steps that only read. The guard step's env var is renamed to `CHECKSUM_PUSH_TOKEN` so the two never look interchangeable.

## Not included

The guard still only checks the secret is non-empty, which is exactly why an invalid token sailed past it and surfaced three steps later as a bare git error rather than a message naming the cause. A `git ls-remote` or `gh api user` probe would fail fast and say so. Left out to keep this change to the one thing that unblocks the workflow — happy to add it here or separately.

## Sequencing

`workflow_dispatch` takes the workflow file from the ref it is dispatched against, so this has to reach a branch before that branch's checksums can be regenerated. For #500 that means merging this to `develop` first, then merging `develop` into the #500 branch, then dispatching against it. The `checksums` artifact for #500's current head is still unexpired, so no new CI run is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
