### PR TITLE
Cache the per-continuum edge part of the bound-free stimulated correction

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -170,6 +170,23 @@ constexpr bool align_to_avoid_false_sharing = false;
     _Pragma("omp atomic update") var += val; \
   }
 
+// relaxed atomic read/write for values that concurrent workers may lazily fill with identical
+// values (e.g. the continuum caches in the cell cache): the atomicity makes the unsynchronised
+// same-value stores well-defined without imposing any ordering
+template <typename T>
+[[nodiscard]] auto atomicload(T& var) -> T {
+  T val{};
+#pragma omp atomic read
+  val = var;
+  return val;
+}
+
+template <typename T, typename U>
+void atomicstore(T& var, const U val) {
+#pragma omp atomic write
+  var = val;
+}
+
 #elifdef STDPAR_ON
 #include <atomic>
 
@@ -178,9 +195,32 @@ constexpr void atomicadd(T& var, U&& val) {
   std::atomic_ref<T>(var).fetch_add(std::forward<U>(val), std::memory_order_relaxed);
 }
 
+// relaxed atomic read/write for values that concurrent workers may lazily fill with identical
+// values (e.g. the continuum caches in the cell cache): the atomicity makes the unsynchronised
+// same-value stores well-defined without imposing any ordering
+template <typename T>
+[[nodiscard]] constexpr auto atomicload(T& var) -> T {
+  return std::atomic_ref<T>(var).load(std::memory_order_relaxed);
+}
+
+template <typename T, typename U>
+constexpr void atomicstore(T& var, const U val) {
+  std::atomic_ref<T>(var).store(val, std::memory_order_relaxed);
+}
+
 #else
 
 #define atomicadd(var, val) var += (val);
+
+template <typename T>
+[[nodiscard]] constexpr auto atomicload(T& var) -> T {
+  return var;
+}
+
+template <typename T, typename U>
+constexpr void atomicstore(T& var, const U val) {
+  var = val;
+}
 
 #endif
 

