### PR TITLE
Document current behaviour and drop historical narration in comments

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -57,9 +57,10 @@ constexpr int xcom_max_atomic_number = USE_XCOM_GAMMAPHOTOION ? 100 : 0;
 
 std::array<std::vector<ElementPhotoionData>, xcom_max_atomic_number> photoion_data;
 
-// Gamma-ray energies expressed as frequencies [Hz]. NB: these are very slightly inconsistent with MEV / H
-// from constants.h (which gives 2.41805e+20 for 1 MeV); the historical values are kept here so that
-// results are unchanged.
+// Reference scales and thresholds [Hz] for the photoelectric and pair-production cross-section fits below
+// (the Compton path works from H * nu_cmf / ME / CLIGHT^2 instead). NB: slightly inconsistent with MEV / H
+// from constants.h, which gives 2.41805e+20 for 1 MeV. Kept as-is because changing them would shift results
+// and the stored regression checksums.
 constexpr double nu_100kev = 2.41326e+19;
 constexpr double nu_1mev = 2.41326e+20;
 constexpr double nu_1p022mev = 2.46636e+20;  // electron-positron pair rest mass energy (pair production threshold)
@@ -169,10 +170,10 @@ void read_decaydata() {
     }
   }
 
-  // Historical mean gamma energies for the nuclides that decay straight to k-packets. Only apply
-  // these where no gamma-ray line table was found: a table sets the mean energy from its own lines,
-  // and overwriting it would leave choose_gamma_ray() normalising its cumulative distribution by a
-  // total that does not match the lines it is sampling from.
+  // Hard-coded mean gamma energies per decay for the only two nuclides the loop above leaves without a
+  // spectrum. Their energy is deposited as a k-packet rather than sampled, so the mean is all that is needed.
+  // The .empty() test must stay: overwriting an existing spectrum's mean would leave choose_gamma_ray()
+  // normalising by a total that does not match the lines it samples.
   if (decay::nuc_exists(26, 52) && gamma_spectra[decay::get_nucindex(26, 52)].empty()) {
     decay::set_nucdecayenergygamma(decay::get_nucindex(26, 52), 0.86 * MEV);  // Fe52
   }
