### PR TITLE
Use the cell's non-thermal deposition as the non-thermal source test

### DIFF
--- a/ltepop.cc
+++ b/ltepop.cc
@@ -18,7 +18,6 @@
 #include "artisoptions.h"
 #include "atomic.h"
 #include "constants.h"
-#include "decay.h"
 #include "globals.h"
 #include "grid.h"
 #include "mpi_logging.h"
@@ -317,10 +316,14 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
   int uppermost_ion = nions - 1;
   if (!use_phi_saha) {
     for (int ion = 0; ion < nions - 1; ion++) {
+      // Truncate the ion list at the first ion the radiation field cannot reach, unless non-thermal ionisation
+      // could still populate the ions above it, i.e. unless non-thermal energy is being deposited in this cell.
+      // get_ntlepton_deposition_rate_density() sums the gamma, positron and electron deposition, which is the
+      // whole of what drives non-thermal ionisation; alpha deposition is excluded here as it is in the solver,
+      // since alphas are passed to the thermal pool as k-packets. It is populated by the time it is read:
+      // update_grid_cell() sets it before the ion balance, and this loop is skipped while lte_iteration holds.
       if (iongamma_is_zero(nonemptymgi, element, ion) &&
-          (!NT_ON || ((globals::dep_estimator_gamma[nonemptymgi] == 0.) &&
-                      (grid::get_modelinitnucmassfrac(modelgridindex, decay::get_nucindex(24, 48)) == 0.) &&
-                      (grid::get_modelinitnucmassfrac(modelgridindex, decay::get_nucindex(28, 56)) == 0.)))) {
+          (!NT_ON || nonthermal::get_ntlepton_deposition_rate_density(nonemptymgi) <= 0.)) {
         uppermost_ion = ion;
         break;
       }


### PR DESCRIPTION
Last of the findings from the review that produced #498, #499, #500 and #502. **No results change and no checksums need regenerating** — verified by running `nebular_1d_3dgrid`, see below.

## The defect

`find_uppermost_ion()` truncates an element's ion list at the first ion the radiation field cannot reach, unless non-thermal ionisation could still populate the ions above it. It decided that with:

```cpp
(!NT_ON || ((globals::dep_estimator_gamma[nonemptymgi] == 0.) &&
            (grid::get_modelinitnucmassfrac(modelgridindex, decay::get_nucindex(24, 48)) == 0.) &&
            (grid::get_modelinitnucmassfrac(modelgridindex, decay::get_nucindex(28, 56)) == 0.)))
```

The nuclide half is specific to the classic Type Ia network — Cr48 and Ni56 are what drive non-thermal deposition there. An r-process composition relies on beta and alpha emitters the test never mentions, so a kilonova cell whose gamma deposition estimator happened to be **exactly** zero was treated as having no non-thermal source and had its ion list truncated while its leptons were still ionising. Exactly zero is reachable in any cell no gamma packet crossed.

## The fix

Ask the question directly — is any non-thermal energy being deposited in this cell:

```cpp
(!NT_ON || nonthermal::get_ntlepton_deposition_rate_density(nonemptymgi) <= 0.)
```

That already sums the gamma, positron and electron deposition, so it replaces **both** halves of the old test rather than just the nuclide half, and needs no new state or helper. Alpha deposition is deliberately excluded, matching the solver: alphas go to the thermal pool as k-packets and do not drive non-thermal ionisation.

The deposition is available wherever this runs: `update_grid_cell()` calls `calculate_deposition_rate_density()` before the ion balance, and the truncation loop is skipped entirely while `globals::lte_iteration` holds, so it first runs at timestep `num_lte_timesteps` — after packets have propagated and the estimators are populated.

## Why no results change

| preset | `NT_ON` | reaches the test? |
|---|---|---|
| `classic`, `kilonova_lte` | false | no — `!NT_ON` short-circuits |
| `nltenebular`, `nltephotospheric_dynamic_ion_range` | true | yes |

All three NT-enabled tests (`nebular_1d_3dgrid`, `nebular_1d_3dgrid_limitbfest`, `nltephotospheric_dynamic_ion_range_1d_1dgrid`) share `nebular_1d_3dgrid_inputfiles` — the W7 model. Every cell there has non-zero `X_Ni56` (0.898, 0.061, 2.4e-07) and so non-zero deposition, so the old test never truncates (its `X_Ni56 == 0` is false) and the new one never truncates either (deposition is positive). Same outcome by different routes.

Verified rather than argued: built develop and this branch in separate worktrees and ran `nebular_1d_3dgrid` under both with identical inputs to timestep 5, where the truncation path is live. **All 26 output files byte-identical.**

## Coverage gap

The configuration this fixes — an r-process composition with `NT_ON` — has no test. `kilonova_lte` sets `NT_ON = false`, so no shipped test combines a kilonova model with the non-thermal solver. That is why the defect survived: the path is real but untested, and the only models reaching it in CI are the Type Ia ones the hardcoded test was written for.

## Testing

`make OPTIMIZE=OFF` clean under `-Werror`; `./unittests` 79/79; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
