### PR TITLE
Add sn3d -o option to write per-rank diagnostic files into a job folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,15 +113,7 @@ jobs:
               working-directory: tests/${{ matrix.testname }}_testrun/
               run: |
                   cp input-newrun.txt input.txt
-                  touch output_0-0.txt
-                  time mpirun -np 4 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d
-
-            - name: Move job0 files
-              if: always()
-              working-directory: tests/${{ matrix.testname }}_testrun/
-              run: |
-                  mkdir job0
-                  ../../scripts/movefiles.sh job0
+                  time mpirun -np 4 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d -o job0
 
             - name: cat job0 estimators
               if: always()
@@ -146,15 +138,12 @@ jobs:
               working-directory: tests/${{ matrix.testname }}_testrun/
               run: |
                   cp input-resume.txt input.txt
-                  time mpirun -np 4 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d
+                  time mpirun -np 4 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d -o job1
 
-            - name: Move job1 files
+            - name: Remove restart files
               if: always()
               working-directory: tests/${{ matrix.testname }}_testrun/
-              run: |
-                  rm *.tmp
-                  mkdir job1
-                  ../../scripts/movefiles.sh job1
+              run: rm *.tmp
 
             - name: cat job1 estimators
               if: always()
@@ -324,13 +313,12 @@ jobs:
                   OMP_NUM_THREADS: 2
               run: |
                   cp input-newrun.txt input.txt
-                  touch output_0-0.txt
-                  time mpirun -np 2 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d
+                  time mpirun -np 2 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d -o job0
 
             - name: cat output log
               if: always()
               working-directory: tests/kilonova_1d_testrun/
-              run: cat output_0-0.txt
+              run: cat job0/output_0-0.txt
 
     # Runs the same small model with C++ standard parallelism on multicore CPUs (no GPU offload), which
     # reaches the same shared-state code paths as the OpenMP job but through std::execution::par_unseq and
@@ -377,13 +365,12 @@ jobs:
               working-directory: tests/kilonova_1d_testrun/
               run: |
                   cp input-newrun.txt input.txt
-                  touch output_0-0.txt
-                  time mpirun -np 2 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d
+                  time mpirun -np 2 --oversubscribe --mca osc ^ucx --mca mpi_yield_when_idle 1 ./sn3d -o job0
 
             - name: cat output log
               if: always()
               working-directory: tests/kilonova_1d_testrun/
-              run: cat output_0-0.txt
+              run: cat job0/output_0-0.txt
 
     combine_checksums:
         needs: testmodels

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A run writes the following into the simulation folder:
 - deposition.out: the radioactive energy deposition rate as a function of time.
 - gridsave_ts*.tmp and packets_*_ts*.tmp: restart files that allow a later job to continue from the end of a timestep.
 
-Run scripts/movefiles.sh to move the per-job output files into a subfolder afterwards. The cluster job scripts do this automatically.
+Run scripts/movefiles.sh to move the per-job output files into a subfolder afterwards. The cluster job scripts do this automatically. Alternatively, run sn3d with `-o JOBFOLDER` to write the per-job diagnostic files (the rank log files and the estimators, nlte, radfield, and macroatom files) directly into a subfolder, e.g. `./sn3d -o job0`. The shared run-level files, including the restart files that a later job resumes from, are still written to the simulation folder, and an output_0-0.txt symlink to the current job's rank-0 log is kept there so that following the log works regardless of the output folder.
 
 ### Post-processing with exspec
 As well as sn3d, `make` builds exspec, which combines the packets files from all ranks into spectra and light curves. Run it in the simulation folder using a single rank:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A run writes the following into the simulation folder:
 - deposition.out: the radioactive energy deposition rate as a function of time.
 - gridsave_ts*.tmp and packets_*_ts*.tmp: restart files that allow a later job to continue from the end of a timestep.
 
-Run sn3d with `-o JOBFOLDER` (e.g. `./sn3d -o job0`) to write the per-job diagnostic files (the rank log files and the estimators, nlte, radfield, and macroatom files) into a subfolder. The cluster job scripts do this automatically with a folder named after the SLURM job id. The shared run-level files, including the restart files that a later job resumes from, are still written to the simulation folder, and an output_0-0.txt symlink to the current job's rank-0 log is kept there so that following the log works regardless of the output folder. For runs made without -o, scripts/movefiles.sh can move the per-job files into a subfolder afterwards.
+Run sn3d with `-o JOBFOLDER` (e.g. `./sn3d -o job0`) to write the per-job output files (the rank log files and the estimators, nlte, radfield, and macroatom files) into a subfolder. The cluster job scripts do this automatically with a folder named after the SLURM job id. The shared run-level files, including the restart files that a later job resumes from, are still written to the simulation folder, and an output_0-0.txt symlink to the current job's rank-0 log is kept there so that following the log works regardless of the output folder. For runs made without -o, scripts/movefiles.sh can move the per-job files into a subfolder afterwards.
 
 ### Post-processing with exspec
 As well as sn3d, `make` builds exspec, which combines the packets files from all ranks into spectra and light curves. Run it in the simulation folder using a single rank:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A run writes the following into the simulation folder:
 - deposition.out: the radioactive energy deposition rate as a function of time.
 - gridsave_ts*.tmp and packets_*_ts*.tmp: restart files that allow a later job to continue from the end of a timestep.
 