@@ -861,11 +862,7 @@ void init_gamma_data() {
 }
 
 [[nodiscard]] auto choose_gamma_ray(const int nucindex, rngstate_type& rngstate) -> double {
-  // Get the frequency [Hz] of a random gamma ray from the decay spectrum of a given nucleus.
-  // If no gamma spectrum is known, return -1.
-
   if (gamma_spectra[nucindex].empty()) {
-    // for historical consistency, Fe52 and Mn52 decay directly to k-packets, which is signalled by a negative nu_cmf
     const auto nuc_z = decay::get_nuc_z(nucindex);
     const auto nuc_a = decay::get_nuc_a(nucindex);
     assert_always((nuc_z == 26 && nuc_a == 52) || (nuc_z == 25 && nuc_a == 52));

--- a/gammapkt.h
+++ b/gammapkt.h
@@ -15,6 +15,9 @@ namespace gammapkt {
 void init_gamma_data();
 DEVICE_FUNC void pellet_gamma_decay(Packet& pkt);
 DEVICE_FUNC void do_gamma(Packet& pkt, int nts, double t2);
+// Frequency [Hz] of a random gamma ray from a nuclide's decay spectrum, or -1 if it has no spectrum. Callers
+// assign the result to pkt.nu_cmf, where the negative value signals pellet_gamma_decay() to deposit the decay
+// energy locally as a k-packet instead of launching a gamma packet.
 auto choose_gamma_ray(int nucindex, rngstate_type& rngstate) -> double;
 
 // The Klein-Nishina (1929) Compton cross section, integrated over the energy loss factor from 1 up to f_max.

--- a/grid.cc
+++ b/grid.cc
@@ -1911,7 +1911,6 @@ void read_ejecta_model() {
     printlnlog("Detected 2D model");
     npts_model = static_cast<ptrdiff_t>(npts_0) * npts_1;
   } else {
-    // for 1D and 3D, this was the total number of model cells
     npts_model = npts_0;
   }
 

--- a/grid.h
+++ b/grid.h
@@ -66,12 +66,22 @@ void init_grid();
 void set_element_meanweight(std::ptrdiff_t nonemptymgi, int element, float meanweight);
 [[gnu::pure]] [[nodiscard]] auto get_electronfrac(int nonemptymgi) -> double;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_numpropcells(int modelgridindex) -> int;
+// must not be called for an empty model cell
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_nonemptymgi_of_mgi(int mgi) -> int;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_mgi_of_nonemptymgi(std::ptrdiff_t nonemptymgi) -> int;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_modelgridtype() -> GridType;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_npts_model() -> int;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_nonempty_npts_model() -> int;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_t_model() -> double;
+// Three cell index spaces are used throughout ARTIS. They are all plain integers, so mixing them up compiles
+// cleanly but silently reads the wrong cell:
+//  - cellindex: propagation grid cell, [0, ngrid). The geometry packets move through; Packet::cellindex.
+//  - modelgridindex (mgi): input model grid cell, [0, get_npts_model()). Where the ejecta model file defines
+//    density and abundances. Several propagation cells can share one model cell (get_numpropcells()).
+//  - nonemptymgi: model cells containing matter, [0, get_nonempty_npts_model()). The per-cell physics arrays
+//    are allocated over only these, so this is the index the physics modules use.
+// The two converters below return -1 for a propagation cell containing no matter, so check the result before
+// indexing a per-cell array.
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_propcell_modelgridindex(int cellindex) -> int;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_propcell_nonemptymgi(int cellindex) -> int;
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_cellindex_from_pos(const Vec3d& pos, double time) -> int;

--- a/input.cc
+++ b/input.cc
@@ -1304,13 +1304,14 @@ auto read_compositiondata() -> std::vector<int> {
   assert_always(compositiondata >> nelements_in);
   globals::elements.resize(nelements_in);
 
-  // temperature to determine relevant ionstages
+  // Unused fields that the compositiondata.txt format still carries: ion stages come from the per-element
+  // ranges below, and abundances from the model file.
   int T_preset = 0;
   assert_always(compositiondata >> T_preset);
-  assert_always(T_preset == 0);  // no longer in use
+  assert_always(T_preset == 0);
   int homogeneous_abundances = 0;
   assert_always(compositiondata >> homogeneous_abundances);
-  assert_always(homogeneous_abundances == 0);  // no longer in use
+  assert_always(homogeneous_abundances == 0);
 
   auto nlevelsmax_readin = std::vector<int>(get_nelements());
   auto nions_readin = std::vector<int>(get_nelements());
@@ -1320,7 +1321,8 @@ auto read_compositiondata() -> std::vector<int> {
     int atomicnumber = 0;
     int lowermost_ionstage = 0;
     int uppermost_ionstage = 0;
-    double uniformabundance{NAN};  // no longer in use mode for setting uniform abundances
+    // unused column; abundances come from the model file (still range-checked below)
+    double uniformabundance{NAN};
     double mass_amu{NAN};
     assert_always(compositiondata >> atomicnumber >> nions_readin[element] >> lowermost_ionstage >>
                   uppermost_ionstage >> nlevelsmax_readin[element] >> uniformabundance >> mass_amu);

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -301,8 +301,6 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
 
 }  // anonymous namespace
 
-// Determine the highest ion stage of an element that retains a non-negligible population in a cell (higher ions
-// are truncated), using either Saha or photoionisation/recombination rate balance.
 [[nodiscard]] auto find_uppermost_ion(const int nonemptymgi, const int element, const double nne_hi,
                                       const bool force_saha) -> int {
   const int nions = get_nions(element);
@@ -352,8 +350,6 @@ auto find_converged_nne(const int nonemptymgi, double nne_max, const bool force_
   return uppermost_ion;
 }
 
-// Calculate the fractions of an element's population in each ionisation stage based on Saha LTE or ionisation
-// equilibrium
 [[nodiscard]] auto calculate_ionfractions(const int element, const int nonemptymgi, const double nne,
                                           const bool use_phi_saha) -> std::vector<double> {
   assert_testmodeonly(element < get_nelements());
@@ -433,8 +429,6 @@ void calculate_cellpartfuncts(const int nonemptymgi, const int element) {
   }
 }
 
-// If not already set by the NLTE solver, set the ground level populations from either Saha LTE or
-// ionisation/recombination balance (Photoionisation Equilibrium)
 void set_groundlevelpops(const int nonemptymgi, const int element, const float nne, const bool force_saha) {
   const int nions = get_nions(element);
 

--- a/ltepop.h
+++ b/ltepop.h
@@ -14,19 +14,40 @@
 #include "grid.h"
 #include "mpi_logging.h"
 
+// Level population [cm^-3]: NLTE where the solver provided one, else Boltzmann off the ground level.
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto calculate_levelpop(int nonemptymgi, int element, int ion, int level)
     -> double;
 
+// Level population [cm^-3] forced to LTE, ignoring any NLTE solution. Unlike calculate_levelpop(), no MINPOP
+// floor is applied to excited levels, so this can return an arbitrarily small population.
 [[gnu::pure]] [[nodiscard]] auto calculate_levelpop_boltzmann(int nonemptymgi, int element, int ion, int level)
     -> double;
 
+// Highest ion stage worth following in this cell, as an ion index; higher stages are treated as unpopulated.
+// nne_hi is an assumed maximum electron density: the ion list is truncated where the running product of
+// nne_hi * phi overflows. force_saha selects Saha even for elements with NLTE levels (which otherwise return
+// all ions untruncated); pass it when the populations that follow will also be LTE.
 [[nodiscard]] auto find_uppermost_ion(int nonemptymgi, int element, double nne_hi, bool force_saha) -> int;
+
+// Solve for the free electron density self-consistently (the ion balance depends on nne, which is itself the
+// sum of the ionic charges) and store nne and the ion populations in the grid.
 void calculate_ion_balance_nne(int nonemptymgi);
+
 void calculate_cellpartfuncts(int nonemptymgi, int element);
+
+// Fractional ion abundances normalised to sum to one, indexed by ion index up to the cell's uppermost_ion.
+// use_phi_saha selects the Saha balance rather than the photoionisation/recombination balance.
 [[nodiscard]] auto calculate_ionfractions(int element, int nonemptymgi, double nne, bool use_phi_saha)
     -> std::vector<double>;
+
+// Set ground level populations from Saha LTE or photoionisation equilibrium. Writes every ion of the element
+// unconditionally, so callers must themselves skip elements whose populations the NLTE solver owns (or call it
+// deliberately to overwrite them). force_saha as for find_uppermost_ion(); works up to the cell's stored
+// uppermost_ion, so that must already be consistent with the balance chosen here.
 void set_groundlevelpops(int nonemptymgi, int element, float nne, bool force_saha);
 
+// Level population [cm^-3] read from the cell cache rather than recomputed: the fast path for packet
+// propagation. Requires the cache to already hold this cell.
 [[gnu::pure]] [[nodiscard]] inline DEVICE_FUNC auto get_cellcache_levelpop(const int nonemptymgi,
                                                                            const int uniquelevelindex) -> double {
   assert_testmodeonly(get_cellcache(nonemptymgi).nonemptymgi == nonemptymgi);
@@ -36,7 +57,7 @@ void set_groundlevelpops(int nonemptymgi, int element, float nne, bool force_sah
   return nn;
 }
 
-// Calculate the population of a level from either LTE or NLTE information
+// as above, by (element, ion, level)
 [[gnu::pure]] [[nodiscard]] inline DEVICE_FUNC auto get_cellcache_levelpop(const int nonemptymgi, const int element,
                                                                            const int ion, const int level) -> double {
   return get_cellcache_levelpop(nonemptymgi, get_uniquelevelindex(element, ion, level));

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -606,9 +606,8 @@ void macroatom_open_file() {
                " nu_cmf_in nu_cmf_out nu_rf_in nu_rf_out");
 }
 
-// The approximate radiative and collisional rates below follow Kromer & Sim (2009), Sections 3.5.1-3.5.2,
-// doi:10.1111/j.1365-2966.2009.15256.x.
-// Radiative excitation rate. Multiply by the lower-level population to obtain a rate per second.
+// The approximate radiative and collisional rate coefficients that follow are declared and documented in
+// macroatom.h. They follow Kromer & Sim (2009), Sections 3.5.1-3.5.2, doi:10.1111/j.1365-2966.2009.15256.x.
 [[gnu::pure]] [[nodiscard]] auto rad_excitation_ratecoeff(const int nonemptymgi, const double upper_statweight,
                                                           const double einstein_A, const double epsilon_trans,
                                                           const double nnlevel_lower, const double nnlevel_upper,
@@ -644,8 +643,6 @@ void macroatom_open_file() {
   return 0.;
 }
 
-// Radiative recombination rate from the upper-ion level given by the lower level's phixstargetindex-th
-// photoionisation target. Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto rad_recombination_ratecoeff(const float T_e, const float clumpednne, const int element,
                                                              const int upperion, const int lowerionlevel,
                                                              const int phixstargetindex) -> double {
@@ -660,9 +657,6 @@ void macroatom_open_file() {
   return R_spont;
 }
 
-// Collisional (three-body) recombination rate from the upper-ion level given by the lower level's
-// phixstargetindex-th photoionisation target; the detailed-balance reverse of col_ionisation_ratecoeff().
-// Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_recombination_ratecoeff(const float T_e, const float clumpednne, const int element,
                                                              const int upperion, const int lower,
                                                              const int phixstargetindex, const double epsilon_trans)
@@ -689,7 +683,6 @@ void macroatom_open_file() {
   return C;
 }
 
-// Collisional ionisation rate. Multiply by the lower-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_ionisation_ratecoeff(const float T_e, const float clumpednne, const int element,
                                                           const int ion, const int lower, const int phixstargetindex,
                                                           const double epsilon_trans) -> double {
@@ -712,7 +705,6 @@ void macroatom_open_file() {
   return C;
 }
 
-// Collisional de-excitation rate. Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_deexcitation_ratecoeff(const float T_e, const float clumpednne,
                                                             const double epsilon_trans, const double upperstatweight,
                                                             const double lowerstatweight, const int alltransindex)
@@ -756,7 +748,6 @@ void macroatom_open_file() {
   return clumpednne * 8.629e-6 * static_cast<double>(coll_strength) / upperstatweight / std::sqrt(T_e);
 }
 
-// Collisional excitation rate. Multiply by the lower-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(const float T_e, const float clumpednne,
                                                           const double upperstatweight, const int alltransindex,
                                                           const double epsilon_trans, const double lowerstatweight)

--- a/macroatom.h
+++ b/macroatom.h
@@ -19,25 +19,38 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate);
 // the lazy mutex-guarded calculation in do_macroatom() cannot run safely on the device.
 DEVICE_FUNC void calculate_cellcache_macroatom_transitionrates(int nonemptymgi, int uniquelevelindex, double t_mid);
 
+// Approximate radiative and collisional rates, following Kromer & Sim (2009), Sections 3.5.1-3.5.2,
+// doi:10.1111/j.1365-2966.2009.15256.x. Throughout, the clumpednne argument is the cell's free electron
+// density multiplied by its clumping factor.
+
+// Radiative excitation rate. Multiply by the lower-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto rad_excitation_ratecoeff(int nonemptymgi, double upper_statweight, double einstein_A,
                                                           double epsilon_trans, double nnlevel_lower,
                                                           double nnlevel_upper, double statweight_lower,
                                                           int alltransindex, double t_current) -> double;
 
+// Radiative recombination rate from the upper-ion level given by the lower level's phixstargetindex-th
+// photoionisation target. Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto rad_recombination_ratecoeff(float T_e, float clumpednne, int element, int upperion,
                                                              int lowerionlevel, int phixstargetindex) -> double;
 
+// Collisional (three-body) recombination rate from the upper-ion level given by the lower level's
+// phixstargetindex-th photoionisation target; the detailed-balance reverse of col_ionisation_ratecoeff().
+// Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_recombination_ratecoeff(float T_e, float clumpednne, int element, int upperion,
                                                              int lower, int phixstargetindex, double epsilon_trans)
     -> double;
 
+// Collisional ionisation rate. Multiply by the lower-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_ionisation_ratecoeff(float T_e, float clumpednne, int element, int ion, int lower,
                                                           int phixstargetindex, double epsilon_trans) -> double;
 
