### PR TITLE
Pack the bound-free keep flags into a bitmap and walk only set bits

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -5,7 +5,9 @@
 #define CONSTANTS_H
 
 #include <array>
+#include <bit>
 #include <cstddef>
+#include <cstdint>
 #include <new>
 #include <numbers>
 #include <string_view>
@@ -146,6 +148,49 @@ constexpr bool cellcache_singleslot = true;
 #define EXEC_PAR_UNSEQ
 #define EXEC_PAR
 #endif
+
+// Index of the lowest set bit. Precondition: bits != 0.
+// std::countr_zero() cannot be translated into an nvc++ GPU accelerator region: libstdc++ implements it
+// with __builtin_ctzll, and nvc++ 26.1 with the gcc-14 headers rejects that with
+//   NVC++-F-0155-Compiler failed to translate accelerator region: Unsupported operation (bit: 418)
+// Only this function is affected -- random.h calls std::rotl from the same header in device code -- so the
+// fallback is limited to the builds that create accelerator regions. It is a binary search rather than a
+// linear scan to stay cheap on that path. Note the two differ on zero (std:: gives 64, this gives 63),
+// hence the precondition.
+[[nodiscard]] DEVICE_FUNC constexpr auto lowest_set_bit(const std::uint64_t bits) -> int {
+#if defined(__NVCOMPILER) && defined(GPU_ON)
+  auto remaining = bits;
+  int index = 0;
+  for (auto width = 32U; width > 0U; width /= 2U) {
+    if ((remaining & ((UINT64_C(1) << width) - 1U)) == 0U) {
+      remaining >>= width;
+      index += static_cast<int>(width);
+    }
+  }
+  return index;
+#else
+  return std::countr_zero(bits);
+#endif
+}
+
+// The nvc++ GPU job is the only build that instantiates the fallback, and it only compiles -- no test ever
+// runs it -- so these are its whole coverage. They step through each halving width of the binary search.
+static_assert(lowest_set_bit(1) == 0);
+static_assert(lowest_set_bit(2) == 1);
+static_assert(lowest_set_bit(0b1100) == 2);
+static_assert(lowest_set_bit(~UINT64_C(0)) == 0);
+static_assert(lowest_set_bit(UINT64_C(1) << 1) == 1);
+static_assert(lowest_set_bit(UINT64_C(1) << 2) == 2);
+static_assert(lowest_set_bit(UINT64_C(1) << 4) == 4);
+static_assert(lowest_set_bit(UINT64_C(1) << 8) == 8);
+static_assert(lowest_set_bit(UINT64_C(1) << 16) == 16);
+static_assert(lowest_set_bit(UINT64_C(1) << 31) == 31);
+static_assert(lowest_set_bit(UINT64_C(1) << 32) == 32);
+static_assert(lowest_set_bit(UINT64_C(1) << 33) == 33);
+static_assert(lowest_set_bit(UINT64_C(1) << 62) == 62);
+static_assert(lowest_set_bit(UINT64_C(1) << 63) == 63);
+static_assert(lowest_set_bit(UINT64_C(3) << 40) == 40);
+static_assert(lowest_set_bit(~UINT64_C(0) << 17) == 17);
 
 #if defined(__cpp_lib_hardware_interference_size) && __cpp_lib_hardware_interference_size >= 201603
 constexpr std::size_t DESTRUCTIVE_INTERFERENCE_SIZE = std::hardware_destructive_interference_size;

--- a/globals.h
+++ b/globals.h
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <span>
 #include <vector>
 