-Run scripts/movefiles.sh to move the per-job output files into a subfolder afterwards. The cluster job scripts do this automatically. Alternatively, run sn3d with `-o JOBFOLDER` to write the per-job diagnostic files (the rank log files and the estimators, nlte, radfield, and macroatom files) directly into a subfolder, e.g. `./sn3d -o job0`. The shared run-level files, including the restart files that a later job resumes from, are still written to the simulation folder, and an output_0-0.txt symlink to the current job's rank-0 log is kept there so that following the log works regardless of the output folder.
+Run sn3d with `-o JOBFOLDER` (e.g. `./sn3d -o job0`) to write the per-job diagnostic files (the rank log files and the estimators, nlte, radfield, and macroatom files) into a subfolder. The cluster job scripts do this automatically with a folder named after the SLURM job id. The shared run-level files, including the restart files that a later job resumes from, are still written to the simulation folder, and an output_0-0.txt symlink to the current job's rank-0 log is kept there so that following the log works regardless of the output folder. For runs made without -o, scripts/movefiles.sh can move the per-job files into a subfolder afterwards.
 
 ### Post-processing with exspec
 As well as sn3d, `make` builds exspec, which combines the packets files from all ranks into spectra and light curves. Run it in the simulation folder using a single rank:
@@ -144,7 +144,7 @@ source ./setup_kilonova_1d.sh   # creates tests/kilonova_1d_testrun/
 
 ## Bundled scripts
 - clean.sh: Remove all output files while keeping input files and resetting the simulation to the beginning.
-- movefiles.sh [DIRNAME]: Move artis output files from the simulation folder into another folder. Usually called automatically by the job scripts, but should be run manually if the simulation crashes or is terminated early.
+- movefiles.sh [DIRNAME]: Move the per-job artis output files from the simulation folder into another folder, for runs made without the sn3d -o option (the job scripts now pass -o so that the files are written there directly).
 - sumcorehourslogs.py: Calculate the summed core hours of all jobs using the timing information in the last line of the output*.txt log files. This cannot include runs where the job was terminated early.
 - sumcorehoursslurm.py: Calculate the summed core hours of all jobs from the slurm job output files.
 

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -580,8 +580,7 @@ void macroatom_open_file() {
     return;
   }
 
