### PR TITLE
Correct Lotz citation and Mewe g-bar description in non-thermal code

### DIFF
--- a/data/binding_energies_lotz1970.txt
+++ b/data/binding_energies_lotz1970.txt
@@ -1,4 +1,4 @@
-#Binding energies from Lotz tables 1 and 2 of Lotz W., 1967, JOSA, 57, 873. doi:10.1364/JOSA.57.000873. 1967JOSA...57..873L
+#Subshell binding energies of neutral free atoms from Lotz W., 1970, JOSA, 60, 206. doi:10.1364/JOSA.60.000206. 1970JOSA...60..206L
 28  108
 #Z  K  L1  L2  L3  M1  M2  M3  M4  M5  N1  N2  N3  N4  N5  N6  N7  O1  O2  O3  O4  O5  O6  O7  P1  P2  P3  P4  Q1
 1  13.600  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000  0.000

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -308,7 +308,7 @@ void read_binding_energies() {
   int nshells = 0;  // number of shell in binding energy file
   int n_z_binding = 0;  // number of elements in binding energy file
 
-  constexpr auto filename = "binding_energies_lotz_tab1and2.txt";
+  constexpr auto filename = "binding_energies_lotz1970.txt";
   auto binding_energies_file = fstream_required(filename, std::ios::in);
 
   std::string line;
@@ -861,8 +861,10 @@ auto get_xs_ionisation_vector(std::array<double, SFPTS>& xs_vec, const ShellPara
 }
 
 // distribution of secondary electron energies for primary electron with energy e_p: KF92 equation 4,
-// a fit by Opal, Peterson, & Beaty (1971) to their measurements. KF92 equation 5 uses it to factorise
-// the differential ionisation cross section into this distribution times the total cross section.
+// their analytically integrable Lorentzian adaptation of the shape Opal, Peterson, & Beaty (1971)
+// fitted to their measurements (whose published exponent is 2.1 rather than 2). KF92 equation 5 uses
+// it to factorise the differential ionisation cross section into this distribution times the total
+// cross section.
 [[nodiscard]] constexpr auto Psecondary(const double e_p, const double en_epsilon, const double I, const double J)
     -> double {
   const double e_s = en_epsilon - I;
@@ -915,13 +917,16 @@ constexpr auto xs_excitation(const int element, const int ion, const int lower, 
     // permitted E1 electric dipole transitions
     const double U = energy / epsilon_trans;
 
-    constexpr double A = 0.28;
-    constexpr double B = 0.15;
-    const double g_bar = (A * std::log(U)) + B;
+    // Mewe (1972) equation 5 fits g(U) = A + B/U + C/U^2 + D*ln(U); keep the A and D ln(U) terms,
+    // with the D = sqrt(3)/(2 pi) that Mewe recommends for all optically allowed transitions rounded
+    // to 0.28 (Shingles et al. 2020, section 2.5, where this pair is described as the formula's
+    // "first two terms")
+    constexpr double mewe_A = 0.15;
+    constexpr double mewe_D = 0.28;
+    const double g_bar = (mewe_D * std::log(U)) + mewe_A;
 
     constexpr double prefactor = 45.585750051;  // 8 * pi^2/sqrt(3)
-    // van Regemorter (1962) approximation with the g_bar above from the first two terms of the
-    // fitting formula in equation 5 of Mewe (1972); see Shingles et al. (2020), section 2.5
+    // van Regemorter (1962) approximation with the g_bar above from Mewe (1972)
     return prefactor * A_naught_squared * pow2(H_ionpot / epsilon_trans) *
            globals::alltrans.osc_strength[alltransindex] * g_bar / U;
   }
@@ -1438,14 +1443,15 @@ auto get_xs_excitation_vector(const int alltransindex, const double statweight_l
     const double trans_osc_strength = globals::alltrans.osc_strength[alltransindex];
     // permitted E1 electric dipole transitions
 
-    constexpr double A = 0.28;
-    constexpr double B = 0.15;
+    // the A and D ln(U) terms of the Mewe (1972) equation 5 fitting formula
+    // g(U) = A + B/U + C/U^2 + D*ln(U); see the comment in xs_excitation()
+    constexpr double mewe_A = 0.15;
+    constexpr double mewe_D = 0.28;
 
     constexpr double prefactor = 45.585750051;  // 8 * pi^2/sqrt(3)
     const double epsilon_trans_ev = epsilon_trans / EV;
 
-    // van Regemorter (1962) approximation with g_bar from the first two terms of the fitting
-    // formula in equation 5 of Mewe (1972); see Shingles et al. (2020), section 2.5
+    // van Regemorter (1962) approximation with the g_bar below from Mewe (1972)
     const double constantfactor =
         epsilon_trans_ev * prefactor * A_naught_squared * pow2(H_ionpot / epsilon_trans) * trans_osc_strength;
 
@@ -1454,12 +1460,12 @@ auto get_xs_excitation_vector(const int alltransindex, const double statweight_l
     std::fill_n(xs_excitation_vec.begin(), en_startindex, 0.);
 
     // U = en / epsilon
-    // g_bar = A * std::log(U) + b
+    // g_bar = mewe_D * std::log(U) + mewe_A
     // xs[j] = constantfactor * g_bar / engrid(j)
     const double logepsilon = std::log(epsilon_trans_ev);
     for (int j = en_startindex; j < SFPTS; j++) {
       const double logU = logengrid[j] - logepsilon;
-      const double g_bar = (A * logU) + B;
+      const double g_bar = (mewe_D * logU) + mewe_A;
       xs_excitation_vec[j] = constantfactor * g_bar / engrid(j);
     }
 


### PR DESCRIPTION
## Summary

Companion to [pynonthermal PR #84](https://github.com/lukeshingles/pynonthermal/pull/84), which validated every citation and equation in the Spencer-Fano solver against the original journal articles. Most findings were already addressed on `develop` (the Axelrod Eq. 3.38 log10-vs-ln correction, relativistic beta, and the KF92 equation 11/8 attributions). This PR fixes the three remaining citation inaccuracies:

- **Lotz binding-energy citation**: the subshell binding-energy table covers 108 elements, which matches Lotz (1970, JOSA, 60, 206, "Electron Binding Energies in Free Atoms"), not Lotz (1967, JOSA, 57, 873) as the data-file header claimed — that paper tabulates ionization potentials up to Z=30 only and contains no subshell binding energies. The data file is renamed `binding_energies_lotz1970.txt` with a corrected header, and the `filename` constant in `read_binding_energies()` is updated (the name appears nowhere else; `fstream_required` resolves it by searching the data folders).
- **Mewe (1972) g-bar wording**: Mewe's equation 5 is g(U) = A + B/U + C/U² + D ln U, so the implemented ḡ = 0.15 + 0.28 ln U uses the A and D ln U terms, not literally the "first two terms" (wording inherited from Shingles et al. 2020, section 2.5). Both van Regemorter sites (`xs_excitation()` and `get_xs_excitation_vector()`) now state the terms and values explicitly, and the misleading `A`/`B` constants are renamed `mewe_A`/`mewe_D` to match Mewe's own labels.
- The `Psecondary` comment now notes that Kozma & Fransson equation 4 is their analytically integrable Lorentzian adaptation of the Opal, Peterson & Beaty (1971) fit, whose published exponent is 2.1 rather than 2.

**No change to numerical results**: the g_bar values are unchanged (constants renamed only) and the data-file content is identical apart from the header comment, so stored test checksums remain valid.

## Test plan

- [x] `make OPTIMIZE=OFF` builds `sn3d` cleanly under `-Werror`
- [x] Pre-commit hooks pass (clang-format, compile hook, whitespace checks)
- [x] Repo-wide sweep confirms no remaining references to the old filename or the wrong Lotz paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)