### PR TITLE
Avoid a division per continuum in the bf opacity hot loop

### DIFF
--- a/atomic.h
+++ b/atomic.h
@@ -198,13 +198,40 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
   return get_phixs_table(get_uniquelevelindex(element, ion, level));
 }
 
+// Interpolate the photoionisation cross-section from the table at fractional table position ireal
+// (= ((nu / nu_edge) - 1) / NPHIXSNUINCREMENT), extrapolating above the table with the Kramers
+// (1923) nu^-3 scaling anchored to the highest tabulated point so that the cross-section stays
+// continuous across the end of the table.
+[[gnu::pure]] [[nodiscard]] inline auto photoionisation_crosssection_attableposition(std::span<const float> photoion_xs,
+                                                                                     const double nu_edge,
+                                                                                     const double nu,
+                                                                                     const double ireal) -> float {
+  float sigma_bf = 0.;
+  // floor() so that nu < nu_edge always gives i < 0 (zero cross-section below the threshold);
+  // truncation toward zero would map ireal in (-1, 0) to the first table point instead
+  const int i = static_cast<int>(std::floor(ireal));
+
+  if (i < 0) {
+    sigma_bf = 0.;
+  } else if (i < globals::NPHIXSPOINTS - 1) {
+    const double sigma_bf_a = photoion_xs[i];
+    const double sigma_bf_b = photoion_xs[i + 1];
+    const double factor_b = ireal - i;
+    sigma_bf = static_cast<float>(((1. - factor_b) * sigma_bf_a) + (factor_b * sigma_bf_b));
+  } else {
+    const double nu_max_phixs = nu_edge * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
+    sigma_bf = static_cast<float>(photoion_xs[globals::NPHIXSPOINTS - 1] * pow3(nu_max_phixs / nu));
+  }
+
+  return sigma_bf;
+}
+
 // Calculate the photoionisation cross-section at frequency nu out of the atomic data.
 [[gnu::pure]] [[nodiscard]] inline auto photoionisation_crosssection_fromtable(std::span<const float> photoion_xs,
                                                                                const double nu_edge, const double nu)
     -> float {
-  float sigma_bf = 0.;
-
   if constexpr (PHIXS_CLASSIC_NO_INTERPOLATION) {
+    float sigma_bf = 0.;
     // classic mode: no interpolation
     if (nu < nu_edge) {
       // below the threshold the cross section is zero (and the table index below would be negative)
@@ -229,26 +256,23 @@ DEVICE_FUNC inline auto get_nphixstargets(const int element, const int ion, cons
   }
 
   const double ireal = ((nu / nu_edge) - 1.0) / globals::NPHIXSNUINCREMENT;
-  // floor() so that nu < nu_edge always gives i < 0 (zero cross-section below the threshold);
-  // truncation toward zero would map ireal in (-1, 0) to the first table point instead
-  const int i = static_cast<int>(std::floor(ireal));
+  return photoionisation_crosssection_attableposition(photoion_xs, nu_edge, nu, ireal);
+}
 
-  if (i < 0) {
-    sigma_bf = 0.;
-  } else if (i < globals::NPHIXSPOINTS - 1) {
-    const double sigma_bf_a = photoion_xs[i];
-    const double sigma_bf_b = photoion_xs[i + 1];
-    const double factor_b = ireal - i;
-    sigma_bf = static_cast<float>(((1. - factor_b) * sigma_bf_a) + (factor_b * sigma_bf_b));
-  } else {
-    // above the top of the table, extrapolate with the Kramers (1923) nu^-3 scaling. It is anchored to the
-    // highest tabulated point rather than to the threshold value so that the cross-section stays continuous
-    // across the end of the table.
-    const double nu_max_phixs = nu_edge * last_phixs_nuovernuedge;  // nu of the uppermost point in the phixs table
-    sigma_bf = static_cast<float>(photoion_xs[globals::NPHIXSPOINTS - 1] * pow3(nu_max_phixs / nu));
+// as photoionisation_crosssection_fromtable(), but with the table position computed from a
+// precomputed reciprocal (1 / (nu_edge * NPHIXSNUINCREMENT)) so that the propagation hot loop
+// avoids a floating-point division per continuum. The table position can differ from the
+// division-based expression in the last bit.
+[[gnu::pure]] [[nodiscard]] inline auto photoionisation_crosssection_fromtable_recip(std::span<const float> photoion_xs,
+                                                                                     const double nu_edge,
+                                                                                     const double recip_nu_edge_incr,
+                                                                                     const double nu) -> float {
+  if constexpr (PHIXS_CLASSIC_NO_INTERPOLATION) {
+    return photoionisation_crosssection_fromtable(photoion_xs, nu_edge, nu);
   }
 
-  return sigma_bf;
+  const double ireal = (nu - nu_edge) * recip_nu_edge_incr;
+  return photoionisation_crosssection_attableposition(photoion_xs, nu_edge, nu, ireal);
 }
 
 // inverse of get_uniquelevelindex(). get the element/ion/level from a unique level index

--- a/globals.h
+++ b/globals.h
@@ -245,6 +245,8 @@ inline MPI_shared_array<const double> bfestim_nu_edge{};
 
 struct AllCont {
   MPI_shared_array<const double> nu_edge;
+  // 1 / (nu_edge * NPHIXSNUINCREMENT): turns the phixs table index calculation into a multiply
+  MPI_shared_array<const double> recip_nu_edge_incr;
   MPI_shared_array<const int> element;
   MPI_shared_array<const int> ion;
   MPI_shared_array<const int> level;

--- a/input.cc
+++ b/input.cc
@@ -928,8 +928,15 @@ void setup_phixs_list() {
       std::ranges::copy(std::views::transform(allcont, &TempPhotoionTransitionInput::index_in_groundphixslist),
                         allcont_index_in_groundphixslist.begin());
     }
+    auto allcont_recip_nu_edge_incr = MPI_shared_array<double>(nbfcontinua);
+    if (globals::rank_in_node == 0) {
+      for (int i = 0; i < nbfcontinua; i++) {
+        allcont_recip_nu_edge_incr[i] = 1. / (allcont_nu_edge[i] * globals::NPHIXSNUINCREMENT);
+      }
+    }
     MPI_Barrier_node();
     globals::allcont.nu_edge = std::move(allcont_nu_edge);
+    globals::allcont.recip_nu_edge_incr = std::move(allcont_recip_nu_edge_incr);
     globals::allcont.element = std::move(allcont_element);
     globals::allcont.ion = std::move(allcont_ion);
     globals::allcont.level = std::move(allcont_level);

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -797,8 +797,8 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
 
       if (USECELLHISTANDUPDATEPHIXSLIST || nnlevel > 0) {
         const double nu_edge = allcont_nu_edge[i];
-        const double sigma_bf =
-            photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
+        const double sigma_bf = photoionisation_crosssection_fromtable_recip(
+            get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, globals::allcont.recip_nu_edge_incr[i], nu);
 
         // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
         // cache with. Only the cellcache path has a stored ratio to reuse: without it there is no cache entry

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_final.txt
@@ -17,12 +17,12 @@ f2d19fae7c33ca36abb873b31597c9cd  packets00_0001.out
 5429db075a064aa9b6bf9986df4681c4  packets00_0003.out
 e5f92402aa33200d9ad126d23f594846  spec.out
 cc34b452ecfeee0499dfb18f1f884818  timesteps.out
-a3a7403950cd0316649ee67936449c5f  job1/estimators_0000.out
+ee335c3ef9ebf67d012077c843dcb596  job1/estimators_0000.out
 daf3e8ba1cdbc43fcda7cbe15139ba75  job1/estimators_0001.out
 10520df567e2474d54fdbde276c8cedf  job1/estimators_0002.out
-0e8ca4dcfd3989de4d386b110b42ac30  job1/nlte_0000.out
-95a6dc8a8cee25a211e7870da90abf54  job1/nlte_0001.out
+665ee8c0f8f424b2e0d4377ffa77385f  job1/nlte_0000.out
+0249729ea0501d619ae058823a648170  job1/nlte_0001.out
 d716ed90211d7213ae72dec310e37c59  job1/nlte_0002.out
-65c938ef8bf89e77fb636c06d4e5d2d3  job1/radfield_0000.out
+b83f4c1200fe6e05ac2e8b4370ce4243  job1/radfield_0000.out
 13987e28b3140fc6cb80652352bda245  job1/radfield_0001.out
 2298e6c1bc34459dfd9d1b4f82af49b3  job1/radfield_0002.out

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/results_md5_job0.txt
@@ -16,12 +16,12 @@ e00859a426c5c386e8a27c9139445a3e  packets00_0001.out
 631a09885d587c926a893c168e171c7a  packets00_0003.out
 1c7e44f71d56b9451b3ab10f158e65f0  spec.out
 cc34b452ecfeee0499dfb18f1f884818  timesteps.out
-9a0ac0be58ef9e8459e22b48c305f51a  job0/estimators_0000.out
+33d5c1acaee1035814c191aefbb4bde9  job0/estimators_0000.out
 174e2d262333a3ed3ca5b8c4b2c2a0cb  job0/estimators_0001.out
 02b43842ee1d05bf439f0cb100b992cf  job0/estimators_0002.out
-dff98f1faf43d931b067797419a63311  job0/nlte_0000.out
+759eaf481bb6439bb01edc68a5a2ab3f  job0/nlte_0000.out
 0f30cbb3666e5bf8342e81e16be10946  job0/nlte_0001.out
 50493b7dc2724429a51ed1fb10feb000  job0/nlte_0002.out
-976d3bf585d8fa12cab94c117b40ac1f  job0/radfield_0000.out
+bdaf9a3341ad3d4469c0f3f92c60eb3b  job0/radfield_0000.out
 2c6d85b332be7bb4e52a24257897133f  job0/radfield_0001.out
 0047938bae5f1cabb3ea38a75d73a1d7  job0/radfield_0002.out


### PR DESCRIPTION
Stacked on #514 (includes its commit; only the second commit is new here).

Precompute `1 / (nu_edge * NPHIXSNUINCREMENT)` per continuum so that the phixs table position in the bound-free opacity hot loop is a subtract and multiply instead of two divisions — removing ~16 billion double-precision divisions per rank-timestep at nebular epochs. **A further ~12% off update_packets** on top of #514 (combined −18 to −21% vs main). No-op for `PHIXS_CLASSIC_NO_INTERPOLATION` presets.

## ⚠️ Results change in the last bit → needs the "Update checksums" workflow

The reciprocal-based table position can differ from the division-based expression by 1 ulp, which occasionally flips a float-rounded cross-section. On macOS/clang the W7 benchmark (48 billion evaluations over three timesteps) and the local CI-config nebular + nltephotospheric tests were all bit-identical — but on the Linux CI runners the nltephotospheric_dynamic_ion_range test deterministically shows last-bit differences in the rank-0 estimator/nlte/radfield files. The signature is instructive: packet trajectories, spectra, and light curves are unchanged (a flipped cross-section in a continuum contributing ≲1e-9 of the total opacity rounds to the same summed chi), but the per-continuum detailed bf estimator picks up the flip at print precision. Physics is unaffected beyond roundoff; the stored checksums for affected tests must be regenerated after CI runs.

## Measurements (M4 Pro, 4 MPI ranks, default fast-math build; W7 nebular, MPKTS=1e7, resumed ts14–16, rank-0 update_packets)

| | ts14 | ts15 | ts16 | total |
|---|---|---|---|---|
| main | 73.6 s | 80.9 s | 73.0 s | 227.5 s |
| #514 | 67.1 s | 68.7 s | 69.5 s | 205.3 s (−10%) |
| #514 + this PR | 59.2 s | 61.4 s | 60.2 s | **180.8 s (−21%)** |

On this machine all outputs including the full binary packet state were bit-identical to main; see above for the Linux caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
