### PR TITLE
Fill the cumulative bf opacity list only when a continuum event needs it

### DIFF
--- a/rpkt.cc
+++ b/rpkt.cc
@@ -407,12 +407,15 @@ void electron_scatter_rpkt(Packet& pkt) {
   set_pkt_restframe_from_cmf(pkt);
 }
 
+template <bool USECELLHISTANDUPDATEPHIXSLIST, bool FILLCHIBFSUM = false, bool FILLESTIMCONTRIBS = true>
+auto calculate_chi_bf_gammacontr(int nonemptymgi, double nu, Phixslist& phixslist) -> double;
+
 // Handle a continuum interaction of an r-packet by sampling which continuum process occurs, in
 // proportion to its share of the total continuum opacity: electron scattering (coherent in the comoving
 // frame; see electron_scatter_rpkt()), free-free absorption (packet becomes a k-packet), or bound-free absorption
 // (packet activates a macro-atom in the upper ion with probability nu_edge/nu, the ionisation energy fraction, and
 // otherwise becomes a k-packet carrying the freed electron's kinetic energy).
-void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
+void rpkt_event_continuum(Packet& pkt, ContinuumOpacity& chi_rpkt_cont) {
   const double nu = pkt.nu_cmf;
 
   const double dopplerfactor = calculate_doppler_nucmf_on_nurf(pkt.pos, pkt.dir, pkt.prop_time);
@@ -449,12 +452,27 @@ void rpkt_event_continuum(Packet& pkt, const ContinuumOpacity& chi_rpkt_cont) {
   } else if (chi_rnd < chi_escatter + chi_ff + chi_bf) {
     // bf: transform to k-pkt or activate macroatom corresponding to probabilities
 
-    const auto& phixslist = chi_rpkt_cont.phixslist;
+    auto& phixslist = chi_rpkt_cont.phixslist;
 
     pkt.absorptiontype = ABSTYPE_BOUNDFREE;
 
     const double chi_bf_inrest = chi_rpkt_cont.chi_boundfree;
-    assert_testmodeonly(phixslist.chi_bf_sum[phixslist.allcontend - 1] == chi_bf_inrest);
+
+    // the opacity evaluations skip filling the cumulative bound-free opacity list (it is only consumed
+    // here, and continuum events are far rarer than evaluations), so fill it now. Evaluating at the
+    // frequency of the last opacity calculation (not the packet's current frequency, which may have
+    // drifted within the recalculation tolerance) reproduces the values that chi_boundfree was
+    // accumulated from. The estimator contributions (gamma_contr and groundcont_gamma_contr) must be
+    // left untouched: they still hold exactly what the original evaluation stored, and rewriting them
+    // here could change them in the last bit (via cellcache entries that the original evaluation
+    // itself populated), which would leak into the estimators if the cached opacity is reused.
+    [[maybe_unused]] const double chi_bf_refilled =
+        calculate_chi_bf_gammacontr<true, true, false>(chi_rpkt_cont.nonemptymgi, chi_rpkt_cont.nu, phixslist);
+    // the refill normally reproduces chi_boundfree bitwise, but the original evaluation may itself have
+    // populated lazy cellcache entries (departure ratios and stimfactor edge parts) whose cached-factorised
+    // form can differ in the last bit from the direct expression that the evaluation used, so allow a
+    // roundoff-level difference here
+    assert_testmodeonly(fabs((chi_bf_refilled / chi_bf_inrest) - 1.) < 1e-10);
 
     // Determine in which continuum the bf-absorption occurs
     const double chi_bf_rand = rng_uniform(get_rngstate(pkt)) * chi_bf_inrest;
@@ -708,13 +726,18 @@ auto calculate_chi_ffheating(const int nonemptymgi, const double nu, const bool 
 
 // sum the bound-free opacity at frequency nu over all photoionisation continua (using the
 // binary-searched frequency window of contributing edges). When USECELLHISTANDUPDATEPHIXSLIST is
-// true, also record each continuum's contribution in the phixslist and cache the running sum for reuse within the cell.
-template <bool USECELLHISTANDUPDATEPHIXSLIST>
+// true, also record each continuum's estimator contribution in the phixslist (FILLESTIMCONTRIBS).
+// The cumulative opacity list (phixslist.chi_bf_sum) is only consumed when a bound-free absorption
+// event is sampled, which is far rarer than opacity evaluations, so it is only filled when
+// FILLCHIBFSUM is set: the propagation hot path skips those stores and rpkt_event_continuum()
+// refills the list on demand at the same frequency as the last evaluation (with FILLESTIMCONTRIBS
+// off, so that the estimator contributions keep the values of the original evaluation).
+template <bool USECELLHISTANDUPDATEPHIXSLIST, bool FILLCHIBFSUM, bool FILLESTIMCONTRIBS>
 auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixslist& phixslist) -> double {
   double chi_bf_sum = 0.;
   if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
     assert_testmodeonly(std::ssize(phixslist.chi_bf_sum) == globals::nbfcontinua);
-    if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
+    if constexpr ((USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) && FILLESTIMCONTRIBS) {
       std::ranges::fill(phixslist.groundcont_gamma_contr, 0.);
     }
   }
@@ -849,7 +872,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
 
         sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
 
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST && FILLESTIMCONTRIBS) {
           if ((USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) && level == 0 && allcont_phixstargetindex[i] == 0) {
             phixslist.groundcont_gamma_contr[allcont_index_in_groundphixslist[i]] = sigma_contr;
           }
@@ -859,8 +882,10 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
       }
     }
     if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-      phixslist.chi_bf_sum[i] = chi_bf_sum;
