### PR TITLE
Tidy the bound-free opacity loop's per-continuum data

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -380,8 +380,13 @@ inline void titer_average(double& value, double& saved) {
 #endif
 }
 
+// Testmode-only bounds check rather than assert_always: this is called several times per iteration of
+// hot loops (the bound-free opacity sum, the macro-atom random walk, the k-packet cooling search), and an
+// always-on assert compiles to a branch calling an out-of-line reporting function, whose memory clobber
+// stops the compiler from hoisting the lookup out of those loops. It matches how the other index
+// preconditions in the atomic data accessors are checked (see testmodeassert_valid_level and friends).
 inline auto get_cellcache(const int nonemptymgi) -> globals::CellCache& {
-  assert_always(nonemptymgi >= 0);
+  assert_testmodeonly(nonemptymgi >= 0);
   const int cacheslotid = cellcache_singleslot ? globals::rank_in_node : nonemptymgi;
   return globals::cellcache[cacheslotid];
 }

--- a/globals.h
+++ b/globals.h
@@ -11,6 +11,7 @@
 #endif
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <span>
 #include <vector>
 
@@ -286,10 +287,14 @@ struct CellCache {
   // not cached for this cell (either not evaluated yet, or the product would overflow), in which case
   // the factor is computed directly from nu - nu_edge (see calculate_chi_bf_gammacontr())
   std::span<double> allcont_stimfactor_edgepart;
-  // level population of each bound-free continuum's lower level, forced to zero for continua that this cell
-  // does not contain the species for (see keep_this_cont), so that zero is the single "contributes nothing"
-  // test in calculate_chi_bf_gammacontr(). The unfiltered populations remain in alllevels_pops.
+  // level population of each bound-free continuum's lower level
   std::span<double> allcont_nnlevel;
+  // whether each bound-free continuum contributes to this cell's opacity at all: a populated lower level
+  // of a species the cell contains (see keep_this_cont). This duplicates "allcont_nnlevel[i] > 0", but is
+  // kept as a separate byte per continuum because it is what calculate_chi_bf_gammacontr() scans over the
+  // whole window every evaluation, and reading 1 byte per skipped continuum instead of 8 measures ~1%
+  // faster on a full-size model (21936 continua).
+  std::span<std::uint8_t> allcont_keep;
   std::span<double> chi_ff_nnionpart;  // single element per cell (stored as a span to allow shared backing)
   std::span<double> allphixstargets_corrphotoioncoeff;
   // The lazy mutex-guarded macroatom/cooling rate calculation is only used when cellcache_singleslot is
@@ -306,6 +311,7 @@ struct CellCache {
     mem_usage += (allcont_modified_departureratios.size() * sizeof(double));
     mem_usage += (allcont_stimfactor_edgepart.size() * sizeof(double));
     mem_usage += (allcont_nnlevel.size() * sizeof(double));
+    mem_usage += (allcont_keep.size() * sizeof(allcont_keep[0]));
     mem_usage += (chi_ff_nnionpart.size() * sizeof(double));
     mem_usage += (allphixstargets_corrphotoioncoeff.size() * sizeof(double));
     mem_usage += (cooling_contrib_locks.size() * sizeof(PaddedMutex));
@@ -327,6 +333,7 @@ struct CellCacheBacking {
   MPI_shared_array<double> allcont_modified_departureratios;
   MPI_shared_array<double> allcont_stimfactor_edgepart;
   MPI_shared_array<double> allcont_nnlevel;
+  MPI_shared_array<std::uint8_t> allcont_keep;
   MPI_shared_array<double> chi_ff_nnionpart;
   MPI_shared_array<double> allphixstargets_corrphotoioncoeff;
 };

--- a/globals.h
+++ b/globals.h
@@ -284,8 +284,10 @@ struct CellCache {
   // not cached for this cell (either not evaluated yet, or the product would overflow), in which case
   // the factor is computed directly from nu - nu_edge (see calculate_chi_bf_gammacontr())
   std::span<double> allcont_stimfactor_edgepart;
-  // level population of each bound-free continuum's lower level, or zero for continua that this cell does
-  // not contain the species for (see keep_this_cont) and are therefore skipped by the opacity loop
+  // level population of each bound-free continuum's lower level, forced to zero for continua that this
+  // cell does not contain the species for (see keep_this_cont). The opacity loop skips on a zero, so a
+  // zero entry means "contributes nothing", not specifically "species absent" — a genuinely unpopulated
+  // level of a species that is present stores zero too.
   std::span<double> allcont_nnlevel;
   std::span<double> chi_ff_nnionpart;  // single element per cell (stored as a span to allow shared backing)
   std::span<double> allphixstargets_corrphotoioncoeff;

--- a/globals.h
+++ b/globals.h
@@ -381,11 +381,6 @@ inline void titer_average(double& value, double& saved) {
 #endif
 }
 
-// The index precondition is checked in testmode only, as for the atomic data accessors (see
-// testmodeassert_valid_level and friends), so that this stays a plain indexing helper rather than
-// emitting a branch and an out-of-line reporting call at every use. Note that this does not on its own
-// let callers in loops keep the slot in registers: the other calls in those loop bodies clobber memory
-// anyway, so a caller that wants the lookup hoisted still has to hold the reference itself.
 inline auto get_cellcache(const int nonemptymgi) -> globals::CellCache& {
   assert_testmodeonly(nonemptymgi >= 0);
   const int cacheslotid = cellcache_singleslot ? globals::rank_in_node : nonemptymgi;

--- a/globals.h
+++ b/globals.h
@@ -252,7 +252,9 @@ struct AllCont {
   MPI_shared_array<const int> uniquelevelindex;
   MPI_shared_array<const double> probability;
   // index into the ground-level continuum estimator arrays, or -1 for continua that do not feed them
-  // (only a ground level's first photoionisation target does)
+  // (only a ground level's first photoionisation target does). This is the nearest-nu_edge slot found by
+  // search_groundphixslist(), the same value closestgroundlevelcont holds, which is not necessarily the
+  // ion's own get_groundcontindex() slot when two ions share a ground-state threshold.
   MPI_shared_array<const int> groundcontestimindex;
   MPI_shared_array<const int> bfestimindex;
 };
@@ -284,10 +286,9 @@ struct CellCache {
   // not cached for this cell (either not evaluated yet, or the product would overflow), in which case
   // the factor is computed directly from nu - nu_edge (see calculate_chi_bf_gammacontr())
   std::span<double> allcont_stimfactor_edgepart;
-  // level population of each bound-free continuum's lower level, forced to zero for continua that this
-  // cell does not contain the species for (see keep_this_cont). The opacity loop skips on a zero, so a
-  // zero entry means "contributes nothing", not specifically "species absent" — a genuinely unpopulated
-  // level of a species that is present stores zero too.
+  // level population of each bound-free continuum's lower level, forced to zero for continua that this cell
+  // does not contain the species for (see keep_this_cont), so that zero is the single "contributes nothing"
+  // test in calculate_chi_bf_gammacontr(). The unfiltered populations remain in alllevels_pops.
   std::span<double> allcont_nnlevel;
   std::span<double> chi_ff_nnionpart;  // single element per cell (stored as a span to allow shared backing)
   std::span<double> allphixstargets_corrphotoioncoeff;
@@ -380,11 +381,11 @@ inline void titer_average(double& value, double& saved) {
 #endif
 }
 
-// Testmode-only bounds check rather than assert_always: this is called several times per iteration of
-// hot loops (the bound-free opacity sum, the macro-atom random walk, the k-packet cooling search), and an
-// always-on assert compiles to a branch calling an out-of-line reporting function, whose memory clobber
-// stops the compiler from hoisting the lookup out of those loops. It matches how the other index
-// preconditions in the atomic data accessors are checked (see testmodeassert_valid_level and friends).
+// The index precondition is checked in testmode only, as for the atomic data accessors (see
+// testmodeassert_valid_level and friends), so that this stays a plain indexing helper rather than
+// emitting a branch and an out-of-line reporting call at every use. Note that this does not on its own
+// let callers in loops keep the slot in registers: the other calls in those loop bodies clobber memory
+// anyway, so a caller that wants the lookup hoisted still has to hold the reference itself.
 inline auto get_cellcache(const int nonemptymgi) -> globals::CellCache& {
   assert_testmodeonly(nonemptymgi >= 0);
   const int cacheslotid = cellcache_singleslot ? globals::rank_in_node : nonemptymgi;

--- a/globals.h
+++ b/globals.h
@@ -11,7 +11,6 @@
 #endif
 #include <cmath>
 #include <cstddef>
-#include <cstdint>
 #include <span>
 #include <vector>
 
@@ -252,7 +251,9 @@ struct AllCont {
   MPI_shared_array<const int> upperlevel;
   MPI_shared_array<const int> uniquelevelindex;
   MPI_shared_array<const double> probability;
-  MPI_shared_array<const int> index_in_groundphixslist;
+  // index into the ground-level continuum estimator arrays, or -1 for continua that do not feed them
+  // (only a ground level's first photoionisation target does)
+  MPI_shared_array<const int> groundcontestimindex;
   MPI_shared_array<const int> bfestimindex;
 };
 inline AllCont allcont{};
@@ -283,8 +284,9 @@ struct CellCache {
   // not cached for this cell (either not evaluated yet, or the product would overflow), in which case
   // the factor is computed directly from nu - nu_edge (see calculate_chi_bf_gammacontr())
   std::span<double> allcont_stimfactor_edgepart;
+  // level population of each bound-free continuum's lower level, or zero for continua that this cell does
+  // not contain the species for (see keep_this_cont) and are therefore skipped by the opacity loop
   std::span<double> allcont_nnlevel;
-  std::span<std::uint8_t> allcont_keep;
   std::span<double> chi_ff_nnionpart;  // single element per cell (stored as a span to allow shared backing)
   std::span<double> allphixstargets_corrphotoioncoeff;
   // The lazy mutex-guarded macroatom/cooling rate calculation is only used when cellcache_singleslot is
@@ -301,7 +303,6 @@ struct CellCache {
     mem_usage += (allcont_modified_departureratios.size() * sizeof(double));
     mem_usage += (allcont_stimfactor_edgepart.size() * sizeof(double));
     mem_usage += (allcont_nnlevel.size() * sizeof(double));
-    mem_usage += (allcont_keep.size() * sizeof(allcont_keep[0]));
     mem_usage += (chi_ff_nnionpart.size() * sizeof(double));
     mem_usage += (allphixstargets_corrphotoioncoeff.size() * sizeof(double));
     mem_usage += (cooling_contrib_locks.size() * sizeof(PaddedMutex));
@@ -323,7 +324,6 @@ struct CellCacheBacking {
   MPI_shared_array<double> allcont_modified_departureratios;
   MPI_shared_array<double> allcont_stimfactor_edgepart;
   MPI_shared_array<double> allcont_nnlevel;
-  MPI_shared_array<std::uint8_t> allcont_keep;
   MPI_shared_array<double> chi_ff_nnionpart;
   MPI_shared_array<double> allphixstargets_corrphotoioncoeff;
 };

--- a/input.cc
+++ b/input.cc
@@ -782,12 +782,6 @@ void setup_phixs_list() {
   printlnlog("[info] setup_phixs_list: number of bfcontinua {}", globals::nbfcontinua);
   printlnlog("[info] setup_phixs_list: number of ground-level bfcontinua {}", globals::nbfcontinua_ground);
 
-  struct TempGroundPhotoion {
-    double nu_edge;
-    int element;
-    int ion;
-  };
-
   struct TempPhotoionTransitionInput {
     double nu_edge;
     int element;
@@ -861,35 +855,29 @@ void setup_phixs_list() {
           const int nphixstargets = get_nphixstargets(uniquelevelindex);
 
           // nlevels_ionising comes from the level energies alone, so a level below the threshold can still
-          // have no photoionisation table; get_phixs_threshold() must not be called for those (their
+          // have no photoionisation table, and get_phixs_threshold() must not be called for those (their
           // phixstargetstart is still the -1 sentinel)
-          if (nphixstargets > 0) {
-            if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
-              // depends only on the level, so it is found once here rather than once per target below
-              const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
-              globals::alllevels.closestgroundlevelcont[uniquelevelindex] =
-                  search_groundphixslist(nu_edge_target0, element, ion, level);
-            }
+          if (nphixstargets == 0) {
+            continue;
+          }
+
+          if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
+            // depends only on the level, so it is found once here rather than once per target below
+            const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
+            globals::alllevels.closestgroundlevelcont[uniquelevelindex] =
+                search_groundphixslist(nu_edge_target0, element, ion, level);
           }
 
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             assert_always(allcontindex < std::ssize(allcont));
 
-            // Only a ground level's first photoionisation target feeds the ground-level continuum
-            // estimators; every other continuum gets -1, so the opacity loop needs only this one test.
-            // (bfestimindex uses the same -1-means-not-applicable sentinel, but is otherwise unrelated:
-            // it is assigned after the nu_edge sort and is dense and monotonic, which is what lets
-            // calculate_chi_bf_gammacontr() bound it with a bfestimbegin/bfestimend window. This index
-            // is sparse and indexes the separately-sorted groundcont arrays, so it supports no window.)
-            // NOTE: this is the nearest-edge slot found by search_groundphixslist(), which is what
-            // ratecoeff.cc reads back via closestgroundlevelcont. It can differ from this ion's own
-            // get_groundcontindex(element, ion) — the index update_grid.cc normalises the estimator by —
-            // when two ions share a ground-state threshold. Kept as-is here to preserve results; see the
-            // review note on reconciling the two conventions.
-            const int groundcontestimindex =
-                (level == 0 && phixstargetindex == 0 && (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS))
-                    ? globals::alllevels.closestgroundlevelcont[uniquelevelindex]
-                    : -1;
+            // See AllCont::groundcontestimindex. closestgroundlevelcont is left at its -1 initialiser when
+            // neither estimator is enabled, so no further guard on those options is needed here.
+            // TODO: the estimators are written at this nearest-edge slot but normalised in update_grid.cc
+            // at get_groundcontindex(element, ion); the two disagree if two ions share a ground threshold.
+            const int groundcontestimindex = (level == 0 && phixstargetindex == 0)
+                                                 ? globals::alllevels.closestgroundlevelcont[uniquelevelindex]
+                                                 : -1;
 
             allcont[allcontindex] = {
                 .nu_edge = get_phixs_threshold(element, ion, level, phixstargetindex) / H,

--- a/input.cc
+++ b/input.cc
@@ -797,7 +797,7 @@ void setup_phixs_list() {
     int upperlevel;
     int uniquelevelindex;
     double probability;
-    int index_in_groundphixslist;
+    int groundcontestimindex;
   };
 
   auto groundcont_nu_edge = MPI_shared_array<double>(globals::nbfcontinua_ground);
@@ -863,12 +863,19 @@ void setup_phixs_list() {
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             assert_always(allcontindex < std::ssize(allcont));
 
-            int index_in_groundphixslist = -1;
+            // Only a ground level's first photoionisation target feeds the ground-level continuum
+            // estimators, so every other continuum gets -1 and the opacity loop needs only this one test
+            // (the same convention as bfestimindex).
+            int groundcontestimindex = -1;
             if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
               const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
-              index_in_groundphixslist = search_groundphixslist(nu_edge_target0, element, ion, level);
+              const int closestgroundcont = search_groundphixslist(nu_edge_target0, element, ion, level);
 
-              globals::alllevels.closestgroundlevelcont[uniquelevelindex] = index_in_groundphixslist;
+              globals::alllevels.closestgroundlevelcont[uniquelevelindex] = closestgroundcont;
+
+              if (level == 0 && phixstargetindex == 0) {
+                groundcontestimindex = closestgroundcont;
+              }
             }
 
             allcont[allcontindex] = {
@@ -880,7 +887,7 @@ void setup_phixs_list() {
                 .upperlevel = get_phixsupperlevel(uniquelevelindex, phixstargetindex),
                 .uniquelevelindex = uniquelevelindex,
                 .probability = get_phixsprobability(uniquelevelindex, phixstargetindex),
-                .index_in_groundphixslist = index_in_groundphixslist,
+                .groundcontestimindex = groundcontestimindex,
             };
 
             allcontindex++;
@@ -911,7 +918,7 @@ void setup_phixs_list() {
     auto allcont_upperlevel = MPI_shared_array<int>(nbfcontinua);
     auto allcont_uniquelevelindex = MPI_shared_array<int>(nbfcontinua);
     auto allcont_probability = MPI_shared_array<double>(nbfcontinua);
-    auto allcont_index_in_groundphixslist = MPI_shared_array<int>(nbfcontinua);
+    auto allcont_groundcontestimindex = MPI_shared_array<int>(nbfcontinua);
     if (globals::rank_in_node == 0) {
       std::ranges::copy(std::views::transform(allcont, &TempPhotoionTransitionInput::nu_edge), allcont_nu_edge.begin());
       std::ranges::copy(std::views::transform(allcont, &TempPhotoionTransitionInput::element), allcont_element.begin());
@@ -925,8 +932,8 @@ void setup_phixs_list() {
                         allcont_uniquelevelindex.begin());
       std::ranges::copy(std::views::transform(allcont, &TempPhotoionTransitionInput::probability),
                         allcont_probability.begin());
-      std::ranges::copy(std::views::transform(allcont, &TempPhotoionTransitionInput::index_in_groundphixslist),
-                        allcont_index_in_groundphixslist.begin());
+      std::ranges::copy(std::views::transform(allcont, &TempPhotoionTransitionInput::groundcontestimindex),
+                        allcont_groundcontestimindex.begin());
     }
     MPI_Barrier_node();
     globals::allcont.nu_edge = std::move(allcont_nu_edge);
@@ -937,7 +944,7 @@ void setup_phixs_list() {
     globals::allcont.upperlevel = std::move(allcont_upperlevel);
     globals::allcont.uniquelevelindex = std::move(allcont_uniquelevelindex);
     globals::allcont.probability = std::move(allcont_probability);
-    globals::allcont.index_in_groundphixslist = std::move(allcont_index_in_groundphixslist);
+    globals::allcont.groundcontestimindex = std::move(allcont_groundcontestimindex);
 
     auto allcont_bfestimindex = MPI_shared_array<int>(nbfcontinua);
     std::vector<double> temp_bfestim_nu_edge;

--- a/input.cc
+++ b/input.cc
@@ -860,23 +860,36 @@ void setup_phixs_list() {
           const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
           const int nphixstargets = get_nphixstargets(uniquelevelindex);
 
+          // nlevels_ionising comes from the level energies alone, so a level below the threshold can still
+          // have no photoionisation table; get_phixs_threshold() must not be called for those (their
+          // phixstargetstart is still the -1 sentinel)
+          if (nphixstargets > 0) {
+            if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
+              // depends only on the level, so it is found once here rather than once per target below
+              const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
+              globals::alllevels.closestgroundlevelcont[uniquelevelindex] =
+                  search_groundphixslist(nu_edge_target0, element, ion, level);
+            }
+          }
+
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             assert_always(allcontindex < std::ssize(allcont));
 
             // Only a ground level's first photoionisation target feeds the ground-level continuum
-            // estimators, so every other continuum gets -1 and the opacity loop needs only this one test
-            // (the same convention as bfestimindex).
-            int groundcontestimindex = -1;
-            if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
-              const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
-              const int closestgroundcont = search_groundphixslist(nu_edge_target0, element, ion, level);
-
-              globals::alllevels.closestgroundlevelcont[uniquelevelindex] = closestgroundcont;
-
-              if (level == 0 && phixstargetindex == 0) {
-                groundcontestimindex = closestgroundcont;
-              }
-            }
+            // estimators; every other continuum gets -1, so the opacity loop needs only this one test.
+            // (bfestimindex uses the same -1-means-not-applicable sentinel, but is otherwise unrelated:
+            // it is assigned after the nu_edge sort and is dense and monotonic, which is what lets
+            // calculate_chi_bf_gammacontr() bound it with a bfestimbegin/bfestimend window. This index
+            // is sparse and indexes the separately-sorted groundcont arrays, so it supports no window.)
+            // NOTE: this is the nearest-edge slot found by search_groundphixslist(), which is what
+            // ratecoeff.cc reads back via closestgroundlevelcont. It can differ from this ion's own
+            // get_groundcontindex(element, ion) — the index update_grid.cc normalises the estimator by —
+            // when two ions share a ground-state threshold. Kept as-is here to preserve results; see the
+            // review note on reconciling the two conventions.
+            const int groundcontestimindex =
+                (level == 0 && phixstargetindex == 0 && (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS))
+                    ? globals::alllevels.closestgroundlevelcont[uniquelevelindex]
+                    : -1;
 
             allcont[allcontindex] = {
                 .nu_edge = get_phixs_threshold(element, ion, level, phixstargetindex) / H,

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -781,9 +781,9 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   // lazy caches are written through below: this function mutates the cell cache and must not be treated
   // as pure.
   struct CellCacheContArrays {
-    std::span<const double> nnlevel{};
-    std::span<double> stimfactor_edgepart{};
-    std::span<double> modified_departureratios{};
+    std::span<const double> nnlevel;
+    std::span<double> stimfactor_edgepart;
+    std::span<double> modified_departureratios;
   };
 
   // The cell's cache slot does not change during the loop, so resolve its arrays once instead of on every

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -729,7 +729,8 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
 
   const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_nne(nonemptymgi) * grid::get_clumpfactor(nonemptymgi);
-  // only the no-cellcache instantiation needs this: it is the one that applies keep_this_cont per continuum
+  // only the no-cellcache instantiation applies keep_this_cont per continuum; the cellcache path reads
+  // populations that were already filtered, so it never needs this
   const auto nnetot = USECELLHISTANDUPDATEPHIXSLIST ? 0.F : grid::get_nnetot(nonemptymgi);
   const auto& allcont_nu_edge = globals::allcont.nu_edge;
 
@@ -777,9 +778,8 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   const auto& allcont_groundcontestimindex = globals::allcont.groundcontestimindex;
   const auto& allcont_probability = globals::allcont.probability;
 
-  // The per-continuum cell cache arrays this loop uses. std::span is only shallowly const, so the two
-  // lazy caches are written through below: this function mutates the cell cache and must not be treated
-  // as pure.
+  // The per-continuum cell cache arrays this loop uses. Spans are only shallowly const, so the two lazy
+  // caches below are written through.
   struct CellCacheContArrays {
     std::span<const double> nnlevel;
     std::span<double> stimfactor_edgepart;
@@ -806,10 +806,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   for (int i = allcontbegin; i < allcontend; i++) {
     double sigma_contr = 0.;
 
-    // zero when the cell does not contain enough of the involved atomic species (see keep_this_cont) or the
-    // level is simply unpopulated. Either way the continuum contributes nothing, so one test covers both.
-    // Returned by value on purpose: a deduced reference return would bind into the cache in one
-    // instantiation and dangle on a temporary in the other, and both would still compile.
+    // zero means the continuum contributes nothing (see CellCache::allcont_nnlevel)
     const double nnlevel = [&] {
       if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
         return cache.nnlevel[i];

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -758,9 +758,6 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   assert_testmodeonly(allcontbegin <= allcontend);
 
   if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM) {
-    phixslist.allcontbegin = allcontbegin;
-    phixslist.allcontend = allcontend;
-
     phixslist.bfestimend =
         static_cast<int>(std::ranges::upper_bound(globals::bfestim_nu_edge, nu) - globals::bfestim_nu_edge.begin());
 
@@ -776,99 +773,113 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   const auto& allcont_bfestimindex = globals::allcont.bfestimindex;
   const auto& allcont_upperlevel = globals::allcont.upperlevel;
   const auto& allcont_uniquelevelindex = globals::allcont.uniquelevelindex;
-  const auto& allcont_index_in_groundphixslist = globals::allcont.index_in_groundphixslist;
+  const auto& allcont_groundcontestimindex = globals::allcont.groundcontestimindex;
   const auto& allcont_probability = globals::allcont.probability;
-  const auto& allcont_phixstargetindex = globals::allcont.phixstargetindex;
+
+  // The cell's cache slot does not change during the loop, so resolve it once instead of on every access.
+  // These stay empty in the no-cellcache instantiation, which reads nothing from the cache: in single-slot
+  // mode get_cellcache() returns the calling rank's one shared slot, which generally holds a different cell.
+  std::span<const double> cache_nnlevel;
+  std::span<double> cache_stimfactor_edgepart;
+  std::span<double> cache_modified_departureratios;
+  if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+    const auto& cacheslot = get_cellcache(nonemptymgi);
+    assert_testmodeonly(cacheslot.nonemptymgi == nonemptymgi);
+    cache_nnlevel = cacheslot.allcont_nnlevel;
+    cache_stimfactor_edgepart = cacheslot.allcont_stimfactor_edgepart;
+    cache_modified_departureratios = cacheslot.allcont_modified_departureratios;
+  }
 
   for (int i = allcontbegin; i < allcontend; i++) {
-    const int element = allcont_element[i];
-    const int ion = allcont_ion[i];
-    const int level = allcont_level[i];
     double sigma_contr = 0.;
 
-    // The bf process happens only if the current cell contains the involved atomic species
-    const bool should_keep_this_cont = USECELLHISTANDUPDATEPHIXSLIST
-                                           ? get_cellcache(nonemptymgi).allcont_keep[i]
-                                           : keep_this_cont(element, ion, level, nonemptymgi, nnetot);
+    // zero when the cell does not contain enough of the involved atomic species (see keep_this_cont) or the
+    // level is simply unpopulated. Either way the continuum contributes nothing, so one test covers both.
+    const double nnlevel = [&] {
+      if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+        return cache_nnlevel[i];
+      } else {
+        return keep_this_cont(allcont_element[i], allcont_ion[i], allcont_level[i], nonemptymgi, nnetot)
+                   ? calculate_levelpop(nonemptymgi, allcont_element[i], allcont_ion[i], allcont_level[i])
+                   : 0.;
+      }
+    }();
 
-    if (should_keep_this_cont) [[likely]] {
-      const double nnlevel = USECELLHISTANDUPDATEPHIXSLIST ? get_cellcache(nonemptymgi).allcont_nnlevel[i]
-                                                           : calculate_levelpop(nonemptymgi, element, ion, level);
+    if (nnlevel > 0) [[likely]] {
+      const double nu_edge = allcont_nu_edge[i];
+      const double sigma_bf =
+          photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
 
-      if (USECELLHISTANDUPDATEPHIXSLIST || nnlevel > 0) {
-        const double nu_edge = allcont_nu_edge[i];
-        const double sigma_bf =
-            photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
+      // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
+      // cache with.
+      // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
+      // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
+      // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
+      // value must also be usable on its own, so the slow path below never infers the validity of one
+      // cached entry from the other.
+      const double stimfactor_edgepart = USECELLHISTANDUPDATEPHIXSLIST ? atomicload(cache_stimfactor_edgepart[i]) : -1.;
 
-        // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
-        // cache with. Only the cellcache path has a stored ratio to reuse: without it there is no cache entry
-        // belonging to this cell to read, because in single-slot mode get_cellcache() returns the calling
-        // rank's one shared slot, which generally holds a different cell entirely.
-        // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
-        // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
-        // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
-        // value must also be usable on its own, so the slow path below never infers the validity of one
-        // cached entry from the other.
-        const double stimfactor_edgepart =
-            USECELLHISTANDUPDATEPHIXSLIST ? atomicload(get_cellcache(nonemptymgi).allcont_stimfactor_edgepart[i]) : -1.;
+      double stimfactor{};
+      if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
+        stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
+      } else {
+        // the edge part is not cached, so compute the stimulated correction factor directly from
+        // nu - nu_edge
+        const int element = allcont_element[i];
+        const int ion = allcont_ion[i];
+        const int level = allcont_level[i];
 
-        double stimfactor{};
-        if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
-          stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
-        } else {
-          // the edge part is not cached, so compute the stimulated correction factor directly from
-          // nu - nu_edge
-          double modified_departure_ratio = -1.;
-          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            modified_departure_ratio = atomicload(get_cellcache(nonemptymgi).allcont_modified_departureratios[i]);
-          }
-          if (modified_departure_ratio < 0) {
-            const int upper = allcont_upperlevel[i];
-            const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
-                                               ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
-                                               : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
-            const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
-                                             stat_weight(element, ion + 1, upper);
-            modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
-            if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-              atomicstore(get_cellcache(nonemptymgi).allcont_modified_departureratios[i], modified_departure_ratio);
-            }
-          }
-
-          stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
-
-          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            // cache the edge part for subsequent evaluations of this continuum in this cell.
-            // The complete cached product must be finite: for a large enough departure ratio the product
-            // can overflow even when the edge exponential alone does not, and recombining an infinity with
-            // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
-            // product is not representable are simply never cached and keep taking this direct path.
-            const double edge_exponent = HOVERKB * nu_edge / T_e;
-            if (edge_exponent < stimfactor_edgepart_maxexponent) {
-              const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
-              if (std::isfinite(edgepart)) {
-                atomicstore(get_cellcache(nonemptymgi).allcont_stimfactor_edgepart[i], edgepart);
-              }
-            }
-          }
+        double modified_departure_ratio = -1.;
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          modified_departure_ratio = atomicload(cache_modified_departureratios[i]);
         }
-        // photoionisation minus stimulated recombination
-        const double corrfactor = std::max(0., 1 - stimfactor);
-
-        sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
-
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM) {
-          if ((USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) && level == 0 && allcont_phixstargetindex[i] == 0) {
-            phixslist.groundcont_gamma_contr[allcont_index_in_groundphixslist[i]] = sigma_contr;
+        if (modified_departure_ratio < 0) {
+          const int upper = allcont_upperlevel[i];
+          const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
+                                             ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
+                                             : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
+          const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
+                                           stat_weight(element, ion + 1, upper);
+          modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
+          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+            atomicstore(cache_modified_departureratios[i], modified_departure_ratio);
           }
         }
 
-        chi_bf_sum += nnlevel * sigma_contr;
+        stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
 
-        if constexpr (SELECTCONTINUUM) {
-          if (chi_bf_sum > chi_bf_sum_selectionthreshold) {
-            return i;
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          // cache the edge part for subsequent evaluations of this continuum in this cell.
+          // The complete cached product must be finite: for a large enough departure ratio the product
+          // can overflow even when the edge exponential alone does not, and recombining an infinity with
+          // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
+          // product is not representable are simply never cached and keep taking this direct path.
+          const double edge_exponent = HOVERKB * nu_edge / T_e;
+          if (edge_exponent < stimfactor_edgepart_maxexponent) {
+            const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
+            if (std::isfinite(edgepart)) {
+              atomicstore(cache_stimfactor_edgepart[i], edgepart);
+            }
           }
+        }
+      }
+      // photoionisation minus stimulated recombination
+      const double corrfactor = std::max(0., 1 - stimfactor);
+
+      sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
+
+      if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM &&
+                    (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS)) {
+        if (allcont_groundcontestimindex[i] >= 0) {
+          phixslist.groundcont_gamma_contr[allcont_groundcontestimindex[i]] = sigma_contr;
+        }
+      }
+
+      chi_bf_sum += nnlevel * sigma_contr;
+
+      if constexpr (SELECTCONTINUUM) {
+        if (chi_bf_sum > chi_bf_sum_selectionthreshold) {
+          return i;
         }
       }
     }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <limits>
@@ -781,6 +782,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   // The per-continuum cell cache arrays this loop uses. Spans are only shallowly const, so the two lazy
   // caches below are written through.
   struct CellCacheContArrays {
+    std::span<const std::uint8_t> keep;
     std::span<const double> nnlevel;
     std::span<double> stimfactor_edgepart;
     std::span<double> modified_departureratios;
@@ -795,6 +797,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
       const auto& cacheslot = get_cellcache(nonemptymgi);
       assert_testmodeonly(cacheslot.nonemptymgi == nonemptymgi);
       return {
+          .keep = cacheslot.allcont_keep,
           .nnlevel = cacheslot.allcont_nnlevel,
           .stimfactor_edgepart = cacheslot.allcont_stimfactor_edgepart,
           .modified_departureratios = cacheslot.allcont_modified_departureratios,
@@ -806,101 +809,103 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   for (int i = allcontbegin; i < allcontend; i++) {
     double sigma_contr = 0.;
 
-    // zero means the continuum contributes nothing (see CellCache::allcont_nnlevel)
-    const double nnlevel = [&] {
+    // the skip test reads one byte per continuum rather than the eight of the population, which is what
+    // most of this window costs in a cell that holds few of the species (see CellCache::allcont_keep)
+    const bool keep = [&] {
       if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-        return cache.nnlevel[i];
+        return cache.keep[i] != 0;
       } else {
-        const int element = allcont_element[i];
-        const int ion = allcont_ion[i];
-        const int level = allcont_level[i];
-        return keep_this_cont(element, ion, level, nonemptymgi, nnetot)
-                   ? calculate_levelpop(nonemptymgi, element, ion, level)
-                   : 0.;
+        return keep_this_cont(allcont_element[i], allcont_ion[i], allcont_level[i], nonemptymgi, nnetot);
       }
     }();
 
-    if (nnlevel > 0) [[likely]] {
-      const double nu_edge = allcont_nu_edge[i];
-      const double sigma_bf =
-          photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
+    if (keep) [[likely]] {
+      // the cached keep flag already required a positive population, so only the uncached path retests it
+      const double nnlevel = USECELLHISTANDUPDATEPHIXSLIST ? cache.nnlevel[i]
+                                                           : calculate_levelpop(nonemptymgi, allcont_element[i],
+                                                                                allcont_ion[i], allcont_level[i]);
+      if (USECELLHISTANDUPDATEPHIXSLIST || nnlevel > 0) {
+        const double nu_edge = allcont_nu_edge[i];
+        const double sigma_bf =
+            photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
 
-      // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
-      // cache with, and is also what the no-cellcache instantiation always sees (it has no cache entry
-      // belonging to this cell to read).
-      // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
-      // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
-      // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
-      // value must also be usable on its own, so the slow path below never infers the validity of one
-      // cached entry from the other.
-      const double stimfactor_edgepart = [&] {
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-          return atomicload(cache.stimfactor_edgepart[i]);
-        }
-        return -1.;
-      }();
-
-      double stimfactor{};
-      if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
-        stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
-      } else {
-        // the edge part is not cached, so compute the stimulated correction factor directly from
-        // nu - nu_edge
-        const int element = allcont_element[i];
-        const int ion = allcont_ion[i];
-        const int level = allcont_level[i];
-
-        double modified_departure_ratio = -1.;
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-          modified_departure_ratio = atomicload(cache.modified_departureratios[i]);
-        }
-        if (modified_departure_ratio < 0) {
-          const int upper = allcont_upperlevel[i];
-          const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
-                                             ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
-                                             : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
-          const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
-                                           stat_weight(element, ion + 1, upper);
-          modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
+        // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
+        // cache with, and is also what the no-cellcache instantiation always sees (it has no cache entry
+        // belonging to this cell to read).
+        // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
+        // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
+        // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
+        // value must also be usable on its own, so the slow path below never infers the validity of one
+        // cached entry from the other.
+        const double stimfactor_edgepart = [&] {
           if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            atomicstore(cache.modified_departureratios[i], modified_departure_ratio);
+            return atomicload(cache.stimfactor_edgepart[i]);
           }
-        }
+          return -1.;
+        }();
 
-        stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
+        double stimfactor{};
+        if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
+          stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
+        } else {
+          // the edge part is not cached, so compute the stimulated correction factor directly from
+          // nu - nu_edge
+          const int element = allcont_element[i];
+          const int ion = allcont_ion[i];
+          const int level = allcont_level[i];
 
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-          // cache the edge part for subsequent evaluations of this continuum in this cell.
-          // The complete cached product must be finite: for a large enough departure ratio the product
-          // can overflow even when the edge exponential alone does not, and recombining an infinity with
-          // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
-          // product is not representable are simply never cached and keep taking this direct path.
-          const double edge_exponent = HOVERKB * nu_edge / T_e;
-          if (edge_exponent < stimfactor_edgepart_maxexponent) {
-            const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
-            if (std::isfinite(edgepart)) {
-              atomicstore(cache.stimfactor_edgepart[i], edgepart);
+          double modified_departure_ratio = -1.;
+          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+            modified_departure_ratio = atomicload(cache.modified_departureratios[i]);
+          }
+          if (modified_departure_ratio < 0) {
+            const int upper = allcont_upperlevel[i];
+            const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
+                                               ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
+                                               : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
+            const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
+                                             stat_weight(element, ion + 1, upper);
+            modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
+            if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+              atomicstore(cache.modified_departureratios[i], modified_departure_ratio);
+            }
+          }
+
+          stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
+
+          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+            // cache the edge part for subsequent evaluations of this continuum in this cell.
+            // The complete cached product must be finite: for a large enough departure ratio the product
+            // can overflow even when the edge exponential alone does not, and recombining an infinity with
+            // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
+            // product is not representable are simply never cached and keep taking this direct path.
+            const double edge_exponent = HOVERKB * nu_edge / T_e;
+            if (edge_exponent < stimfactor_edgepart_maxexponent) {
+              const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
+              if (std::isfinite(edgepart)) {
+                atomicstore(cache.stimfactor_edgepart[i], edgepart);
+              }
             }
           }
         }
-      }
-      // photoionisation minus stimulated recombination
-      const double corrfactor = std::max(0., 1 - stimfactor);
+        // photoionisation minus stimulated recombination
+        const double corrfactor = std::max(0., 1 - stimfactor);
 
-      sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
+        sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
 
-      if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM &&
-                    (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS)) {
-        if (allcont_groundcontestimindex[i] >= 0) {
-          phixslist.groundcont_gamma_contr[allcont_groundcontestimindex[i]] = sigma_contr;
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM &&
+                      (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS)) {
+          if (allcont_groundcontestimindex[i] >= 0) {
+            phixslist.groundcont_gamma_contr[allcont_groundcontestimindex[i]] = sigma_contr;
+          }
         }
-      }
 
-      chi_bf_sum += nnlevel * sigma_contr;
+        chi_bf_sum += nnlevel * sigma_contr;
 
-      if constexpr (SELECTCONTINUUM) {
-        if (chi_bf_sum > chi_bf_sum_selectionthreshold) {
-          return i;
+        if constexpr (SELECTCONTINUUM) {
+          if (chi_bf_sum > chi_bf_sum_selectionthreshold) {
+            return i;
+          }
         }
       }
     }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -729,7 +729,8 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
 
   const auto T_e = grid::Te_allcells[nonemptymgi];
   const auto clumpednne = grid::get_nne(nonemptymgi) * grid::get_clumpfactor(nonemptymgi);
-  const auto nnetot = grid::get_nnetot(nonemptymgi);
+  // only the no-cellcache instantiation needs this: it is the one that applies keep_this_cont per continuum
+  const auto nnetot = USECELLHISTANDUPDATEPHIXSLIST ? 0.F : grid::get_nnetot(nonemptymgi);
   const auto& allcont_nu_edge = globals::allcont.nu_edge;
 
   const double modified_sahafact_statweightpart = SAHACONST * std::pow(T_e, -1.5);
@@ -776,31 +777,48 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   const auto& allcont_groundcontestimindex = globals::allcont.groundcontestimindex;
   const auto& allcont_probability = globals::allcont.probability;
 
-  // The cell's cache slot does not change during the loop, so resolve it once instead of on every access.
-  // These stay empty in the no-cellcache instantiation, which reads nothing from the cache: in single-slot
-  // mode get_cellcache() returns the calling rank's one shared slot, which generally holds a different cell.
-  std::span<const double> cache_nnlevel;
-  std::span<double> cache_stimfactor_edgepart;
-  std::span<double> cache_modified_departureratios;
-  if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-    const auto& cacheslot = get_cellcache(nonemptymgi);
-    assert_testmodeonly(cacheslot.nonemptymgi == nonemptymgi);
-    cache_nnlevel = cacheslot.allcont_nnlevel;
-    cache_stimfactor_edgepart = cacheslot.allcont_stimfactor_edgepart;
-    cache_modified_departureratios = cacheslot.allcont_modified_departureratios;
-  }
+  // The per-continuum cell cache arrays this loop uses. std::span is only shallowly const, so the two
+  // lazy caches are written through below: this function mutates the cell cache and must not be treated
+  // as pure.
+  struct CellCacheContArrays {
+    std::span<const double> nnlevel{};
+    std::span<double> stimfactor_edgepart{};
+    std::span<double> modified_departureratios{};
+  };
+
+  // The cell's cache slot does not change during the loop, so resolve its arrays once instead of on every
+  // access. They stay empty in the no-cellcache instantiation, which reads nothing from the cache: in
+  // single-slot mode get_cellcache() returns the calling rank's one shared slot, which generally holds a
+  // different cell.
+  const auto cache = [&]() -> CellCacheContArrays {
+    if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+      const auto& cacheslot = get_cellcache(nonemptymgi);
+      assert_testmodeonly(cacheslot.nonemptymgi == nonemptymgi);
+      return {
+          .nnlevel = cacheslot.allcont_nnlevel,
+          .stimfactor_edgepart = cacheslot.allcont_stimfactor_edgepart,
+          .modified_departureratios = cacheslot.allcont_modified_departureratios,
+      };
+    }
+    return {};
+  }();
 
   for (int i = allcontbegin; i < allcontend; i++) {
     double sigma_contr = 0.;
 
     // zero when the cell does not contain enough of the involved atomic species (see keep_this_cont) or the
     // level is simply unpopulated. Either way the continuum contributes nothing, so one test covers both.
+    // Returned by value on purpose: a deduced reference return would bind into the cache in one
+    // instantiation and dangle on a temporary in the other, and both would still compile.
     const double nnlevel = [&] {
       if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-        return cache_nnlevel[i];
+        return cache.nnlevel[i];
       } else {
-        return keep_this_cont(allcont_element[i], allcont_ion[i], allcont_level[i], nonemptymgi, nnetot)
-                   ? calculate_levelpop(nonemptymgi, allcont_element[i], allcont_ion[i], allcont_level[i])
+        const int element = allcont_element[i];
+        const int ion = allcont_ion[i];
+        const int level = allcont_level[i];
+        return keep_this_cont(element, ion, level, nonemptymgi, nnetot)
+                   ? calculate_levelpop(nonemptymgi, element, ion, level)
                    : 0.;
       }
     }();
@@ -811,13 +829,19 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
           photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
 
       // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
-      // cache with.
+      // cache with, and is also what the no-cellcache instantiation always sees (it has no cache entry
+      // belonging to this cell to read).
       // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
       // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
       // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
       // value must also be usable on its own, so the slow path below never infers the validity of one
       // cached entry from the other.
-      const double stimfactor_edgepart = USECELLHISTANDUPDATEPHIXSLIST ? atomicload(cache_stimfactor_edgepart[i]) : -1.;
+      const double stimfactor_edgepart = [&] {
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          return atomicload(cache.stimfactor_edgepart[i]);
+        }
+        return -1.;
+      }();
 
       double stimfactor{};
       if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
@@ -831,7 +855,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
 
         double modified_departure_ratio = -1.;
         if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-          modified_departure_ratio = atomicload(cache_modified_departureratios[i]);
+          modified_departure_ratio = atomicload(cache.modified_departureratios[i]);
         }
         if (modified_departure_ratio < 0) {
           const int upper = allcont_upperlevel[i];
@@ -842,7 +866,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
                                            stat_weight(element, ion + 1, upper);
           modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
           if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            atomicstore(cache_modified_departureratios[i], modified_departure_ratio);
+            atomicstore(cache.modified_departureratios[i], modified_departure_ratio);
           }
         }
 
@@ -858,7 +882,7 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
           if (edge_exponent < stimfactor_edgepart_maxexponent) {
             const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
             if (std::isfinite(edgepart)) {
-              atomicstore(cache_stimfactor_edgepart[i], edgepart);
+              atomicstore(cache.stimfactor_edgepart[i], edgepart);
             }
           }
         }

--- a/rpkt.h
+++ b/rpkt.h
@@ -52,8 +52,9 @@ struct Phixslist {
   std::span<double> groundcont_gamma_contr;
   // needed for DETAILED_BF_ESTIMATORS_ON. Size = bfestimcount
   std::span<double> gamma_contr;
-  // radfield::update_bfestimators() passes bfestimend to std::span::first(), whose count is unsigned, so
-  // the default must be a valid count rather than a negative "not set yet" sentinel
+  // window of bfestim entries covered by the last opacity evaluation. The default is the empty window
+  // rather than a negative "not set yet" sentinel, so the bounds are always a valid range (they are used
+  // as an unsigned count by std::span::first()).
   int bfestimend{0};
   int bfestimbegin{0};
 
@@ -184,10 +185,10 @@ static_assert(closest_transition(8., 2, test_closest_transition_linelist_nu) == 
 static_assert(closest_transition(8., 4, test_closest_transition_linelist_nu) == -1);  // no more line interactions
 
 // Whether a bound-free continuum contributes to the opacity of a cell, i.e. whether the cell contains enough
-// of the involved atomic species. calculate_chi_bf_gammacontr() applies this per continuum when it is not
-// using the cell cache; when it is, the filter has already been folded into the cached level population,
-// which cellcacheslot_populate() stores as zero for the continua that fail this test.
-[[gnu::pure]] [[nodiscard]] inline auto keep_this_cont(int element, const int ion, const int level,
+// of the involved atomic species. See CellCache::allcont_nnlevel for how the cell cache stores the result.
+// nnetot is passed in rather than looked up here so that callers can hoist it out of their loop: it is
+// [[gnu::pure]] but defined in another translation unit, so LICM cannot lift it over a loop that stores.
+[[gnu::pure]] [[nodiscard]] inline auto keep_this_cont(const int element, const int ion, const int level,
                                                        const int nonemptymgi, const float nnetot) -> bool {
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {
     return grid::get_elem_massfrac(nonemptymgi, element) > 0;

--- a/rpkt.h
+++ b/rpkt.h
@@ -52,7 +52,9 @@ struct Phixslist {
   std::span<double> groundcont_gamma_contr;
   // needed for DETAILED_BF_ESTIMATORS_ON. Size = bfestimcount
   std::span<double> gamma_contr;
-  int bfestimend{-1};
+  // radfield::update_bfestimators() passes bfestimend to std::span::first(), whose count is unsigned, so
+  // the default must be a valid count rather than a negative "not set yet" sentinel
+  int bfestimend{0};
   int bfestimbegin{0};
 
   // unique ptrs are used instead of vectors for nvc++ compatibility in device code
@@ -182,8 +184,9 @@ static_assert(closest_transition(8., 2, test_closest_transition_linelist_nu) == 
 static_assert(closest_transition(8., 4, test_closest_transition_linelist_nu) == -1);  // no more line interactions
 
 // Whether a bound-free continuum contributes to the opacity of a cell, i.e. whether the cell contains enough
-// of the involved atomic species. Continua that fail this are given a zero level population (see
-// CellCache::allcont_nnlevel), which is the single condition that calculate_chi_bf_gammacontr() skips on.
+// of the involved atomic species. calculate_chi_bf_gammacontr() applies this per continuum when it is not
+// using the cell cache; when it is, the filter has already been folded into the cached level population,
+// which cellcacheslot_populate() stores as zero for the continua that fail this test.
 [[gnu::pure]] [[nodiscard]] inline auto keep_this_cont(int element, const int ion, const int level,
                                                        const int nonemptymgi, const float nnetot) -> bool {
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {

--- a/rpkt.h
+++ b/rpkt.h
@@ -52,8 +52,6 @@ struct Phixslist {
   std::span<double> groundcont_gamma_contr;
   // needed for DETAILED_BF_ESTIMATORS_ON. Size = bfestimcount
   std::span<double> gamma_contr;
-  int allcontend{-1};
-  int allcontbegin{0};
   int bfestimend{-1};
   int bfestimbegin{0};
 
@@ -183,6 +181,9 @@ static_assert(closest_transition(2., -1, test_closest_transition_linelist_nu) ==
 static_assert(closest_transition(8., 2, test_closest_transition_linelist_nu) == 2);  // known next transition
 static_assert(closest_transition(8., 4, test_closest_transition_linelist_nu) == -1);  // no more line interactions
 
+// Whether a bound-free continuum contributes to the opacity of a cell, i.e. whether the cell contains enough
+// of the involved atomic species. Continua that fail this are given a zero level population (see
+// CellCache::allcont_nnlevel), which is the single condition that calculate_chi_bf_gammacontr() skips on.
 [[gnu::pure]] [[nodiscard]] inline auto keep_this_cont(int element, const int ion, const int level,
                                                        const int nonemptymgi, const float nnetot) -> bool {
   if constexpr (DETAILED_BF_ESTIMATORS_ON) {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -108,7 +108,6 @@ void setup_cellcache() {
   backing.allcont_modified_departureratios.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_stimfactor_edgepart.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_nnlevel.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
-  backing.allcont_keep.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.chi_ff_nnionpart.allocate(static_cast<ptrdiff_t>(nslots));
   backing.allphixstargets_corrphotoioncoeff.allocate(static_cast<ptrdiff_t>(allphixstargetcount * nslots));
 
@@ -131,7 +130,6 @@ void setup_cellcache() {
         backing.allcont_modified_departureratios.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_stimfactor_edgepart = backing.allcont_stimfactor_edgepart.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_nnlevel = backing.allcont_nnlevel.subspan(s * nbfcontinua, nbfcontinua);
-    cacheslot.allcont_keep = backing.allcont_keep.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.chi_ff_nnionpart = backing.chi_ff_nnionpart.subspan(s, 1);
     cacheslot.allphixstargets_corrphotoioncoeff =
         backing.allphixstargets_corrphotoioncoeff.subspan(s * allphixstargetcount, allphixstargetcount);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -108,6 +108,7 @@ void setup_cellcache() {
   backing.allcont_modified_departureratios.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_stimfactor_edgepart.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_nnlevel.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
+  backing.allcont_keep.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.chi_ff_nnionpart.allocate(static_cast<ptrdiff_t>(nslots));
   backing.allphixstargets_corrphotoioncoeff.allocate(static_cast<ptrdiff_t>(allphixstargetcount * nslots));
 
@@ -130,6 +131,7 @@ void setup_cellcache() {
         backing.allcont_modified_departureratios.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_stimfactor_edgepart = backing.allcont_stimfactor_edgepart.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_nnlevel = backing.allcont_nnlevel.subspan(s * nbfcontinua, nbfcontinua);
+    cacheslot.allcont_keep = backing.allcont_keep.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.chi_ff_nnionpart = backing.chi_ff_nnionpart.subspan(s, 1);
     cacheslot.allphixstargets_corrphotoioncoeff =
         backing.allphixstargets_corrphotoioncoeff.subspan(s * allphixstargetcount, allphixstargetcount);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -427,12 +427,10 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   for (int i = 0; i < globals::nbfcontinua; i++) {
     const auto nnlevel = cacheslot.alllevels_pops[globals::allcont.uniquelevelindex[i]];
-    // continua that this cell does not contain the species for are stored as a zero population, so that the
-    // opacity loop only has to test the population (see calculate_chi_bf_gammacontr)
-    cacheslot.allcont_nnlevel[i] = (nnlevel > 0 && keep_this_cont(globals::allcont.element[i], globals::allcont.ion[i],
-                                                                  globals::allcont.level[i], nonemptymgi, nnetot))
-                                       ? nnlevel
-                                       : 0.;
+    // an unpopulated level stores zero either way, so skip keep_this_cont's division for those
+    const bool keep = nnlevel > 0 && keep_this_cont(globals::allcont.element[i], globals::allcont.ion[i],
+                                                    globals::allcont.level[i], nonemptymgi, nnetot);
+    cacheslot.allcont_nnlevel[i] = keep ? nnlevel : 0.;
   }
 
   if constexpr (!cellcache_singleslot) {

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <limits>
 #include <optional>
@@ -427,10 +428,11 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   for (int i = 0; i < globals::nbfcontinua; i++) {
     const auto nnlevel = cacheslot.alllevels_pops[globals::allcont.uniquelevelindex[i]];
-    // an unpopulated level stores zero either way, so skip keep_this_cont's division for those
+    // an unpopulated level is skipped either way, so skip keep_this_cont's division for those
     const bool keep = nnlevel > 0 && keep_this_cont(globals::allcont.element[i], globals::allcont.ion[i],
                                                     globals::allcont.level[i], nonemptymgi, nnetot);
-    cacheslot.allcont_nnlevel[i] = keep ? nnlevel : 0.;
+    cacheslot.allcont_nnlevel[i] = nnlevel;
+    cacheslot.allcont_keep[i] = static_cast<std::uint8_t>(keep);
   }
 
   if constexpr (!cellcache_singleslot) {

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
-#include <cstdint>
 #include <cstdlib>
 #include <limits>
 #include <optional>
@@ -428,10 +427,12 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   for (int i = 0; i < globals::nbfcontinua; i++) {
     const auto nnlevel = cacheslot.alllevels_pops[globals::allcont.uniquelevelindex[i]];
-    cacheslot.allcont_nnlevel[i] = nnlevel;
-    cacheslot.allcont_keep[i] =
-        static_cast<std::uint8_t>(nnlevel > 0 && keep_this_cont(globals::allcont.element[i], globals::allcont.ion[i],
-                                                                globals::allcont.level[i], nonemptymgi, nnetot));
+    // continua that this cell does not contain the species for are stored as a zero population, so that the
+    // opacity loop only has to test the population (see calculate_chi_bf_gammacontr)
+    cacheslot.allcont_nnlevel[i] = (nnlevel > 0 && keep_this_cont(globals::allcont.element[i], globals::allcont.ion[i],
+                                                                  globals::allcont.level[i], nonemptymgi, nnetot))
+                                       ? nnlevel
+                                       : 0.;
   }
 
   if constexpr (!cellcache_singleslot) {


### PR DESCRIPTION
Cleanups to the data that the hot bound-free opacity loop (`calculate_chi_bf_gammacontr`) walks per continuum, plus one measured performance finding. Output-preserving throughout.

## Changes

**Resolve the cell cache arrays once per call** rather than on every access. `get_cellcache()` was called up to five times per iteration, each carrying a live `assert_always`, a `cellcache_singleslot` branch and a `std::vector` indirection, and the `atomicstore`s in the cache-cold path stop the compiler hoisting it. Related: `get_cellcache()`'s index precondition is now `assert_testmodeonly`, matching the atomic-data accessors (`testmodeassert_valid_level` and friends), so it is a plain indexing helper again.

**Give the ground-continuum estimator index its own sentinel.** `allcont.index_in_groundphixslist` becomes `allcont.groundcontestimindex`, `-1` except on a ground level's first photoionisation target — the only case its single consumer read it in. The loop now does one load and one test instead of two of each, matching the existing `bfestimindex` convention, and the `groundcont_gamma_contr[...]` write is guarded against a `-1` index rather than relying on construction.

**Remove dead state:** `Phixslist::allcontbegin` / `allcontend` were written on every opacity evaluation and never read. `Phixslist::bfestimend` now defaults to `0` (the empty window) rather than `-1`, which `radfield.cc` passes to `std::span::first()` as an unsigned count. Also deletes the unused `TempGroundPhotoion` struct.

**Startup:** the closest ground continuum is now found once per level instead of once per photoionisation target, guarded by `nphixstargets > 0` (a level below the ionisation threshold can still have no photoionisation table, and its `phixstargetstart` is the `-1` sentinel).

## The one thing that did not work

An earlier revision of this branch folded the per-continuum `allcont_keep` flags into `allcont_nnlevel`, so that a zero population was the single "contributes nothing" test and the byte array could be deleted. That is measurably slower and has been reverted.

Measured on sim2010 1.06 M☉ classic (21936 continua, 100k packets, 6 timesteps, 4 ranks, `-O3 -ffast-math`, Apple M4 Pro), summed packet-propagation time over 4 order-rotated repeats:

| | propagation | vs main |
|---|---|---|
| main | 73.85 s (sd 0.33) | — |
| flags folded into the population | 76.08 s (sd 0.15) | **+3.0%** |
| flags kept separate (this branch) | 73.97 s (sd 0.13) | +0.2% |

The skip test is scanned over the whole `[allcontbegin, allcontend)` window on every opacity evaluation, and with phixsdata v1 that window is nearly the entire continuum list. Reading an 8-byte population instead of a 1-byte flag streams ~175 kB per evaluation instead of ~22 kB. Per-iteration instruction count did drop when folded (134 → 94 in the classic preset), but this loop is limited by that scan rather than by issue width — worth remembering before anyone tries the same simplification again.

## Verification

Results are unchanged and the stored checksums should not need regenerating.

- Bit-identical to main on `kilonova_1d`, `nebular_1d_3dgrid` and `classicmode_1d_3dgrid` (the last covering `VPKT_ON` and so the no-cellcache template instantiation), over the full job0 → resume → exspec sequence, plus a `TESTMODE=ON` run with sanitizers.
- Byte-identical physics output (`spec.out`, `light_curve.out`, all `estimators_*.out`, `deposition.out`, packets) against main on the sim2010 production run above.
- All six `artisoptions_*.h` presets compile under clang and gcc-16; `unittests` pass for the classic and nebular presets; clang-format and clang-tidy-22 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)