### PR TITLE
Correct the mapped nuclide masses for any change of grid geometry

### DIFF
--- a/grid.cc
+++ b/grid.cc
@@ -2315,12 +2315,14 @@ void init_grid() {
   // come after read_elem_abundances(), which checks the input files against each other while the mass fractions
   // are still the ones they gave.
   //
-  // NB: a 2D cylindrical model is mapped onto the cubic grid by the same centre-of-cell rule
-  // (map_2dmodelto3dgrid) and loses mass the same way, but is deliberately not corrected here, because doing so
-  // would change existing results. The "Total grid-mapped mass" line logged below shows the size of the
-  // discrepancy for any model.
-  if (prop_gridtype == GridType::CARTESIAN3D && get_modelgridtype() == GridType::SPHERICAL1D &&
-      globals::rank_in_node == 0) {
+  // Gated on the two geometries differing rather than on a particular pair of them, because every such mapping
+  // loses mass the same way: map_1dmodelto3dgrid() and map_2dmodelto3dgrid() both place a propagation cell by
+  // its centre. Only GRID_TYPE_OVERRIDE makes them differ; left alone, get_propgridtype() returns the model's
+  // own geometry and map_modeltogrid_direct() gives each model cell exactly its own volume, so there is no
+  // discretisation error to correct and the ratio would be one throughout. The "Total grid-mapped mass" line
+  // logged below shows the size of the discrepancy for any model.
+  const bool mapping_loses_nuclide_mass = (get_modelgridtype() != prop_gridtype);
+  if (mapping_loses_nuclide_mass && globals::rank_in_node == 0) {
     for (int nucindex = 0; nucindex < decay::get_num_nuclides(); nucindex++) {
       if (totmassnuclide[nucindex] <= 0) {
         continue;


### PR DESCRIPTION
Follow-up to #500, which flagged this in a code comment. **No results change and no checksums need regenerating** — verified by running `kilonova_2d`, see below.

## Change

The rescale that restores each nuclide's total mass after mapping was gated on the model being `SPHERICAL1D` *and* the propagation grid `CARTESIAN3D`. The error it corrects isn't specific to that pair: `map_1dmodelto3dgrid()` and `map_2dmodelto3dgrid()` both assign a propagation cell to the model cell its centre falls in, so the volume associated with a model cell is a staircase approximation of its true volume either way.

Gate it on the two geometries differing instead — the same condition that selects those two mappings over `map_modeltogrid_direct()` in the dispatch just above.

## Correcting the premise from #500

The comment I left in #500 said a 2D model "is mapped onto the cubic grid by the same centre-of-cell rule and loses mass the same way". That is only true when `GRID_TYPE_OVERRIDE` forces a Cartesian propagation grid. Left alone, `get_propgridtype()` returns the model's own geometry, so a 2D model runs on a **2D cylindrical** grid through `map_modeltogrid_direct()`, which gives each model cell exactly its own volume. There is no discretisation error there and nothing to correct. The same is true of 1D models — the `*_3dgrid` tests set the override, which is what puts them on the staircase path.

So the gap was narrower than #500 implied: it affects a 2D model run on a Cartesian grid, not 2D models generally.

## Verification

Built develop and this branch in separate worktrees and ran `kilonova_2d` under both with identical inputs:

```
Total grid-mapped mass: 4.848e-03 [Msun] (100.0% of input mass)   [both]

cells compared at timestep 0: 116
T_e   |max| 0.00000%
nne   |max| 0.00000%
Ye    |max| 0.00000%

all 19 *.out files: byte-identical
```

Identical because that configuration takes the direct mapping, so no rescale runs either before or after this change. The shipped `kilonova_2d*` tests are all in that category, which is why nothing moves.

The path this does change — a 2D model with `GRID_TYPE_OVERRIDE = CARTESIAN3D` — has no test coverage, so I could not measure it. Expect it to behave like the 1D-on-Cartesian case measured in #500 (there, a 100.4% mass discrepancy moved `T_e` by ~0.1% and `nne` by ~1%), scaled by whatever that model's own mapped-mass discrepancy turns out to be.

## Testing

`make OPTIMIZE=OFF` clean under `-Werror`; `./unittests` 79/79; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Known limitation of the newly-enabled path

A global per-nuclide rescale has no per-cell constraint, so a ratio above one applied to a mass fraction already near unity can exceed one and trip the `assert_always(abund <= 1.)` in `set_modelinitnucmassfrac()` (grid.cc:318). This is pre-existing rather than introduced here — the same assert is reached from the same rescale on the 1D-on-Cartesian path merged in #500, and that path is the more exposed of the two, since a Type Ia model can have `X_Ni56` approaching one centrally while r-process compositions spread mass over hundreds of nuclides.

This PR widens which configurations reach that hazard rather than creating it. The root cause is shared with the composition-normalisation point raised on #500 (comment 3740555837): both come from correcting nuclide masses globally without respecting per-cell bounds, and any real fix changes 1D results and needs its own checksum regeneration. Fixing it for 2D alone would re-introduce exactly the asymmetry this PR removes.

Worth stating plainly that the alternative is not "2D-on-Cartesian works today" — before this change it ran with nuclide masses that silently did not match the input model.