-  macroatom_file =
-      fstream_required(std::format("macroatom_{:04d}.out", globals::my_rank), std::ios::out | std::ios::trunc);
+  macroatom_file = open_rank_outfile("macroatom");
 
   std::println(macroatom_file,
                "timestep modelgridindex Z ionstage_in ionstage_out level_in level_out activline"

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -13,8 +13,6 @@
 #include <format>
 #include <fstream>
 #include <functional>
-#include <ios>
-#include <iostream>
 #include <numeric>
 #include <print>
 #include <span>

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -54,6 +54,9 @@ inline int rank_in_node{-1};
 inline int node_count{-1};
 inline int node_id{-1};
 
+// optional folder (sn3d -o option) receiving the per-rank diagnostic files; empty means the current directory
+inline std::string runoutputfolder;
+
 inline void setup_mpi_vars() {
   MPI_Comm_rank(MPI_COMM_WORLD, &globals::my_rank);
   MPI_Comm_size(MPI_COMM_WORLD, &globals::nprocs);
@@ -499,6 +502,13 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
   assert_always(items_processed == std::ssize(dataspan));
 }
 
+// path for a timestep-specific diagnostic file (rank logs, estimators, nlte/radfield/macroatom files), which the
+// sn3d -o option redirects into a run output folder (stored without a trailing slash)
+[[nodiscard]] inline auto get_runoutputfolder_filepath(const std::string_view filename) -> std::string {
+  return globals::runoutputfolder.empty() ? std::string(filename)
+                                          : std::format("{}/{}", globals::runoutputfolder, filename);
+}
+
 [[nodiscard]] inline auto fopen_required(const std::string& filename, std::span<const char> mode) -> FILE* {
   if (mode[0] == 'r') {
     // search data folders in order to find file to read
@@ -550,6 +560,12 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
 
   printlnlog("[error] Could not open file '{}'", filename);
   std::abort();
+}
+
+// open a per-rank diagnostic output file such as estimators_0000.out for writing
+[[nodiscard]] inline auto open_rank_outfile(const std::string_view basename) -> std::fstream {
+  return fstream_required(get_runoutputfolder_filepath(std::format("{}_{:04d}.out", basename, globals::my_rank)),
+                          std::ios::out | std::ios::trunc);
 }
 
 // padded to a full cache line in CPU multithreaded modes so that adjacent mutexes in an array don't false share

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -54,7 +54,7 @@ inline int rank_in_node{-1};
 inline int node_count{-1};
 inline int node_id{-1};
 
-// optional folder (sn3d -o option) receiving the per-rank diagnostic files; empty means the current directory
+// optional folder (sn3d -o option) receiving the per-rank output files; empty means the current directory
 inline std::string runoutputfolder;
 
 inline void setup_mpi_vars() {
@@ -502,7 +502,7 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
   assert_always(items_processed == std::ssize(dataspan));
 }
 
-// path for a timestep-specific diagnostic file (rank logs, estimators, nlte/radfield/macroatom files), which the
+// path for a per-rank output file (rank logs, estimators, nlte/radfield/macroatom files), which the
 // sn3d -o option redirects into a run output folder (stored without a trailing slash)
 [[nodiscard]] inline auto get_runoutputfolder_filepath(const std::string_view filename) -> std::string {
   return globals::runoutputfolder.empty() ? std::string(filename)
@@ -562,7 +562,7 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
   std::abort();
 }
 
-// open a per-rank diagnostic output file such as estimators_0000.out for writing
+// open a per-rank output file such as estimators_0000.out for writing
 [[nodiscard]] inline auto open_rank_outfile(const std::string_view basename) -> std::fstream {
   return fstream_required(get_runoutputfolder_filepath(std::format("{}_{:04d}.out", basename, globals::my_rank)),
                           std::ios::out | std::ios::trunc);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1681,7 +1681,7 @@ DEVICE_FUNC auto superlevel_boltzmann(const int nonemptymgi, const int element, 
 }
 
 void nltepop_open_file() {
-  nlte_file = fstream_required(std::format("nlte_{:04d}.out", globals::my_rank), std::ios::out | std::ios::trunc);
+  nlte_file = open_rank_outfile("nlte");
   std::println(nlte_file, "timestep modelgridindex Z ionstage level n_LTE n_NLTE ion_popfrac");
 }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -13,7 +13,6 @@
 #include <cstdlib>
 #include <format>
 #include <fstream>
-#include <ios>
 #include <numeric>
 #include <optional>
 #include <print>

--- a/radfield.cc
+++ b/radfield.cc
@@ -15,7 +15,6 @@
 #include <cstdlib>
 #include <format>
 #include <fstream>
-#include <ios>
 #include <iterator>
 #include <print>
 #include <span>

--- a/radfield.cc
+++ b/radfield.cc
@@ -598,8 +598,7 @@ void init() {
         1e8 * CLIGHT / RADFIELDBINS_T_E_SUPERBIN_NU_MAX);
     if (grid::get_ndo_nonempty(globals::my_rank) > 0) {
       assert_always(!radfieldfile.is_open());
-      radfieldfile =
-          fstream_required(std::format("radfield_{:04d}.out", globals::my_rank), std::ios::out | std::ios::trunc);
+      radfieldfile = open_rank_outfile("radfield");
       std::println(radfieldfile, "timestep modelgridindex bin_num nu_lower nu_upper nuJ J J_nu_avg T_R W");
       radfieldfile.flush();
     }

--- a/scripts/artis-cosma8.sh
+++ b/scripts/artis-cosma8.sh
@@ -41,16 +41,13 @@ source ./artis/scripts/exspec-before.sh
 
 hoursleft=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): before srun sn3d. hours left: $hoursleft"
-time mpirun -- ./artis/sn3d -w $hoursleft > out.txt
+time mpirun -- ./artis/sn3d -w $hoursleft -o ${SLURM_JOB_ID}.slurm > out.txt
 hoursleftafter=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): after srun sn3d finished. hours left: $hoursleftafter"
 hourselapsed=$(python3 -c "print($hoursleft - $hoursleftafter)")
 echo "hours of runtime: $hourselapsed"
 cpuhrs=$(python3 -c "print($SLURM_NTASKS * $hourselapsed)")
 echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
-
-mkdir ${SLURM_JOB_ID}.slurm
-./artis/scripts/movefiles.sh ${SLURM_JOB_ID}.slurm
 
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then

--- a/scripts/artis-juwels.sh
+++ b/scripts/artis-juwels.sh
@@ -25,16 +25,13 @@ source ./artis/scripts/exspec-before.sh
 
 hoursleft=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): before srun sn3d. hours left: $hoursleft"
-time srun --hint=nomultithread -- ./artis/sn3d -w $hoursleft > out.txt
+time srun --hint=nomultithread -- ./artis/sn3d -w $hoursleft -o ${SLURM_JOB_ID}.slurm > out.txt
 hoursleftafter=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): after srun sn3d finished. hours left: $hoursleftafter"
 hourselapsed=$(python3 -c "print($hoursleft - $hoursleftafter)")
 echo "hours of runtime: $hourselapsed"
 cpuhrs=$(python3 -c "print($SLURM_NTASKS * $hourselapsed)")
 echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
-
-mkdir ${SLURM_JOB_ID}.slurm
-./artis/scripts/movefiles.sh ${SLURM_JOB_ID}.slurm
 
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then