-      if constexpr (DETAILED_BF_ESTIMATORS_ON) {
+      if constexpr (FILLCHIBFSUM) {
+        phixslist.chi_bf_sum[i] = chi_bf_sum;
+      }
+      if constexpr (DETAILED_BF_ESTIMATORS_ON && FILLESTIMCONTRIBS) {
         if (allcont_bfestimindex[i] >= 0) {
           phixslist.gamma_contr[allcont_bfestimindex[i]] = sigma_contr;
         }


### PR DESCRIPTION
Skip filling the cumulative bound-free opacity list in the propagation hot path, refilling it on demand only when a bound-free absorption event actually needs it. **~10% faster update_packets** at nebular NLTE epochs with **bit-identical outputs** (verified down to the full binary packet state) and **unchanged CI checksums**.

(The companion change that also removes the per-continuum division — another ~12% — is split into a follow-up PR because it perturbs float cross-sections in the last bit on some platforms and needs a checksum regeneration; this PR is exactly result-neutral.)

## Motivation (W7 nebular profile at ts14, per rank)

Counter instrumentation showed the shape of the problem:

- 1.28M propagation steps trigger **1.22M full bf opacity evaluations** (the 1e-4 nu-reuse guard almost never hits because per-step redshift exceeds it), each covering an average window of **13,300 continua** → **16.2 billion loop iterations per rank per timestep**, ~70% of update_packets CPU.
- The `chi_bf_sum` cumulative list that every iteration stores is consumed only when a bf absorption is actually sampled: **1,621 times per rank-timestep (0.13% of evaluations)**.

## Change

The hot path computes the scalar `chi_boundfree` and the estimator contributions only (new `FILLCHIBFSUM` template flag); `rpkt_event_continuum()` refills the list on demand at the frequency of the last evaluation, which reproduces the values that `chi_boundfree` was accumulated from. The refill runs with `FILLESTIMCONTRIBS` off so the estimator contributions (`gamma_contr`, `groundcont_gamma_contr`) keep exactly the values the original evaluation stored — rewriting them could change them in the last bit via cellcache entries that the original evaluation itself populated.

## Measurements (M4 Pro, 4 MPI ranks, default fast-math build)

**W7 nebular, nltenebular preset, MPKTS=1e7, resumed ts14–16** (rank-0 update_packets):

| | ts14 | ts15 | ts16 | total |
|---|---|---|---|---|
| main | 73.6 s | 80.9 s | 73.0 s | 227.5 s |
| this PR | 67.1 s | 68.7 s | 69.5 s | **205.3 s (−10%)** |

Light curves, spectra, deposition, and the full `packets_*.tmp` state after three timesteps are **bit-identical to main**.

**sim2010 classic-mode photospheric model, quasi-NLTE ts1–4, MPKTS=1e6, fixed seed:** performance parity (rank-summed update_packets within 0.3% across repeat runs) and bit-identical outputs — expected, since the grey/thick photospheric regime barely exercises the bf window loop.

## Verification

- CI configuration (`REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2`): the nebular_1d_3dgrid and nltephotospheric_dynamic_ion_range tests (job0 + job1 resume + exspec) run locally for main and this branch — **all output files md5-identical**, and a commit-1-only probe branch passed the full CI matrix with unchanged checksums.
- 86/86 unit tests pass; classic preset compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