@@ -290,11 +291,14 @@ struct CellCache {
   // level population of each bound-free continuum's lower level
   std::span<double> allcont_nnlevel;
   // whether each bound-free continuum contributes to this cell's opacity at all: a populated lower level
-  // of a species the cell contains (see keep_this_cont). This duplicates "allcont_nnlevel[i] > 0", but is
-  // kept as a separate byte per continuum because it is what calculate_chi_bf_gammacontr() scans over the
-  // whole window every evaluation, and reading 1 byte per skipped continuum instead of 8 measures ~1%
-  // faster on a full-size model (21936 continua).
-  std::span<std::uint8_t> allcont_keep;
+  // of a species the cell contains (see keep_this_cont). Bit (i % keepbits_wordbits) of word
+  // (i / keepbits_wordbits), in ascending continuum order. This duplicates "allcont_nnlevel[i] > 0", but is
+  // held separately
+  // and packed because it is what calculate_chi_bf_gammacontr() scans across the whole window on every
+  // evaluation: with only ~11% of continua contributing in a typical cell (classic; the
+  // DETAILED_BF_ESTIMATORS_ON presets keep nearly all of them), packing lets that scan clear a whole word
+  // of absent species per test.
+  std::span<std::uint64_t> allcont_keepbits;
   std::span<double> chi_ff_nnionpart;  // single element per cell (stored as a span to allow shared backing)
   std::span<double> allphixstargets_corrphotoioncoeff;
   // The lazy mutex-guarded macroatom/cooling rate calculation is only used when cellcache_singleslot is
@@ -311,7 +315,7 @@ struct CellCache {
     mem_usage += (allcont_modified_departureratios.size() * sizeof(double));
     mem_usage += (allcont_stimfactor_edgepart.size() * sizeof(double));
     mem_usage += (allcont_nnlevel.size() * sizeof(double));
-    mem_usage += (allcont_keep.size() * sizeof(allcont_keep[0]));
+    mem_usage += (allcont_keepbits.size() * sizeof(allcont_keepbits[0]));
     mem_usage += (chi_ff_nnionpart.size() * sizeof(double));
     mem_usage += (allphixstargets_corrphotoioncoeff.size() * sizeof(double));
     mem_usage += (cooling_contrib_locks.size() * sizeof(PaddedMutex));
@@ -333,7 +337,7 @@ struct CellCacheBacking {
   MPI_shared_array<double> allcont_modified_departureratios;
   MPI_shared_array<double> allcont_stimfactor_edgepart;
   MPI_shared_array<double> allcont_nnlevel;
-  MPI_shared_array<std::uint8_t> allcont_keep;
+  MPI_shared_array<std::uint64_t> allcont_keepbits;
   MPI_shared_array<double> chi_ff_nnionpart;
   MPI_shared_array<double> allphixstargets_corrphotoioncoeff;
 };
@@ -386,6 +390,20 @@ inline void titer_average(double& value, double& saved) {
 #else
   return 0;
 #endif
+}
+
+// Word size of the CellCache::allcont_keepbits packing. Changing it means auditing every user of the
+// layout: the two helpers below, and calculate_chi_bf_gammacontr()'s walk in rpkt.cc, which derives the
+// word index and both window-edge masks itself so that it can keep the rest of a word in a register.
+inline constexpr auto keepbits_wordbits = std::numeric_limits<std::uint64_t>::digits;
+
+[[nodiscard]] inline auto get_allcont_keepwordcount() -> ptrdiff_t {
+  return get_chunk_count(globals::nbfcontinua, keepbits_wordbits);
+}
+
+// mark a bound-free continuum as contributing to this cell
+inline void set_allcont_keepbit(const std::span<std::uint64_t> keepbits, const int contindex) {
+  keepbits[contindex / keepbits_wordbits] |= UINT64_C(1) << static_cast<unsigned>(contindex % keepbits_wordbits);
 }
 
 inline auto get_cellcache(const int nonemptymgi) -> globals::CellCache& {

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -767,6 +767,13 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
     phixslist.bfestimbegin = static_cast<int>(
         std::ranges::lower_bound(globals::bfestim_nu_edge.first(phixslist.bfestimend), nu / last_phixs_nuovernuedge) -
         globals::bfestim_nu_edge.begin());
+
+    if constexpr (DETAILED_BF_ESTIMATORS_ON) {
+      // only the contributing continua write below, so clear the rest of the window here. This window
+      // holds exactly the continua of [allcontbegin, allcontend) that have an estimator index.
+      std::ranges::fill(
+          phixslist.gamma_contr.subspan(phixslist.bfestimbegin, phixslist.bfestimend - phixslist.bfestimbegin), 0.);
+    }
   }
 
   // const ref these so that the compiler knows they don't change in the loop (and shortens the names)
@@ -779,139 +786,132 @@ auto calculate_chi_bf_gammacontr(const int nonemptymgi, const double nu, Phixsli
   const auto& allcont_groundcontestimindex = globals::allcont.groundcontestimindex;
   const auto& allcont_probability = globals::allcont.probability;
 
-  // The per-continuum cell cache arrays this loop uses. Spans are only shallowly const, so the two lazy
-  // caches below are written through.
-  struct CellCacheContArrays {
-    std::span<const std::uint8_t> keep;
-    std::span<const double> nnlevel;
-    std::span<double> stimfactor_edgepart;
-    std::span<double> modified_departureratios;
-  };
+  // Only the cellcache instantiation reads the slot: in single-slot mode get_cellcache() returns the
+  // calling rank's one shared slot, which generally holds a different cell.
+  const auto& cacheslot = get_cellcache(nonemptymgi);
+  assert_testmodeonly(!USECELLHISTANDUPDATEPHIXSLIST || cacheslot.nonemptymgi == nonemptymgi);
 
-  // The cell's cache slot does not change during the loop, so resolve its arrays once instead of on every
-  // access. They stay empty in the no-cellcache instantiation, which reads nothing from the cache: in
-  // single-slot mode get_cellcache() returns the calling rank's one shared slot, which generally holds a
-  // different cell.
-  const auto cache = [&]() -> CellCacheContArrays {
-    if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-      const auto& cacheslot = get_cellcache(nonemptymgi);
-      assert_testmodeonly(cacheslot.nonemptymgi == nonemptymgi);
-      return {
-          .keep = cacheslot.allcont_keep,
-          .nnlevel = cacheslot.allcont_nnlevel,
-          .stimfactor_edgepart = cacheslot.allcont_stimfactor_edgepart,
-          .modified_departureratios = cacheslot.allcont_modified_departureratios,
-      };
+  // Walk the window a word of the keep bitmap at a time, visiting only the continua whose bit is set and
+  // holding the rest of the word in a register meanwhile. The no-cellcache instantiation has no bitmap, so
+  // it walks an all-ones word and applies keep_this_cont() per continuum instead.
+  for (int word = allcontbegin / keepbits_wordbits; word * keepbits_wordbits < allcontend; word++) {
+    auto bits = USECELLHISTANDUPDATEPHIXSLIST ? cacheslot.allcont_keepbits[word] : ~UINT64_C(0);
+
+    // drop the bits of the first and last words that fall outside [allcontbegin, allcontend)
+    if (word == (allcontbegin / keepbits_wordbits)) {
+      bits &= ~UINT64_C(0) << static_cast<unsigned>(allcontbegin % keepbits_wordbits);
     }
-    return {};
-  }();
+    if (((word + 1) * keepbits_wordbits) > allcontend) {
+      bits &= ~UINT64_C(0) >> static_cast<unsigned>(keepbits_wordbits - (allcontend % keepbits_wordbits));
+    }
 
-  for (int i = allcontbegin; i < allcontend; i++) {
-    double sigma_contr = 0.;
+    while (bits != 0) {
+      const int i = (word * keepbits_wordbits) + lowest_set_bit(bits);
+      bits &= bits - 1;  // clear the lowest set bit
 
-    // the skip test reads one byte per continuum rather than the eight of the population, which is what
-    // most of this window costs in a cell that holds few of the species (see CellCache::allcont_keep)
-    const bool keep = [&] {
+      double nnlevel{};
       if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-        return cache.keep[i] != 0;
+        nnlevel = cacheslot.allcont_nnlevel[i];
       } else {
-        return keep_this_cont(allcont_element[i], allcont_ion[i], allcont_level[i], nonemptymgi, nnetot);
+        const int element = allcont_element[i];
+        const int ion = allcont_ion[i];
+        const int level = allcont_level[i];
+        if (!keep_this_cont(element, ion, level, nonemptymgi, nnetot)) {
+          continue;
+        }
+        nnlevel = calculate_levelpop(nonemptymgi, element, ion, level);
+        if (!(nnlevel > 0)) {
+          continue;
+        }
       }
-    }();
 
-    if (keep) [[likely]] {
-      // the cached keep flag already required a positive population, so only the uncached path retests it
-      const double nnlevel = USECELLHISTANDUPDATEPHIXSLIST ? cache.nnlevel[i]
-                                                           : calculate_levelpop(nonemptymgi, allcont_element[i],
-                                                                                allcont_ion[i], allcont_level[i]);
-      if (USECELLHISTANDUPDATEPHIXSLIST || nnlevel > 0) {
-        const double nu_edge = allcont_nu_edge[i];
-        const double sigma_bf =
-            photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
+      const double nu_edge = allcont_nu_edge[i];
+      const double sigma_bf =
+          photoionisation_crosssection_fromtable(get_phixs_table(allcont_uniquelevelindex[i]), nu_edge, nu);
 
-        // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
-        // cache with, and is also what the no-cellcache instantiation always sees (it has no cache entry
-        // belonging to this cell to read).
-        // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
-        // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
-        // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
-        // value must also be usable on its own, so the slow path below never infers the validity of one
-        // cached entry from the other.
-        const double stimfactor_edgepart = [&] {
-          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            return atomicload(cache.stimfactor_edgepart[i]);
-          }
-          return -1.;
-        }();
-
-        double stimfactor{};
-        if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
-          stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
-        } else {
-          // the edge part is not cached, so compute the stimulated correction factor directly from
-          // nu - nu_edge
-          const int element = allcont_element[i];
-          const int ion = allcont_ion[i];
-          const int level = allcont_level[i];
-
-          double modified_departure_ratio = -1.;
-          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            modified_departure_ratio = atomicload(cache.modified_departureratios[i]);
-          }
-          if (modified_departure_ratio < 0) {
-            const int upper = allcont_upperlevel[i];
-            const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
-                                               ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
-                                               : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
-            const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
-                                             stat_weight(element, ion + 1, upper);
-            modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
-            if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-              atomicstore(cache.modified_departureratios[i], modified_departure_ratio);
-            }
-          }
-
-          stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
-
-          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
-            // cache the edge part for subsequent evaluations of this continuum in this cell.
-            // The complete cached product must be finite: for a large enough departure ratio the product
-            // can overflow even when the edge exponential alone does not, and recombining an infinity with
-            // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
-            // product is not representable are simply never cached and keep taking this direct path.
-            const double edge_exponent = HOVERKB * nu_edge / T_e;
-            if (edge_exponent < stimfactor_edgepart_maxexponent) {
-              const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
-              if (std::isfinite(edgepart)) {
-                atomicstore(cache.stimfactor_edgepart[i], edgepart);
-              }
-            }
-          }
+      // negative means "not computed for this cell yet", which is what cellcacheslot_populate() fills the
+      // cache with, and is also what the no-cellcache instantiation always sees (it has no cache entry
+      // belonging to this cell to read).
+      // These lazy caches may be filled by concurrent workers of the same cell: every writer stores
+      // identical values and a stale read of a sentinel just repeats the computation, with the relaxed
+      // atomic accesses (plain loads and stores in a serial build) making that well-defined. Each cached
+      // value must also be usable on its own, so the slow path below never infers the validity of one
+      // cached entry from the other.
+      const double stimfactor_edgepart = [&] {
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          return atomicload(cacheslot.allcont_stimfactor_edgepart[i]);
         }
-        // photoionisation minus stimulated recombination
-        const double corrfactor = std::max(0., 1 - stimfactor);
+        return -1.;
+      }();
 
-        sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
+      double stimfactor{};
+      if (stimfactor_edgepart >= 0. && stimfactor_split_usable) [[likely]] {
+        stimfactor = stimfactor_edgepart * exp_minus_hnu_over_kte;
+      } else {
+        // the edge part is not cached, so compute the stimulated correction factor directly from
+        // nu - nu_edge
+        const int element = allcont_element[i];
+        const int ion = allcont_ion[i];
+        const int level = allcont_level[i];
 
-        if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM &&
-                      (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS)) {
-          if (allcont_groundcontestimindex[i] >= 0) {
-            phixslist.groundcont_gamma_contr[allcont_groundcontestimindex[i]] = sigma_contr;
+        double modified_departure_ratio = -1.;
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          modified_departure_ratio = atomicload(cacheslot.allcont_modified_departureratios[i]);
+        }
+        if (modified_departure_ratio < 0) {
+          const int upper = allcont_upperlevel[i];
+          const double nnupperionlevel = USECELLHISTANDUPDATEPHIXSLIST
+                                             ? get_cellcache_levelpop(nonemptymgi, element, ion + 1, upper)
+                                             : calculate_levelpop(nonemptymgi, element, ion + 1, upper);
+          const double modified_sahafact = modified_sahafact_statweightpart * stat_weight(element, ion, level) /
+                                           stat_weight(element, ion + 1, upper);
+          modified_departure_ratio = nnupperionlevel / nnlevel * clumpednne * modified_sahafact;
+          if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+            atomicstore(cacheslot.allcont_modified_departureratios[i], modified_departure_ratio);
           }
         }
 
-        chi_bf_sum += nnlevel * sigma_contr;
+        stimfactor = modified_departure_ratio * exp(-HOVERKB * (nu - nu_edge) / T_e);
 
-        if constexpr (SELECTCONTINUUM) {
-          if (chi_bf_sum > chi_bf_sum_selectionthreshold) {
-            return i;
+        if constexpr (USECELLHISTANDUPDATEPHIXSLIST) {
+          // cache the edge part for subsequent evaluations of this continuum in this cell.
+          // The complete cached product must be finite: for a large enough departure ratio the product
+          // can overflow even when the edge exponential alone does not, and recombining an infinity with
+          // the per-call factor would wrongly zero the continuum's opacity contribution. Continua whose
+          // product is not representable are simply never cached and keep taking this direct path.
+          const double edge_exponent = HOVERKB * nu_edge / T_e;
+          if (edge_exponent < stimfactor_edgepart_maxexponent) {
+            const double edgepart = modified_departure_ratio * std::exp(edge_exponent);
+            if (std::isfinite(edgepart)) {
+              atomicstore(cacheslot.allcont_stimfactor_edgepart[i], edgepart);
+            }
           }
         }
       }
-    }
-    if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM && DETAILED_BF_ESTIMATORS_ON) {
-      if (allcont_bfestimindex[i] >= 0) {
-        phixslist.gamma_contr[allcont_bfestimindex[i]] = sigma_contr;
+      // photoionisation minus stimulated recombination
+      const double corrfactor = std::max(0., 1 - stimfactor);
+
+      const double sigma_contr = sigma_bf * allcont_probability[i] * corrfactor;
+
+      if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM &&
+                    (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS)) {
+        if (allcont_groundcontestimindex[i] >= 0) {
+          phixslist.groundcont_gamma_contr[allcont_groundcontestimindex[i]] = sigma_contr;
+        }
+      }
+
+      if constexpr (USECELLHISTANDUPDATEPHIXSLIST && !SELECTCONTINUUM && DETAILED_BF_ESTIMATORS_ON) {
+        if (allcont_bfestimindex[i] >= 0) {
+          phixslist.gamma_contr[allcont_bfestimindex[i]] = sigma_contr;
+        }
+      }
+
+      chi_bf_sum += nnlevel * sigma_contr;
+
+      if constexpr (SELECTCONTINUUM) {
+        if (chi_bf_sum > chi_bf_sum_selectionthreshold) {
+          return i;
+        }
       }
     }
   }

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -108,7 +108,8 @@ void setup_cellcache() {
   backing.allcont_modified_departureratios.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_stimfactor_edgepart.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
   backing.allcont_nnlevel.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
-  backing.allcont_keep.allocate(static_cast<ptrdiff_t>(nbfcontinua * nslots));
+  const auto nkeepwords = static_cast<size_t>(get_allcont_keepwordcount());
+  backing.allcont_keepbits.allocate(static_cast<ptrdiff_t>(nkeepwords * nslots));
   backing.chi_ff_nnionpart.allocate(static_cast<ptrdiff_t>(nslots));
   backing.allphixstargets_corrphotoioncoeff.allocate(static_cast<ptrdiff_t>(allphixstargetcount * nslots));
 
@@ -131,7 +132,7 @@ void setup_cellcache() {
         backing.allcont_modified_departureratios.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_stimfactor_edgepart = backing.allcont_stimfactor_edgepart.subspan(s * nbfcontinua, nbfcontinua);
     cacheslot.allcont_nnlevel = backing.allcont_nnlevel.subspan(s * nbfcontinua, nbfcontinua);
-    cacheslot.allcont_keep = backing.allcont_keep.subspan(s * nbfcontinua, nbfcontinua);
+    cacheslot.allcont_keepbits = backing.allcont_keepbits.subspan(s * nkeepwords, nkeepwords);
     cacheslot.chi_ff_nnionpart = backing.chi_ff_nnionpart.subspan(s, 1);
     cacheslot.allphixstargets_corrphotoioncoeff =
         backing.allphixstargets_corrphotoioncoeff.subspan(s * allphixstargetcount, allphixstargetcount);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
-#include <cstdint>
 #include <cstdlib>
 #include <limits>
 #include <optional>
@@ -425,6 +424,8 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
   std::ranges::fill(cacheslot.allcont_modified_departureratios, -1.);
   std::ranges::fill(cacheslot.allcont_stimfactor_edgepart, -1.);
 
+  std::ranges::fill(cacheslot.allcont_keepbits, 0);
+
   const auto nnetot = grid::get_nnetot(nonemptymgi);
   for (int i = 0; i < globals::nbfcontinua; i++) {
     const auto nnlevel = cacheslot.alllevels_pops[globals::allcont.uniquelevelindex[i]];
@@ -432,7 +433,9 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
     const bool keep = nnlevel > 0 && keep_this_cont(globals::allcont.element[i], globals::allcont.ion[i],
                                                     globals::allcont.level[i], nonemptymgi, nnetot);
     cacheslot.allcont_nnlevel[i] = nnlevel;
-    cacheslot.allcont_keep[i] = static_cast<std::uint8_t>(keep);
+    if (keep) {
+      set_allcont_keepbit(cacheslot.allcont_keepbits, i);
+    }
   }
 
   if constexpr (!cellcache_singleslot) {


### PR DESCRIPTION
Rebased onto main now that #517 is merged.

## What the loop was doing

`calculate_chi_bf_gammacontr` scans `[allcontbegin, allcontend)` on every opacity evaluation, testing each continuum's keep flag. Instrumenting a throwaway build on sim2010 classic showed how little of that scan is useful:

- **11.3%** of continua are kept in a typical cell
- **57.7%** of 64-continuum blocks contain no kept continuum at all
- mean window is **9324** of 21936 continua

So of ~9324 iterations per evaluation, ~8268 existed only to read a flag and move on.

## What this does

Store the flags as one bit per continuum rather than one byte, and iterate words instead of continua. A zero word clears 64 at a time; within a word, `std::countr_zero` steps straight to the next set bit, so unset bits inside a partly-filled word are skipped too. The loop body runs **~1056 times per evaluation instead of ~9324** — an 8.8× cut in trip count.

Set bits are visited in ascending index order, so the summation order is unchanged and results are bit-identical rather than merely close.

The detailed bound-free estimator entries that skipped continua used to zero individually are now cleared with one `fill` over the bfestim window, which covers exactly the continua of `[allcontbegin, allcontend)` that have an estimator index. That is the only behavioural subtlety here, and it is what the `nebular_1d_3dgrid` regression test exercises.

## Measured — and the gain depends strongly on the configuration

**sim2010 1.06 M☉ classic** (`USE_LUT_PHOTOION`, `DETAILED_BF_ESTIMATORS_ON = false`; 21936 continua, 461k lines, 100k packets, 6 timesteps, 4 ranks, `-O3 -ffast-math`, Apple M4 Pro), 3 order-alternated repeats on an idle machine:

| | before | after | |
|---|---|---|---|
| packet propagation | 73.87 s (sd 0.38) | 29.70 s (sd 0.16) | **2.49×** |
| total wall | 79.20 s | 35.01 s | **2.26×** |

Per-pair propagation ratios agree to within 1%: 0.401, 0.404, 0.402.

**W7 nebular** (`artisoptions_nltenebular.h`, `DETAILED_BF_ESTIMATORS_ON = true`; 47649 continua, 2.84M lines, 1M packets, timesteps 0–7, 4 ranks), 4 order-alternated pairs: summed propagation 14.7 s → 13.8 s. That is within the noise of a ~14 s signal at 0.1 s log resolution, so the honest reading is **no measurable change** — not a regression, but no gain either.

The reason is visible in the same instrumentation: on W7, **100.00% of continua are kept and 0.00% of words are all-zero** (measured over 7980 cell populations). Under `DETAILED_BF_ESTIMATORS_ON` the keep test in `keep_this_cont()` degenerates to `grid::get_elem_massfrac(...) > 0`, i.e. "is this element present in the cell at all", which in W7 is true for every continuum. There is nothing to skip, so the bit-walk reduces to the byte scan plus a little bit-extraction.

**So: a large win for the LUT-photoion configurations (classic, kilonova), neutral for the nebular ones.** If the nebular presets ever want this, the lever is a more selective `keep_this_cont()` under `DETAILED_BF_ESTIMATORS_ON` — but that changes which continua contribute to the opacity, so it is a physics decision rather than a refactor.

Caveats on the W7 numbers: that model directory has no saved state to resume from, so the run covers timesteps 0–7 at 150–160 days rather than the 410-day regime the model is built for, and `num_grey_timesteps = 4` means only four of those timesteps do opacity work at all. `DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP = 13`, so the detailed estimators are accumulated (that is not timestep-gated) but not yet consumed by `get_corrphotoioncoeff()` in the measured range.

Secondary benefit: in multi-slot (GPU) mode the flags are per cell rather than per rank, so this shrinks that allocation 8× — roughly 220 MB to 27 MB for 21936 continua across 10⁴ cells.

## Verification

- Bit-identical to `main` on `kilonova_1d`, `nebular_1d_3dgrid` and `classicmode_1d_3dgrid`, over the full job0 → resume → exspec sequence, plus a `TESTMODE=ON` (assertions + ASan/UBSan) run of the nebular case — the config that exercises the estimator zeroing this restructures. Re-run after the rebase.
- Byte-identical physics output and identical event counters against the pre-change build on both the sim2010 and W7 production runs above.
- All six `artisoptions_*.h` presets compile under clang and gcc-16; `unittests` pass for the classic and nebular presets; clang-format clean.

Results are unchanged, so the stored checksums should not need regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)