--- a/scripts/artis-kelvin2.sh
+++ b/scripts/artis-kelvin2.sh
@@ -21,16 +21,13 @@ echo "CPU type: $(c++ -march=native -Q --help=target | grep -- '-march=  ' | cut
 
 hoursleft=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): before srun sn3d. hours left: $hoursleft"
-time mpirun -- ./artis/sn3d -w $hoursleft > out.txt
+time mpirun -- ./artis/sn3d -w $hoursleft -o ${SLURM_JOB_ID}.slurm > out.txt
 hoursleftafter=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): after srun sn3d finished. hours left: $hoursleftafter"
 hourselapsed=$(python3 -c "print($hoursleft - $hoursleftafter)")
 echo "hours of runtime: $hourselapsed"
 cpuhrs=$(python3 -c "print($SLURM_NTASKS * $hourselapsed)")
 echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
-
-mkdir ${SLURM_JOB_ID}.slurm
-./artis/scripts/movefiles.sh ${SLURM_JOB_ID}.slurm
 
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then

--- a/scripts/artis-meluxina.sh
+++ b/scripts/artis-meluxina.sh
@@ -30,16 +30,13 @@ echo "CPU type: $(c++ -march=native -Q --help=target | grep -- '-march=  ' | cut
 source ./artis/scripts/exspec-before.sh
 hoursleft=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): before srun sn3d. hours left: $hoursleft"
-time srun --hint=nomultithread -- ./artis/sn3d -w $hoursleft > out.txt
+time srun --hint=nomultithread -- ./artis/sn3d -w $hoursleft -o ${SLURM_JOB_ID}.slurm > out.txt
 hoursleftafter=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): after srun sn3d finished. hours left: $hoursleftafter"
 hourselapsed=$(python3 -c "print($hoursleft - $hoursleftafter)")
 echo "hours of runtime: $hourselapsed"
 cpuhrs=$(python3 -c "print($SLURM_NTASKS * $hourselapsed)")
 echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
-
-mkdir ${SLURM_JOB_ID}.slurm
-./artis/scripts/movefiles.sh ${SLURM_JOB_ID}.slurm
 
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then

--- a/scripts/artis-virgo-slurmjob.sh
+++ b/scripts/artis-virgo-slurmjob.sh
@@ -30,7 +30,7 @@ source ./artis/scripts/exspec-before.sh
 hoursleft=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): before srun sn3d. hours left: $hoursleft"
 
-time srun -- ./artis/sn3d -w $hoursleft > out.txt
+time srun -- ./artis/sn3d -w $hoursleft -o ${SLURM_JOB_ID}.slurm > out.txt
 
 hoursleftafter=$(python3 ./artis/scripts/slurmjobhoursleft.py ${SLURM_JOB_ID})
 echo "$(date): after srun sn3d finished. hours left: $hoursleftafter"
@@ -38,9 +38,6 @@ hourselapsed=$(python3 -c "print($hoursleft - $hoursleftafter)")
 echo "hours of runtime: $hourselapsed"
 cpuhrs=$(python3 -c "print($SLURM_NTASKS * $hourselapsed)")
 echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