--- a/globals.h
+++ b/globals.h
@@ -278,6 +278,11 @@ struct CellCache {
   std::span<double> alllevels_maprocessrates;  // rates for macroatom processes
   std::span<double> allmacroatomictransitions;  // cumulative macroatom transition rates for all levels
   std::span<double> allcont_modified_departureratios;
+  // modified departure ratio times exp(H * nu_edge / (KB * T_e)), so that the stimulated correction
+  // factor at any nu needs only a multiply by the per-call exp(-H * nu / (KB * T_e)). Negative means
+  // not cached for this cell (either not evaluated yet, or the product would overflow), in which case
+  // the factor is computed directly from nu - nu_edge (see calculate_chi_bf_gammacontr())
+  std::span<double> allcont_stimfactor_edgepart;
   std::span<double> allcont_nnlevel;
   std::span<std::uint8_t> allcont_keep;
   std::span<double> chi_ff_nnionpart;  // single element per cell (stored as a span to allow shared backing)
@@ -294,6 +299,7 @@ struct CellCache {
     mem_usage += (alllevels_maprocessrates.size() * sizeof(double));
     mem_usage += (allmacroatomictransitions.size() * sizeof(double));
     mem_usage += (allcont_modified_departureratios.size() * sizeof(double));
+    mem_usage += (allcont_stimfactor_edgepart.size() * sizeof(double));
     mem_usage += (allcont_nnlevel.size() * sizeof(double));
     mem_usage += (allcont_keep.size() * sizeof(allcont_keep[0]));
     mem_usage += (chi_ff_nnionpart.size() * sizeof(double));
@@ -315,6 +321,7 @@ struct CellCacheBacking {
   MPI_shared_array<double> alllevels_maprocessrates;
   MPI_shared_array<double> allmacroatomictransitions;
   MPI_shared_array<double> allcont_modified_departureratios;
+  MPI_shared_array<double> allcont_stimfactor_edgepart;
   MPI_shared_array<double> allcont_nnlevel;
   MPI_shared_array<std::uint8_t> allcont_keep;
   MPI_shared_array<double> chi_ff_nnionpart;

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -724,6 +724,18 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   const auto& allcont_nu_edge = globals::allcont.nu_edge;
 
+  const double modified_sahafact_statweightpart = SAHACONST * std::pow(T_e, -1.5);
+  // the stimulated correction factor exp(-H (nu - nu_edge) / (KB T_e)) factorises into this per-call
+  // part times a cached per-continuum part (see allcont_stimfactor_edgepart in globals.h)
+  const double exp_minus_hnu_over_kte = std::exp(-HOVERKB * nu / T_e);
+  // if the per-call factor is subnormal (flushed to zero under fast-math) or zero, multiplying it by a
+  // large finite cached edge part could wrongly zero a stimulated correction of order unity, so the
+  // factorisation is unusable and every continuum takes the direct path for this call
+  const bool stimfactor_split_usable = (exp_minus_hnu_over_kte >= std::numeric_limits<double>::min());
+  // above this exponent the cached edge part would overflow, so such continua stay uncached and keep
+  // computing the factor directly
+  constexpr double stimfactor_edgepart_maxexponent = 690.;
+
   // The phixslist is sorted by nu_edge in ascending order, so if nu < allcont[i].nu_edge then no absorption in any of
   // the remaining continua is possible. so set their kappas to zero and break
   const int allcontend = static_cast<int>(std::ranges::upper_bound(allcont_nu_edge, nu) - allcont_nu_edge.begin());
@@ -784,26 +796,54 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
         // cache with. Only the cellcache path has a stored ratio to reuse: without it there is no cache entry
         // belonging to this cell to read, because in single-slot mode get_cellcache() returns the calling
         // rank's one shared slot, which generally holds a different cell entirely.
-        double modified_departure_ratio = -1.;
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-          modified_departure_ratio = get_cellcache(nonemptymgi).allcont_modified_departureratios[i];
-        }
+        // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
+        // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
+        // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
+        // value must also be usable on its own, so the slow path below never infers the validity of one
+        // cached entry from the other.
+        const double stimfactor_edgepart =
+            USECELLHISTANDUPDATEPHIXSLIST ? atomicload(get_cellcache(nonemptymgi).allcont_stimfactor_edgepart[i]) : -1.;
 
-        if (modified_departure_ratio < 0) {
-          const int upper = allcont_upperlevel[i];
-          const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
-                                             ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
-                                             : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
-          const double modified_sahafact =
-              SAHACONST * stat_weight(element, ion, level) / stat_weight(element, ion + 1, upper) * std::pow(T_e, -1.5);
-          modified_departure_ratio =
-              nnupperionlevel / nnlevel * clumpednne * modified_sahafact;  // put that to phixslist
-          if (USECELLHISTANDUPDATEPHIXSLIST) {
-            get_cellcache(nonemptymgi).allcont_modified_departureratios[i] = modified_departure_ratio;
+        double stimfactor{};
+        if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
+          stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
+        } else {
+          // the edge part is not cached, so compute the stimulated correction factor directly from
+          // nu - nu_edge
+          double modified_departure_ratio = -1.;
+          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+            modified_departure_ratio = atomicload(get_cellcache(nonemptymgi).allcont_modified_departureratios[i]);
+          }
+          if (modified_departure_ratio < 0) {
+            const int upper = allcont_upperlevel[i];
+            const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
+                                               ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
+                                               : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
+            const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
+                                             stat_weight(element, ion + 1, upper);
+            modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
+            if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+              atomicstore(get_cellcache(nonemptymgi).allcont_modified_departureratios[i], modified_departure_ratio);
+            }
+          }
+
+          stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
+
+          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+            // cache the edge part for subsequent evaluations of this continuum in this cell.
+            // The complete cached product must be finite: for a large enough departure ratio the product
+            // can overflow even when the edge exponential alone does not, and recombining an infinity with
+            // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
+            // product is not representable are simply never cached and keep taking this direct path.
+            const double edge_exponent = HOVERKB * nu_edge / T_e;
+            if (edge_exponent < stimfactor_edgepart_maxexponent) {
+              const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
+              if (std::isfinite(edgepart)) {
+                atomicstore(get_cellcache(nonemptymgi).allcont_stimfactor_edgepart[i], edgepart);
+              }
+            }
           }
         }
