### PR TITLE
Cache level populations and matrix indices in the NLTE bound-bound fill

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -515,6 +515,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     std::for_each(ndowntransindices.begin(), ndowntransindices.end(), [&](const auto& i) {
       const auto alltransindex = alltrans_startdown + i;
       const int lower = globals::alltrans.targetlevelindex[alltransindex];
+      assert_testmodeonly(lower >= 0 && lower < nlevels);
       const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
       const auto lower_statweight = stat_weight(lower_uniquelevelindex);
       const auto nnlevel_lower = levelpops[lower];
@@ -544,6 +545,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
     std::for_each(nuptransindices.begin(), nuptransindices.end(), [&](const auto i) {
       const auto alltransindex = alltrans_startup + i;
       const int upper = globals::alltrans.targetlevelindex[alltransindex];
+      assert_testmodeonly(upper >= 0 && upper < nlevels);
       const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
       const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_level;
       const auto upper_statweight = stat_weight(upper_uniquelevelindex);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -490,14 +490,23 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
   const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
   const auto nlte_dimension = rate_matrices.used_nlte_dimension;
 
+  // the level populations and matrix indices are constants of the fill but are needed for both
+  // endpoints of every transition, so look them up once per level instead of twice per transition
+  std::vector<double> levelpops(nlevels);
+  std::vector<int> levelindices(nlevels);
+  for (int level = 0; level < nlevels; level++) {
+    levelpops[level] = calculate_levelpop(nonemptymgi, element, ion, level);
+    levelindices[level] = get_nlte_vector_index(element, ion, level, first_ion_used);
+  }
+
   const auto levels = std::views::iota(0, nlevels);
   std::for_each(levels.begin(), levels.end(), [&](const auto level) {
-    const int level_index = get_nlte_vector_index(element, ion, level, first_ion_used);
+    const int level_index = levelindices[level];
     const auto matrix_index_level_level = (level_index * nlte_dimension) + level_index;
     const auto uniquelevelindex = ionuniquelevelindexstart + level;
     const double epsilon_level = epsilon(uniquelevelindex);
     const double statweight = stat_weight(uniquelevelindex);
-    const auto nnlevel = calculate_levelpop(nonemptymgi, element, ion, level);
+    const auto nnlevel = levelpops[level];
 
     // de-excitation
     const auto alltrans_startdown = get_alltrans_startdown(uniquelevelindex);
@@ -508,7 +517,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const int lower = globals::alltrans.targetlevelindex[alltransindex];
       const auto lower_uniquelevelindex = ionuniquelevelindexstart + lower;
       const auto lower_statweight = stat_weight(lower_uniquelevelindex);
-      const auto nnlevel_lower = calculate_levelpop(nonemptymgi, element, ion, lower);
+      const auto nnlevel_lower = levelpops[lower];
 
       const double epsilon_trans = epsilon_level - epsilon(lower_uniquelevelindex);
       const double R = rad_deexcitation_ratecoeff(epsilon_trans, globals::alltrans.einstein_A[alltransindex],
@@ -518,7 +527,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
           col_deexcitation_ratecoeff(T_e, clumpednne, epsilon_trans, statweight, lower_statweight, alltransindex) *
           s_renorm[level];
 
-      const int lower_index = get_nlte_vector_index(element, ion, lower, first_ion_used);
+      const int lower_index = levelindices[lower];
       const auto matrix_index_upper_upper = matrix_index_level_level;
       const auto matrix_index_lower_upper = (lower_index * nlte_dimension) + level_index;
 
@@ -538,7 +547,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const auto upper_uniquelevelindex = ionuniquelevelindexstart + upper;
       const double epsilon_trans = epsilon(upper_uniquelevelindex) - epsilon_level;
       const auto upper_statweight = stat_weight(upper_uniquelevelindex);
-      const auto nnlevel_upper = calculate_levelpop(nonemptymgi, element, ion, upper);
+      const auto nnlevel_upper = levelpops[upper];
 
       const double R =
           rad_excitation_ratecoeff(nonemptymgi, upper_statweight, globals::alltrans.einstein_A[alltransindex],
@@ -552,7 +561,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
       const double NTC =
           nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, alltransindex) * s_renorm[level];
 
-      const int upper_index = get_nlte_vector_index(element, ion, upper, first_ion_used);
+      const int upper_index = levelindices[upper];
       const auto matrix_index_lower_lower = matrix_index_level_level;
       const auto matrix_index_upper_lower = (upper_index * nlte_dimension) + level_index;
 


### PR DESCRIPTION
## What changed

`nltepop_matrix_add_boundbound()` called `calculate_levelpop()` and `get_nlte_vector_index()` for the far endpoint of every bound-bound transition, although both are constants of the matrix fill. They are now looked up once per level into two per-ion vectors, and the de-excitation/excitation transition loops read from those.

## Why

Profiling the NLTE population solver (sampling live ranks on the `nebular_1d_3dgrid` setup) showed these repeated lookups account for roughly 15% of solver time — the largest cost in the fill after the photoionisation rate integrals.

## Measured performance

Benchmark: `nebular_1d_3dgrid` test setup, timesteps 5–6 resumed from an identical snapshot, M4 Pro, 4 MPI ranks, `REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2`, temporary fill/solve timers (not part of this PR):

| per element-solve (mean of 66) | before | after |
|---|---|---|
| NLTE matrix fill | 8.7 ms | 6.6 ms (**−24%**) |
| NLTE matrix solve (unchanged) | 4.9 ms | 4.9 ms |
| Fe fill per iteration (dim 527) | 12.9 ms | 10.0 ms |

## No result changes

The change is bit-exact: the same functions are called with the same arguments, and the values are reused. All `*.out` files from the benchmark run are **byte-identical** to the baseline, so no checksum regeneration is needed.

## Reviewer notes

- Sampling profiles show the remaining fill time is dominated by `calculate_corrphotoioncoeff_integral()` (adaptive Gauss–Kronrod photoionisation integrals). These are deliberately untouched: restructuring the quadrature would change results at the integrator's 1e-3 relative tolerance, and the integrals depend on the current iteration's populations and T_e, so caching them across NLTE iterations would alter the converged solution.
- The matrix solve is Eigen's blocked LU; it is only slow in `REPRODUCIBLE=ON` builds because of `EIGEN_DONT_VECTORIZE`, so it was also left alone.
- 86/86 unit tests pass; clang-format and the `OPTIMIZE=OFF` pre-commit compile pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)