+// Collisional de-excitation rate. Multiply by the upper-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_deexcitation_ratecoeff(float T_e, float clumpednne, double epsilon_trans,
                                                             double upperstatweight, double lowerstatweight,
                                                             int alltransindex) -> double;
 
+// Collisional excitation rate. Multiply by the lower-level population to obtain a rate per second.
 [[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float clumpednne, double upperstatweight,
                                                           int alltransindex, double epsilon_trans,
                                                           double lowerstatweight) -> double;

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -815,9 +815,9 @@ void set_element_pops_lte(const int nonemptymgi, const int element) {
   // set NLTE level pops as invalid so that Boltzmann pops will be used instead
   nltepop_reset_element(nonemptymgi, element);
   calculate_cellpartfuncts(nonemptymgi, element);
-  // set_groundlevelpops uses uppermost_ion. Previously, this was set based on the NLTE phi factors. Therefore we need
-  // to call find_uppermost_ion with force_saha = true so the uppermost ion used in set_groundlevelpops is changed to
-  // the one based on the correct LTE phi factors instead
+  // set_groundlevelpops() works up to the cell's stored uppermost_ion, which for an NLTE element is simply all
+  // ions (find_uppermost_ion() does not truncate those unless force_saha is set). Recompute it with
+  // force_saha = true first, so the ion range is truncated on the same LTE phi factors as the populations.
   printlnlog("  [warning] cell {} ts {}: NLTEPOP setting element Z={} level pops to LTE", nltelog.modelgridindex,
              nltelog.timestep, get_atomicnumber(element));
   const double nne_hi = grid::get_rho(nonemptymgi) / MH;

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1191,10 +1191,15 @@ auto get_nt_frac_excitation(const int nonemptymgi) -> float {
   return frac_excitation;
 }
 
-// compute the approximate work per ion pair without using the Spencer-Fano equation
-// Makes use of EXTREMELY SIMPLE approximations - high energy limits only (can be used as an alternative to the
-// Spencer-Fano solver)
-// Luke (2026-02-20): This is so far from the Spencer-Fano eff_ionpot that I think there is a mistake in the calculation
+// Reciprocal work per ion pair, 1/W, from the analytic estimate of Axelrod (1980): high-energy cross-section
+// limits, neglecting energy lost to free electrons. Used by nt_ionisation_ratecoeff_wfapprox() as the
+// alternative to the Spencer-Fano solve, and as the fallback eff_ionpot for ions with no collisional-ionisation
+// subshell data.
+//
+// WARNING: this disagrees with the Spencer-Fano eff_ionpot by more than the approximation should explain. One
+// candidate is this function's own Aconst (note that xs_ionisation_lotz() defines a separate constant of the
+// same name and value): it takes Axelrod's 10 keV-fitted A where Lotz's, 3.4x larger, suits the low energies
+// that set the heating and ionisation fractions. Treat ions relying on this fallback as uncertain.
 auto get_oneoverw_approx_axelrod(const int element, const int ion, const int nonemptymgi) -> double {
   // Work in terms of 1/W since this is actually what we want. It is given by sigma/(Latom + Lelec).
   // We are going to start by taking all the high energy limits and ignoring Lelec, so that the
@@ -1215,7 +1220,8 @@ auto get_oneoverw_approx_axelrod(const int element, const int ion, const int non
   // Axelrod 1980 says the constant A = 1.33e-14 [cm^2 eV^2] has been determined by normalising to the average of the
   // values given by Jacobs et al (1979) and McGuire (1977) at 10 keV. However, this reduces the accuracy of the
   // approximation at lower energies, and since we are mostly interested in the low energy end of the spectrum for
-  // calculating the heating and ionisation fractions, it would be better to use Lotz value of A = 4.5e-14 [cm2 eV2].
+  // calculating the heating and ionisation fractions, it would be better to use Lotz value of A = 4.5e-14 [cm2 eV2],
+  // a factor of 3.4 larger.
   constexpr double Aconst = 1.33e-14 * EV * EV;
 
   return Aconst * binding / Zbar / (2 * PI * pow4(QE));
@@ -2012,12 +2018,10 @@ void sfmatrix_add_ionisation(std::span<double> sfmatrixuppertri, const int Z, co
 
       const int xsstartindex = get_xs_ionisation_vector(vec_xs_ionisation, collionrow);
       assert_always(xsstartindex >= 0);
-      // Luke Shingles: the use of min and max on the epsilon limits keeps energies
-      // from becoming unphysical. This insight came from reading the
-      // CMFGEN Fortran source code (Li, Dessart, Hillier 2012, doi:10.1111/j.1365-2966.2012.21198.x)
-      // I had neglected this, so the limits of integration were incorrect. The fix didn't massively affect
-      // ionisation rates or spectra, but it was a source of error that led to energy fractions not adding up to
-      // 100%
+      // The min and max clamps on the epsilon limits below are load-bearing, not defensive: they keep the energy
+      // transfer physical where the two raw limits would cross over, and dropping them leaves the heating,
+      // ionisation, and excitation fractions not summing to 100%. CMFGEN clamps the same way (Li, Dessart,
+      // Hillier 2012, doi:10.1111/j.1365-2966.2012.21198.x).
       // The inner epsilon integral of P(E', epsilon - I) has the closed form
       //   [atan((epsilon - I) / J)] / atan((E' - I) / (2 J))
       // evaluated between the epsilon limits: J * atan((epsilon - I) / J) is the antiderivative of the
@@ -2208,12 +2212,12 @@ auto sfmatrix_solve(const std::span<const double> sfmatrixuppertri) -> std::arra
 
 }  // anonymous namespace
 
-// Solve U * x = b for x, where U is the compacted upper triangular matrix (indexed via uppertriangular()). The loop
-// structure replicates the scalar (EIGEN_DONT_VECTORIZE, as set by REPRODUCIBLE builds) code path of Eigen's
-// triangularView<Upper>().solve() that was previously used here, keeping the floating-point operation order and
-// therefore the stored test checksums unchanged: back substitution proceeds bottom-up over row panels, and each panel
-// first removes the contribution of the already-solved elements to the right with one in-order dot product per row.
-// The residual and error scoring in sfmatrix_solve() are part of the same contract.
+// Solve U * x = b for x, where U is the compacted upper triangular matrix (indexed via uppertriangular()).
+// The loop structure here is frozen: back substitution bottom-up over row panels, each panel removing the
+// already-solved elements to its right with one in-order dot product per row, reproduces the floating-point
+// operation order of Eigen's scalar triangularView<Upper>().solve(). FP addition is not associative, so
+// regrouping these sums shifts the result at the ulp level and breaks the stored regression checksums. The
+// residual and error scoring in sfmatrix_solve() are part of the same contract.
 void solve_upper_triangular(const std::span<const double> sfmatrixuppertri, const std::span<const double, SFPTS> bvec,
                             const std::span<double, SFPTS> xvec) {
   std::ranges::copy(bvec, xvec.begin());
@@ -2366,8 +2370,8 @@ void calculate_deposition_rate_density(const int nonemptymgi, HeatingCoolingRate
       (heatingcoolingrates.dep_gamma + heatingcoolingrates.dep_positron + heatingcoolingrates.dep_electron);
 }
 
-// get the non-thermal lepton deposition rate density (gamma + positron + electron, excluding alpha and
-// spontaneous fission) in erg / s / cm^3, previously stored by calculate_deposition_rate_density()
+// A stored value: calculate_deposition_rate_density() must have been called for this cell earlier in the
+// timestep, or what is returned is the previous timestep's value.
 DEVICE_FUNC auto get_ntlepton_deposition_rate_density(const int nonemptymgi) -> double {
   assert_testmodeonly(ntlepton_deposition_rate_density_all_cells[nonemptymgi] >= 0);
   return ntlepton_deposition_rate_density_all_cells[nonemptymgi];
@@ -2530,13 +2534,9 @@ DEVICE_FUNC void do_ntlepton_deposit(Packet& pkt) {
     // zrand is initially between [0, 1), but we will subtract off each component of the deposition fractions
     // until we end and select transition_ij when zrand < dep_frac_transition_ij
 
-    // Gate on the stored ionisation fraction so that the k-packet probability below is exactly
-    // 1 - frac_ionisation - frac_excitation = frac_heating, the deposition partition that
-    // analyse_sf_solution() stores and the T_e solver applies. (The live get_ntion_energyrate() /
-    // deposition estimate used previously is a different estimator and does not sum with frac_excitation
-    // to give frac_heating.) The live per-ion rates still choose which ion is ionised in
-    // select_nt_ionisation(), via a separate random draw that is renormalised internally, so the gate
-    // and the ion selection do not need to share a normalisation.
+    // Gate on the stored fraction, not a separately normalised estimate, so the channel split below matches
+    // the partition the T_e solver assumes (see the k-packet probability note further down). Which ion is
+    // ionised is a separate, internally renormalised draw in select_nt_ionisation().
     const double frac_ionisation = get_nt_frac_ionisation(nonemptymgi);
 
     if (zrand < frac_ionisation) {

--- a/packet.h
+++ b/packet.h
@@ -12,22 +12,67 @@
 
 #include "constants.h"
 
+// Packet state in the indivisible energy packet scheme of Lucy (2002), doi:10.1051/0004-6361:20011756.
+// do_packet() dispatches on this. Every packet starts as TYPE_RADIOACTIVE_PELLET; those that reach the grid
+// surface end as TYPE_ESCAPE, while packets still in flight when the run ends keep whatever type they held,
+// which is why exspec filters on TYPE_ESCAPE:
+//
+//   RADIOACTIVE_PELLET --(decay to gamma rays)--> GAMMA
+//                      --(decay to a lepton/alpha)--> NONTHERMAL_PREDEPOSIT_{BETAMINUS,BETAPLUS,ALPHA}
+//                      --(spontaneous fission)--> NTALPHA_FISPROD_DEPOSITED
+//                      --(decay with no gamma line table, e.g. the 52Fe chain)--> KPKT
+//                      --(decayed before tmin)--> PRE_KPKT
+//   GAMMA --(Compton/photoelectric/pair production)--> NTLEPTON_DEPOSITED or a PREDEPOSIT type
+//         --(leaves the grid)--> ESCAPE
+//   NONTHERMAL_PREDEPOSIT_* --(thermalises)--> NTLEPTON_DEPOSITED / NTALPHA_FISPROD_DEPOSITED
+//                           --(Barnes/Wollaeger schemes, no deposition)--> ESCAPE
+//   NTLEPTON_DEPOSITED --(heating, or non-thermal ionisation/excitation)--> KPKT or RPKT
+//   NTALPHA_FISPROD_DEPOSITED --(all to heating)--> KPKT
+//   KPKT --(free-free, free-bound, or collisional emission)--> RPKT
+//   RPKT --(free-free or bound-free absorption)--> KPKT
+//        --(bound-bound activation, then collisional deactivation of the macro-atom)--> KPKT
+//        --(leaves the grid)--> ESCAPE
+//
+// The values are written to packets*.out as type_id and escape_type_id and parsed by artistools, so they
+// must not be renumbered.
 enum packet_type : int {
-  TYPE_NONE = 0,
-  TYPE_ESCAPE = 32,
-  TYPE_RADIOACTIVE_PELLET = 100,
+  TYPE_NONE = 0,  // zero-init default; also the escape_type written for a packet that never escaped
   TYPE_GAMMA = 10,
   TYPE_RPKT = 11,
+
+  // Normally destroyed by sampling a cooling channel, but do_kpkt() advances the packet by a small fraction of
+  // the timestep first, so a k-packet can also survive to the next timestep. In optically thick cells and
+  // whenever RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY is set, that selection is skipped and
+  // do_kpkt_blackbody() re-emits immediately, from a Planck function that is weighted by the expansion opacity
+  // in the latter case.
   TYPE_KPKT = 12,
+
+  // Never stored in Packet::type: do_macroatom() runs to deactivation within one call. Used only as a
+  // provenance tag to vpkt::trace_vpkts(), marking an emission as a macro-atom deactivation.
   TYPE_MA = 13,
-  TYPE_NTLEPTON_DEPOSITED = 20,
+
+  TYPE_NTLEPTON_DEPOSITED = 20,  // awaiting partition into heating/ionisation/excitation by nonthermal.cc
+
+  // Fast particles that have not yet given up their energy. PARTICLE_THERMALISATION_SCHEME decides whether
+  // and when they do, so these states can persist across timesteps (time-dependent schemes) or escape
+  // without depositing at all (Barnes/Wollaeger).
   TYPE_NONTHERMAL_PREDEPOSIT_BETAMINUS = 21,
   TYPE_NONTHERMAL_PREDEPOSIT_BETAPLUS = 22,
   TYPE_NONTHERMAL_PREDEPOSIT_ALPHA = 23,
+
+  // All of this energy goes to heating, so it converts straight to a k-packet with no Spencer-Fano solve.
   TYPE_NTALPHA_FISPROD_DEPOSITED = 24,
+
+  TYPE_ESCAPE = 32,  // inactive; binned into spectra and light curves by escape_type and escape_time
+  TYPE_RADIOACTIVE_PELLET = 100,  // decays at Packet::tdecay, moving with the homologous flow until then
+
+  // A pellet that decayed before tmin, re-emitted at tmin as a blackbody r-packet. update_pellet() scales its
+  // energy for the work done on the ejecta before tmin.
   TYPE_PRE_KPKT = 120,
 };
 
+// Sentinels for Packet::emissiontype: other values are a linelist index if non-negative, else a bound-free
+// continuum encoded by get_emtype_continuum() (see get_bflistindex_from_emtype_continuum() in atomic.h).
 constexpr int EMTYPE_NOTSET{-9999000};
 constexpr int EMTYPE_FREEFREE{-9999999};
 
@@ -43,11 +88,15 @@ enum absorption_type : int {
   ABSTYPE_PELLET_PARTICLEDECAY = -10,  // pellet decay to non-thermal particle (beta+/-, alpha, fission fragment)
 };
 
+// The state a macro-atom is activated in. Local to a do_macroatom() call, not part of the packet's
+// persistent state, since a macro-atom always runs to deactivation before the packet is handed back.
 struct MacroAtomState {
   int element{-1};  // macro atom of type element (this is an element index)
   int ion{-1};  // in ionstage ion (this is an ion index)
   int level{-1};  // and level=level (this is a level index)
-  int activatingline{-99};  // Linelistindex of the activating line for bb activated MAs, -99 else.
+  // Linelist index of the activating line for bb activated MAs, -99 else. Does not affect which transition is
+  // sampled; it feeds the resonance/up/down-scattering counters and the macroatom.out activline column.
+  int activatingline{-99};
 };
 
 #include "random.h"
@@ -68,9 +117,15 @@ struct Packet {
   int next_trans{-1};  // This keeps track of the next possible line interaction of a rpkt by storing
                        // its linelist index (to overcome numerical problems in propagating the rpkts).
   int nscatterings{0};  // records number of electron scatterings a r-pkt undergone since it was emitted
+
+  // exspec decomposes the spectra by these two. emissiontype is the most recent emission; trueemissiontype
+  // is carried unchanged through scatterings and macro-atom deactivations back to the last emission out of
+  // the thermal pool, attributing energy to where it was thermalised rather than where it last scattered.
+  // trueemissiontype is reset to EMTYPE_NOTSET when the packet re-enters the thermal pool; emissiontype keeps
+  // its value until the next emission overwrites it.
   int emissiontype{EMTYPE_NOTSET};  // records how the packet was emitted if it is a r-pkt
   Vec3d em_pos{NAN, NAN, NAN};  // Position of the last emission (x,y,z).
-  float em_time{-1.};
+  float em_time{-1.};  // [s]
   int absorptiontype{0};  // records linelistindex of the last absorption
                           // or a negative absorption_type enum value
   double absorptionfreq{};  // records nu_rf of packet at last absorption

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -370,8 +370,9 @@ void read_recombrate_file() {
           }
         }
 
-        // hopefully the RRC now matches the low_n value well, if it was defined
-        // Next, use the superlevel recombination rates to make up the excess needed to reach the total RRC
+        // The low-n levels are now calibrated. Reconciling with the total below prefers to scale only the
+        // superlevel, whose lumped levels the atomic dataset represents least well, but falls back to scaling
+        // all levels when the superlevel cannot supply the shortfall or when the total is already exceeded.
 
         printlnlog("  input_rrc_total: {:10.3e} [cm^3/s]", input_rrc_total);
 

--- a/thermalbalance.h
+++ b/thermalbalance.h
@@ -6,22 +6,38 @@
 
 #include <span>
 
+// Per-cell energy budget of the free electrons. All members are erg/s/cm^3 except dep_frac_heating.
+// call_T_e_finder() solves heating_ff + heating_bf + heating_collisional + heating_dep
+//                        = cooling_ff + cooling_fb + cooling_collisional + cooling_adiabatic for T_e.
+// Only the heating_* and cooling_* members are terms in that balance. The dep_* members feed it (via
+// heating_dep), dep_frac_heating is computed from them, and the eps_*_ana members are reported to
+// estimators.out and used to set some dep_* values, but never enter the balance directly.
 struct HeatingCoolingRates {
   double cooling_collisional{0};
   double cooling_fb{0};
   double cooling_ff{0};
-  double cooling_adiabatic{0};
+  double cooling_adiabatic{0};  // work done by the expanding ejecta, p * (dV/dt) / V
+
   double heating_collisional{0};
   double heating_bf{0};
   double heating_ff{0};
-  double heating_dep{0};
+  double heating_dep{0};  // the share of the deposition below that goes to heating
+
+  // heating_dep over the total deposition (leptons + alpha + spontaneous fission). The lepton share comes
+  // from the Spencer-Fano solution; alpha and spontaneous fission are assumed to thermalise completely.
   double dep_frac_heating{0};
+
+  // Deposition actually seen in this cell. dep_gamma is always from the Monte Carlo estimators and so noisy,
+  // as are the positron/electron/alpha rates unless PARTICLE_THERMALISATION_SCHEME is INSTANTFULLDEPOSITION,
+  // which copies them from the analytic rates below. dep_spfission is always eps_spfission_ana.
   double dep_gamma{0};
   double dep_positron{0};
   double dep_electron{0};
   double dep_alpha{0};
   double dep_spfission{0};
-  // analytic rates at the middle of the timestep (t_mid)
+
+  // Analytic rates at t_mid (density times decay power per mass): what the cell would absorb if everything
+  // thermalised locally and instantly, so dep_* against eps_*_ana shows how much escapes or moves elsewhere.
   double eps_gamma_ana{0};
   double eps_positron_ana{0};
   double eps_electron_ana{0};


### PR DESCRIPTION
Rewrites comments that narrated what the code *used to* do (or who changed it) so they describe current assumptions and behaviour, and fills the documentation gaps a new group member hits first.

## Historical narration → current contract

| Site | Was | Now |
|---|---|---|
| `solve_upper_triangular()` | "replicates the Eigen call *that was previously used here*" | The loop grouping is **frozen** because it reproduces Eigen's scalar FP operation order; regrouping shifts results at ulp level and breaks the stored checksums |
| `get_oneoverw_approx_axelrod()` | `Luke (2026-02-20): ...I think there is a mistake` | Names both call sites and the likely cause: Axelrod's 10 keV-fitted `A` where Lotz's (3.4× larger) suits the low energies that set the heating/ionisation fractions |
| Spencer-Fano epsilon clamps | "I had neglected this, *it was* a source of error" | The clamps are load-bearing; without them the energy fractions don't sum to 100% |
| `set_element_pops_lte()` | "*Previously*, this was set based on NLTE phi factors" | Why `force_saha` is needed so the ion range and populations agree |
| `compositiondata.txt` fields ×3 | "no longer in use" | Unused columns the format still carries |
| gamma constants / 52Fe / 52Mn | "historical values" | The 0.2% offset from `MEV/H` is deliberate; the empty-spectrum convention is explained |
| `ratecoeff.cc` calibration | "*hopefully* the RRC now matches..." | What is calibrated, and the three reconciliation branches |

## Documentation added

- **`packet.h`** — `packet_type` was entirely undocumented despite being the core of the indivisible-packet scheme. Adds a state diagram plus per-state notes. Two facts contradict what the names suggest: `TYPE_MA` is **never** stored in `Packet::type` (`do_macroatom()` runs to deactivation in one call; it's only a vpkt provenance tag), and `TYPE_PRE_KPKT` is exclusively for pre-`tmin` decays — the thick-cell blackbody path keeps `TYPE_KPKT`.
- **`grid.h`** — the `cellindex` / `modelgridindex` / `nonemptymgi` index spaces, their ranges, and which converters return `-1`. These are all bare `int`s, so mixing them up compiles silently.
- **`thermalbalance.h`** — units (erg/s/cm³) on every `HeatingCoolingRates` member and the balance equation being solved.
- **`ltepop.h` / `macroatom.h`** — which population each rate coefficient must be multiplied by, and how the three level-population accessors differ.

Comments sit on declarations rather than definitions so clangd surfaces them at call sites; `.cc` copies that would have drifted are removed.

## Reviewer notes

- **No functional change.** Comments-only apart from reordering the `packet_type` enumerators into ascending value order — every name→value pair is unchanged (verified), and the values are wire format for `packets*.out`. **Numerical results are not expected to change, so the checksums should not need regenerating.**
- Verified locally: `make OPTIMIZE=OFF` builds `sn3d` and `exspec` clean under `-Werror`; clang-format clean; pre-commit hooks pass.
- I did **not** run the regression tests — the comments-only diff is the basis for the no-change claim, not a checksum comparison.
- The comments were reviewed against the code and ~19 factual errors in the first draft were corrected, including: only `trueemissiontype` resets on thermal re-entry (not both); k-packets can survive a timestep via `do_kpkt()` diffusion; `calculate_levelpop_boltzmann()` applies no MINPOP floor to excited levels; `set_groundlevelpops()` writes every ion (the NLTE guard is in the caller); `dep_spfission` is always analytic while `dep_gamma` is always Monte Carlo. Worth a sanity check from someone who knows the physics, since a wrong comment is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)