-
-mkdir ${SLURM_JOB_ID}.slurm
-source ./artis/scripts/movefiles.sh ${SLURM_JOB_ID}.slurm
 
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-paths="gridsave*.tmp packets*.tmp vspecpol*.tmp vpackets*.tmp *.out *.out.* out.txt output_*-*.txt* exspec*.txt* machine.file.* core.* *.slurm packets vspecpol vpackets speclc_angle_res bflist.dat ratecoeff.dat line_list.txt logfiles.tar*"
+# for the +([0-9]) patterns that only match generated filenames (e.g. output_0-0.txt but not output_0-0_backup.txt)
+shopt -s extglob
+
+paths="gridsave*.tmp packets*.tmp vspecpol*.tmp vpackets*.tmp *.out *.out.* out.txt output_+([0-9])-+([0-9]).txt?(.zst|.gz|.xz) exspec*.txt* machine.file.* core.* *.slurm packets vspecpol vpackets speclc_angle_res bflist.dat ratecoeff.dat line_list.txt logfiles.tar*"
 
 if [ 0 -lt $(ls $paths 2>/dev/null | wc -w) ]; then
   echo "The following ARTIS run files will be deleted:"

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -859,15 +859,15 @@ void setup_runoutputfolder() {
         std::filesystem::remove(linkname, ec);
       }
     } else {
-      // clear out diagnostic files left in the folder by a previous run, so that e.g. a rerun with fewer
+      // clear out per-rank output files left in the folder by a previous run, so that e.g. a rerun with fewer
       // ranks does not leave a mixture of new estimator files and stale ones from ranks that no longer exist
       for (const auto& entry : std::filesystem::directory_iterator(globals::runoutputfolder, ec)) {
         const auto filename = entry.path().filename().string();
-        const bool is_diagfile = (filename.starts_with("output_") && filename.ends_with(".txt")) ||
-                                 ((filename.starts_with("estimators_") || filename.starts_with("nlte_") ||
-                                   filename.starts_with("radfield_") || filename.starts_with("macroatom_")) &&
-                                  filename.ends_with(".out"));
-        if (is_diagfile) {
+        const bool is_rank_outfile = (filename.starts_with("output_") && filename.ends_with(".txt")) ||
+                                     ((filename.starts_with("estimators_") || filename.starts_with("nlte_") ||
+                                       filename.starts_with("radfield_") || filename.starts_with("macroatom_")) &&
+                                      filename.ends_with(".out"));
+        if (is_rank_outfile) {
           std::filesystem::remove(entry.path(), ec);
         }
       }
@@ -888,7 +888,7 @@ void setup_runoutputfolder() {
 void print_options_help(std::FILE* stream, const char* progname) {
   std::println(stream, "Usage: {} [-w WALLTIMELIMITHOURS] [-o OUTPUTFOLDER] [-h]", progname);
   std::println(stream, "  -w WALLTIMELIMITHOURS  finish cleanly (writing restart files) before this much wall time");
-  std::println(stream, "  -o OUTPUTFOLDER        write the per-rank diagnostic files (rank logs and estimators,");
+  std::println(stream, "  -o OUTPUTFOLDER        write the per-rank output files (rank logs and estimators,");
   std::println(stream, "                         nlte, radfield, and macroatom files) into this folder");
   std::println(stream, "  -h                     print this help and exit");
 }
@@ -1010,7 +1010,7 @@ auto main(int argc, char* argv[]) -> int {
   }
 
   if (!globals::runoutputfolder.empty()) {
-    printlnlog("command line argument specifies output folder '{}' for the per-rank diagnostic files",
+    printlnlog("command line argument specifies output folder '{}' for the per-rank output files",
                globals::runoutputfolder);
   }
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -24,6 +24,7 @@
 #include <limits>
 #include <print>
 #include <string>
+#include <system_error>
 #include <utility>
 #ifdef STDPAR_ON
 #include <ranges>
@@ -829,6 +830,48 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
   return !do_this_full_loop;
 }
 
+// Create the run output folder given with the -o option and keep an output_0-0.txt symlink in the
+// simulation folder pointing at the current job's rank-0 log, so that e.g. tail -f output_0-0.txt works
+// regardless of the output folder. Without -o, remove any symlink left by a previous -o run, since
+// opening the log through it would truncate that job's stored log.
+void setup_runoutputfolder() {
+  const auto* const linkname = "output_0-0.txt";
+
+  if (globals::runoutputfolder.empty()) {
+    if (std::error_code ec; globals::my_rank == 0 && std::filesystem::is_symlink(linkname, ec)) {
+      std::filesystem::remove(linkname, ec);
+    }
+    return;
+  }
+
+  if (globals::my_rank == 0) {
+    std::error_code ec;
+    std::filesystem::create_directories(globals::runoutputfolder, ec);
+    if (ec) {
+      std::println(stderr, "[error] could not create output folder '{}': {}", globals::runoutputfolder, ec.message());
+      std::abort();
+    }
+
+    // not having the log symlink is no reason to stop the simulation, so just warn if it cannot be created
+    const auto linktarget = get_runoutputfolder_filepath(linkname);
+    std::filesystem::remove(linkname, ec);
+    std::filesystem::create_symlink(linktarget, linkname, ec);
+    if (ec) {
+      std::println(stderr, "[warning] could not create symlink '{}' to '{}': {}", linkname, linktarget, ec.message());
+    }
+  }
+  // the folder must exist before any rank opens its log file there
+  MPI_Barrier_allranks();
+}
+
+void print_options_help(std::FILE* stream, const char* progname) {
+  std::println(stream, "Usage: {} [-w WALLTIMELIMITHOURS] [-o OUTPUTFOLDER] [-h]", progname);
+  std::println(stream, "  -w WALLTIMELIMITHOURS  finish cleanly (writing restart files) before this much wall time");
+  std::println(stream, "  -o OUTPUTFOLDER        write the per-rank diagnostic files (rank logs and estimators,");
+  std::println(stream, "                         nlte, radfield, and macroatom files) into this folder");
+  std::println(stream, "  -h                     print this help and exit");
+}
+
 }  // anonymous namespace
 
 auto main(int argc, char* argv[]) -> int {
@@ -848,11 +891,54 @@ auto main(int argc, char* argv[]) -> int {
 
   globals::setup_mpi_vars();
 
+#ifdef WALLTIMELIMITSECONDS
+  int walltimelimitseconds = WALLTIMELIMITSECONDS;
+#else
+  int walltimelimitseconds = -1;
+#endif
+
+  std::string walltimehours_str;
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "hw:o:")) != -1) {  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
+    if (opt == 'h') {
+      if (globals::my_rank == 0) {
+        print_options_help(stdout, argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      }
+      MPI_Finalize();
+      std::exit(EXIT_SUCCESS);  // NOLINT(concurrency-mt-unsafe)
+    }
+    if (opt == 'w') {
+      char* parse_end = nullptr;
+      const float walltimehours = strtof(optarg, &parse_end);  // NOLINT(misc-include-cleaner)
+      if (parse_end == optarg || *parse_end != '\0' || !std::isfinite(walltimehours) || walltimehours <= 0.) {
+        // silently accepting a bad value would disable the wall time limit instead of applying it
+        std::println(stderr, "[error] invalid wall time hours '{}' given with -w option", optarg);
+        std::abort();
+      }
+      walltimelimitseconds = static_cast<int>(walltimehours * HOUR);
+      walltimehours_str = optarg;
+    } else if (opt == 'o') {
+      globals::runoutputfolder = optarg;
+      while (globals::runoutputfolder.ends_with('/')) {
+        globals::runoutputfolder.pop_back();
+      }
+      if (globals::runoutputfolder.empty()) {
+        std::println(stderr, "[error] empty output folder given with -o option");
+        std::abort();
+      }
+    } else {
+      print_options_help(stderr, argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      std::abort();
+    }
+  }
+
   check_already_running();
+
+  setup_runoutputfolder();
 
 #ifdef STDPAR_ON
   for (int t = 1; t < get_max_threads(); t++) {
-    std::filesystem::remove(std::format("output_{}-{}.txt", globals::my_rank, t));
+    std::filesystem::remove(get_runoutputfolder_filepath(std::format("output_{}-{}.txt", globals::my_rank, t)));
   }
 #endif
 
@@ -865,7 +951,7 @@ auto main(int argc, char* argv[]) -> int {
 #endif
   {
     // initialise the thread and rank specific output file
-    set_log_file(std::format("output_{}-{}.txt", globals::my_rank, get_thread_num()));
+    set_log_file(get_runoutputfolder_filepath(std::format("output_{}-{}.txt", globals::my_rank, get_thread_num())));
 
 #ifdef _OPENMP
     printlnlog("OpenMP parallelisation is active with {} threads (max {})", omp_get_num_threads(), get_max_threads());
@@ -897,30 +983,14 @@ auto main(int argc, char* argv[]) -> int {
   printlnlog("Boost Gauss-Kronrod quadrature");
 #endif
 
-#ifdef WALLTIMELIMITSECONDS
-  int walltimelimitseconds = WALLTIMELIMITSECONDS;
-#else
-  int walltimelimitseconds = -1;
-#endif
+  if (!walltimehours_str.empty()) {
+    printlnlog("command line argument specifies wall time hours '{}', so setting walltimelimitseconds = {}",
+               walltimehours_str, walltimelimitseconds);
+  }
 
-  int opt = 0;
-  while ((opt = getopt(argc, argv, "w:")) != -1) {  // NOLINT(concurrency-mt-unsafe,misc-include-cleaner)
-    if (opt == 'w') {
-      char* parse_end = nullptr;
-      const float walltimehours = strtof(optarg, &parse_end);  // NOLINT(misc-include-cleaner)
-      if (parse_end == optarg || *parse_end != '\0' || !std::isfinite(walltimehours) || walltimehours <= 0.) {
-        // silently accepting a bad value would disable the wall time limit instead of applying it
-        std::println(stderr, "[error] invalid wall time hours '{}' given with -w option", optarg);
-        std::abort();
-      }
-      walltimelimitseconds = static_cast<int>(walltimehours * HOUR);
-      printlnlog("command line argument specifies wall time hours '{}', so setting walltimelimitseconds = {}", optarg,
-                 walltimelimitseconds);
-    } else {
-      std::println(stderr, "Usage: {} [-w WALLTIMELIMITHOURS]",
-                   argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic,)
-      std::abort();
-    }
+  if (!globals::runoutputfolder.empty()) {
+    printlnlog("command line argument specifies output folder '{}' for the per-rank diagnostic files",
+               globals::runoutputfolder);
   }
 
   std::vector<Packet> packets;
@@ -1034,8 +1104,7 @@ auto main(int argc, char* argv[]) -> int {
   macroatom_open_file();
   if (ndo > 0) {
     assert_always(!estimators_file.is_open());
-    estimators_file =
-        fstream_required(std::format("estimators_{:04d}.out", globals::my_rank), std::ios::out | std::ios::trunc);
+    estimators_file = open_rank_outfile("estimators");
 
     if (globals::total_nlte_levels > 0 && ndo_nonempty > 0) {
       nltepop_open_file();

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -859,6 +859,19 @@ void setup_runoutputfolder() {
         std::filesystem::remove(linkname, ec);
       }
     } else {
+      // clear out diagnostic files left in the folder by a previous run, so that e.g. a rerun with fewer
+      // ranks does not leave a mixture of new estimator files and stale ones from ranks that no longer exist
+      for (const auto& entry : std::filesystem::directory_iterator(globals::runoutputfolder, ec)) {
+        const auto filename = entry.path().filename().string();
+        const bool is_diagfile = (filename.starts_with("output_") && filename.ends_with(".txt")) ||
+                                 ((filename.starts_with("estimators_") || filename.starts_with("nlte_") ||
+                                   filename.starts_with("radfield_") || filename.starts_with("macroatom_")) &&
+                                  filename.ends_with(".out"));
+        if (is_diagfile) {
+          std::filesystem::remove(entry.path(), ec);
+        }
+      }
+
       // not having the log symlink is no reason to stop the simulation, so just warn if it cannot be created
       const auto linktarget = get_runoutputfolder_filepath(linkname);
       std::filesystem::remove(linkname, ec);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -24,6 +24,7 @@
 #include <limits>
 #include <print>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <utility>
 #ifdef STDPAR_ON
@@ -830,6 +831,31 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
   return !do_this_full_loop;
 }
 
+// exactly match the generated per-rank output filenames: output_<rank>-<thread>.txt and the
+// estimators/nlte/radfield/macroatom _<rank>.out files
+[[nodiscard]] auto is_rank_outfile_name(const std::string_view filename) -> bool {
+  const auto alldigits = [](const std::string_view str) {
+    return !str.empty() && std::ranges::all_of(str, [](const char c) { return c >= '0' && c <= '9'; });
+  };
+
+  if (constexpr std::string_view logprefix = "output_"; filename.starts_with(logprefix) && filename.ends_with(".txt")) {
+    const auto rank_thread = filename.substr(logprefix.size(), filename.size() - logprefix.size() - 4);
+    const auto dashpos = rank_thread.find('-');
+    return dashpos != std::string_view::npos && alldigits(rank_thread.substr(0, dashpos)) &&
+           alldigits(rank_thread.substr(dashpos + 1));
+  }
+
+  if (filename.ends_with(".out")) {
+    for (const std::string_view prefix : {"estimators_", "nlte_", "radfield_", "macroatom_"}) {
+      if (filename.starts_with(prefix)) {
+        return alldigits(filename.substr(prefix.size(), filename.size() - prefix.size() - 4));
+      }
+    }
+  }
+
+  return false;
+}
+
 // Create the run output folder given with the -o option and keep an output_0-0.txt symlink in the
 // simulation folder pointing at the current job's rank-0 log, so that e.g. tail -f output_0-0.txt works
 // regardless of the output folder. Without -o, remove any symlink left by a previous -o run, since
@@ -852,26 +878,16 @@ void setup_runoutputfolder() {
       std::abort();
     }
 
-    if (std::filesystem::equivalent(globals::runoutputfolder, ".", ec)) {
-      // -o names the simulation folder itself, so the log will be at the link's path anyway and a symlink
-      // would point at itself. Just remove any symlink left by a previous run with a real output folder.
-      if (std::filesystem::is_symlink(linkname, ec)) {
-        std::filesystem::remove(linkname, ec);
+    // clear out per-rank output files (and any leftover log symlink) from a previous run of this folder, so
+    // that e.g. a rerun with fewer ranks does not leave a mixture of new estimator files and stale ones from
+    // ranks that no longer exist. Only exact matches of the generated filenames are removed.
+    for (const auto& entry : std::filesystem::directory_iterator(globals::runoutputfolder, ec)) {
+      if (is_rank_outfile_name(entry.path().filename().string())) {
+        std::filesystem::remove(entry.path(), ec);
       }
-    } else {
-      // clear out per-rank output files left in the folder by a previous run, so that e.g. a rerun with fewer
-      // ranks does not leave a mixture of new estimator files and stale ones from ranks that no longer exist
-      for (const auto& entry : std::filesystem::directory_iterator(globals::runoutputfolder, ec)) {
-        const auto filename = entry.path().filename().string();
-        const bool is_rank_outfile = (filename.starts_with("output_") && filename.ends_with(".txt")) ||
-                                     ((filename.starts_with("estimators_") || filename.starts_with("nlte_") ||
-                                       filename.starts_with("radfield_") || filename.starts_with("macroatom_")) &&
-                                      filename.ends_with(".out"));
-        if (is_rank_outfile) {
-          std::filesystem::remove(entry.path(), ec);
-        }
-      }
+    }
 
+    if (!std::filesystem::equivalent(globals::runoutputfolder, ".", ec)) {
       // not having the log symlink is no reason to stop the simulation, so just warn if it cannot be created
       const auto linktarget = get_runoutputfolder_filepath(linkname);
       std::filesystem::remove(linkname, ec);
@@ -880,6 +896,8 @@ void setup_runoutputfolder() {
         std::println(stderr, "[warning] could not create symlink '{}' to '{}': {}", linkname, linktarget, ec.message());
       }
     }
+    // when -o names the simulation folder itself, no symlink is made (it would point at itself and the log
+    // will be at the link's path anyway), and the cleanup above has already removed any leftover link
   }
   // the folder must exist before any rank opens its log file there
   MPI_Barrier_allranks();
@@ -940,7 +958,7 @@ auto main(int argc, char* argv[]) -> int {
       walltimehours_str = optarg;
     } else if (opt == 'o') {
       globals::runoutputfolder = optarg;
-      while (globals::runoutputfolder.ends_with('/')) {
+      while (globals::runoutputfolder.size() > 1 && globals::runoutputfolder.ends_with('/')) {
         globals::runoutputfolder.pop_back();
       }
       if (globals::runoutputfolder.empty()) {

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -832,11 +832,19 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
 }
 
 // exactly match the generated per-rank output filenames: output_<rank>-<thread>.txt and the
-// estimators/nlte/radfield/macroatom _<rank>.out files
-[[nodiscard]] auto is_rank_outfile_name(const std::string_view filename) -> bool {
+// estimators/nlte/radfield/macroatom _<rank>.out files, possibly with a compression extension added by
+// the post-processing scripts (e.g. exspec-after.sh runs zstd)
+[[nodiscard]] auto is_rank_outfile_name(std::string_view filename) -> bool {
   const auto alldigits = [](const std::string_view str) {
     return !str.empty() && std::ranges::all_of(str, [](const char c) { return c >= '0' && c <= '9'; });
   };
+
+  for (const std::string_view compressext : {".zst", ".gz", ".xz"}) {
+    if (filename.ends_with(compressext)) {
+      filename.remove_suffix(compressext.size());
+      break;
+    }
+  }
 
   if (constexpr std::string_view logprefix = "output_"; filename.starts_with(logprefix) && filename.ends_with(".txt")) {
     const auto rank_thread = filename.substr(logprefix.size(), filename.size() - logprefix.size() - 4);

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -852,12 +852,20 @@ void setup_runoutputfolder() {
       std::abort();
     }
 
-    // not having the log symlink is no reason to stop the simulation, so just warn if it cannot be created
-    const auto linktarget = get_runoutputfolder_filepath(linkname);
-    std::filesystem::remove(linkname, ec);
-    std::filesystem::create_symlink(linktarget, linkname, ec);
-    if (ec) {
-      std::println(stderr, "[warning] could not create symlink '{}' to '{}': {}", linkname, linktarget, ec.message());
+    if (std::filesystem::equivalent(globals::runoutputfolder, ".", ec)) {
+      // -o names the simulation folder itself, so the log will be at the link's path anyway and a symlink
+      // would point at itself. Just remove any symlink left by a previous run with a real output folder.
+      if (std::filesystem::is_symlink(linkname, ec)) {
+        std::filesystem::remove(linkname, ec);
+      }
+    } else {
+      // not having the log symlink is no reason to stop the simulation, so just warn if it cannot be created
+      const auto linktarget = get_runoutputfolder_filepath(linkname);
+      std::filesystem::remove(linkname, ec);
+      std::filesystem::create_symlink(linktarget, linkname, ec);
+      if (ec) {
+        std::println(stderr, "[warning] could not create symlink '{}' to '{}': {}", linkname, linktarget, ec.message());
+      }
     }
   }
   // the folder must exist before any rank opens its log file there


### PR DESCRIPTION
## What

Adds an optional command-line argument `-o OUTPUTFOLDER` to sn3d that writes the per-rank output files — the rank log files (`output_<rank>-<thread>.txt`) and the `estimators`, `nlte`, `radfield`, and `macroatom` files — directly into the given folder (created if missing, nested paths and trailing slashes handled), e.g. `./sn3d -o job0`. This replaces the post-run `scripts/movefiles.sh` step. Also adds `-h` help output.

Run-level files (`linestat.out`, spectra, `packets*.out`, `deposition.out`, ...) and the restart `.tmp` files that a later job resumes from are still written to the simulation folder, so a job1 with a different `-o` resumes from job0's restart files as before.

An `output_0-0.txt` symlink in the simulation folder points at the current job's rank-0 log, so `tail -f output_0-0.txt` works regardless of the output folder. A run without `-o` removes a leftover symlink first — otherwise it would truncate the previous job's stored log through the link.

## Implementation notes

- The getopt loop is hoisted above the log-file setup (the `-o` value determines where logs open); the `-w` confirmation line is deferred so log content and ordering are unchanged.
- `globals::runoutputfolder` and the `get_runoutputfolder_filepath()` / `open_rank_outfile()` helpers live in `mpi_logging.h` next to the existing file-open helpers. The path join uses `std::format` so the widely-included header does not need `<filesystem>`.
- Rank 0 creates the folder with an MPI barrier before any rank opens its log there.
- CI workflows now pass `-o jobN` instead of running `movefiles.sh`, and the cluster job scripts run sn3d with `-o ${SLURM_JOB_ID}.slurm` (`movefiles.sh` is kept for runs made without `-o`). The OpenMP and STDPAR smoke jobs also use `-o`, exercising the per-thread log opens and the STDPAR stale-log cleanup with a folder prefix.

## Results are unchanged

Without `-o`, file paths are byte-identical to before. With `-o`, files have the same names and contents in the same layout that `movefiles.sh` produced, verified byte-identical against a baseline in local kilonova_1d job0 + resume runs — so the stored CI checksums remain valid and no checksum regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