-
-        const double stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
         // photoionisation minus stimulated recombination
         const double corrfactor = std::max(0., 1 - stimfactor);
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -106,6 +106,7 @@ void setup_cellcache() {
   backing.alllevels_maprocessrates.allocate(static_cast<ptrdiff_t>(maprocess_percell * nslots));
   backing.allmacroatomictransitions.allocate(static_cast<ptrdiff_t>(chtransblocksize * nslots));
   backing.allcont_modified_departureratios.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
+  backing.allcont_stimfactor_edgepart.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_nnlevel.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_keep.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.chi_ff_nnionpart.allocate(static_cast<ptrdiff_t>(nslots));
@@ -128,6 +129,7 @@ void setup_cellcache() {
         backing.allmacroatomictransitions.subspan(s * chtransblocksize, chtransblocksize);
     cacheslot.allcont_modified_departureratios =
         backing.allcont_modified_departureratios.subspan(s * nbfcontinua, nbfcontinua);
+    cacheslot.allcont_stimfactor_edgepart = backing.allcont_stimfactor_edgepart.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_nnlevel = backing.allcont_nnlevel.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_keep = backing.allcont_keep.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.chi_ff_nnionpart = backing.chi_ff_nnionpart.subspan(s, 1);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -423,6 +423,7 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
   std::ranges::fill(cacheslot.allphixstargets_corrphotoioncoeff, -99.);
 
   std::ranges::fill(cacheslot.allcont_modified_departureratios, -1.);
+  std::ranges::fill(cacheslot.allcont_stimfactor_edgepart, -1.);
 
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   for (int i = 0; i < globals::nbfcontinua; i++) {


### PR DESCRIPTION
## What changed

`calculate_chi_bf_gammacontr()` evaluated `exp(-H (nu - nu_edge) / (KB T_e))` for **every continuum in the frequency window on every opacity evaluation** — sampling profiles of an NLTE nebular run showed this single line to be the dominant libm cost of r-packet propagation (≈40% of `do_rpkt` inclusive samples).

The factor separates as `exp(-H nu / (KB T_e)) × exp(+H nu_edge / (KB T_e))`:

- the first part depends only on the packet frequency and is now computed **once per call**;
- the second is a per-continuum constant while the cell cache is valid, so it is cached (pre-multiplied by the already-cached modified departure ratio) in a new cellcache array `allcont_stimfactor_edgepart`, filled in the same lazy cache-miss branch as the departure ratio and reset with it on cell change.

Continua whose edge exponential would overflow (`H nu_edge / (KB T_e) > 690`) store a sentinel and keep computing the factor directly, so the scheme is safe for any edge/temperature combination. The statweight-independent part of the modified Saha factor (including the `pow(T_e, -1.5)`) is also hoisted out of the continuum loop. The non-cellcache template instantiation is unchanged in cost.

## Measured performance

Both models resumed/started with identical fixed seeds, M4 Pro, 4 MPI ranks, default build flags (fast-math on), measured with the final revision of this branch.

**140-shell W7 nebular model (150–410 d, `artisoptions_nltenebular.h` preset, `MPKTS = 1e7`, timesteps 0–14):**

| update_packets (summed over ranks) | main | this PR |
|---|---|---|
| NLTE timesteps 8–14 | 1930 s | 1360 s (**−30%**) |
| LTE timesteps 0–7 | 351 s | 290 s (−17%) |
| **total wall time** | **2263 s** | **2093 s (−7.5%)** |

The gain grows as the radiation field and ionisation state become realistic: −17% at the first NLTE timestep rising to **−34…35% at timesteps 13–14** (binned radiation field, converged ionisation). The remaining wall-time difference is dominated by the packet-count-independent NLTE/Spencer-Fano grid updates, so production runs with more packets per cell sit closer to the propagation numbers.

**`nebular_1d_3dgrid` CI test setup (`MPKTS = 1e6`, timesteps 5–6):** update_packets drops from 10.1 s to ~8.6 s (**−15%**), with the bf-loop exp calls disappearing from the profile entirely (1391 → 0 attributed samples).

For contrast, an early-photospheric classic-mode model (t ≈ 2 d, grey/thick-dominated, line and electron-scattering opacity) shows only ~1%: this is specifically an optically-thin/nebular-regime win.

## Result changes

`exp(a) * exp(b)` rounds differently from `exp(a+b)`, so the stimulated correction (and hence packet trajectories) can shift at roundoff level. In the benchmark, `light_curve.out` and `deposition.out` were identical to printed precision. REPRODUCIBLE-mode CI checksums may still shift at the ulp level — if the checksum jobs fail, the checksums need regenerating via the "Update checksums" workflow.

## Reviewer notes

- `do_kpkt` was profiled in the same session: ~12% of propagation samples, not exp-bound (cooling contributions are already lazily cached per cell) — no change proposed there.
- 86/86 unit tests pass; clang-format and the `OPTIMIZE=OFF` pre-commit compile pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
