### PR TITLE
Make ARTIS easier to use correctly and harder to use incorrectly

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -182,9 +182,11 @@ jobs:
 
             - name: Compile all remaining option files
               run: |
+                  # no -p here: a preserved (checkout-time) mtime would be older than the objects built in the
+                  # previous steps, so make would consider everything up to date and skip compiling the preset
                   for file in $(find . -name "artisoptions_*.h" ! -name "artisoptions_classic.h" ! -name "artisoptions_nltenebular.h"); do
-                      cp -v -p "$file" artisoptions.h
-                      make sn3d
+                      cp -v "$file" artisoptions.h
+                      make -j$(nproc) sn3d
                   done
 
     mac-clang:
@@ -264,9 +266,11 @@ jobs:
 
             - name: LLVM Clang Compile all remaining option files
               run: |
+                  # no -p here: a preserved (checkout-time) mtime would be older than the objects built in the
+                  # previous steps, so make would consider everything up to date and skip compiling the preset
                   for file in $(find . -name "artisoptions_*.h" ! -name "artisoptions_classic.h" ! -name "artisoptions_nltenebular.h"); do
-                      cp -v -p "$file" artisoptions.h
-                      make sn3d
+                      cp -v "$file" artisoptions.h
+                      make -j$(nproc) sn3d
                   done
 
     amd-rocm-hipcc:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ code must compile under all of those compilers (including `GPU=ON` paths).
 - clang-format (Google-based style, 120-column limit; config in `.clang-format`)
   is enforced on all C++ files.
 - clang-tidy with an extensive check list (`.clang-tidy`); run via `make check`
-  (needs `compile_commands.json`, e.g. `compiledb -n make TESTMODE=ON`).
+  (needs `compile_commands.json`, e.g. `compiledb -n --full-path make TESTMODE=ON`).
 - cppcheck runs in CI (`.github/workflows/ci-checks.yml`).
 - Pre-commit hooks (`.pre-commit-config.yaml`, managed with `prek`/pre-commit)
   run clang-format, whitespace/EOF fixers, and a `make OPTIMIZE=OFF` compile.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ ifneq ($(strip $(filter-out clean,$(if $(MAKECMDGOALS),$(MAKECMDGOALS),all))),)
   ifeq ($(wildcard artisoptions.h),)
     $(error artisoptions.h not found. Select a compile-time option preset, e.g. 'ln -s artisoptions_classic.h artisoptions.h'. Symlinking (rather than copying) keeps it in sync when the preset changes. The options are documented in artisoptions_doc.md)
   endif
+  # Without --check-symlink-times, make compares timestamps through the symlink, so switching presets
+  # with 'ln -sf' can leave a build silently up to date with the previous preset's options. The flag is
+  # condensed into the letter 'L' in the first (dashless) word of MAKEFLAGS.
+  ifneq ($(shell test -L artisoptions.h && echo is_symlink),)
+    ifeq (,$(findstring L,$(filter-out -%,$(firstword $(MAKEFLAGS)))))
+      $(warning artisoptions.h is a symlink, but make was started without --check-symlink-times: switching presets with ln -sf may not trigger a rebuild. Recommended: export MAKEFLAGS="--check-symlink-times --jobs=$$(nproc --all)")
+    endif
+  endif
 endif
 
 $(info mpicxx version: $(shell mpicxx --showme:version 2> /dev/null))
@@ -199,6 +207,9 @@ endif
 
 ifneq ($(MAX_NODE_SIZE),)
 	CXXFLAGS += -DMAX_NODE_SIZE=$(MAX_NODE_SIZE)
+	# like every other option that changes CXXFLAGS, this must go into the build directory name, or
+	# changing it would reuse (or worse, mix with) objects compiled with a different node size
+	BUILD_DIR := $(BUILD_DIR)_maxnodesize$(MAX_NODE_SIZE)
 endif
 
 ifeq ($(TESTMODE),ON)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,16 @@
 # export MAKEFLAGS="--check-symlink-times --jobs=$(nproc --all)"
 .DEFAULT_GOAL := all
 
+# artisoptions.h is gitignored and must be supplied before building (normally a symlink to one of the
+# artisoptions_*.h presets). Check for it up front, so that a missing file gives one actionable message
+# instead of a 'no such file' error from every translation unit, interleaved across parallel jobs.
+# 'make clean' is exempt, so that a tree without artisoptions.h can still be cleaned.
+ifneq ($(strip $(filter-out clean,$(if $(MAKECMDGOALS),$(MAKECMDGOALS),all))),)
+  ifeq ($(wildcard artisoptions.h),)
+    $(error artisoptions.h not found. Select a compile-time option preset, e.g. 'ln -s artisoptions_classic.h artisoptions.h'. Symlinking (rather than copying) keeps it in sync when the preset changes. The options are documented in artisoptions_doc.md)
+  endif
+endif
+
 $(info mpicxx version: $(shell mpicxx --showme:version 2> /dev/null))
 
 ifeq ($(TESTMODE),ON)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ brew install llvm open-mpi prek compiledb
 Install the pre-commit hooks and generate a compilation database for clang tools:
 ```sh
 prek install
-make clean && compiledb -n make TESTMODE=ON
+make clean && compiledb -n --full-path make TESTMODE=ON
 ```
 For editing, the clangd language server is recommended (e.g., with the [VS Code plugin](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd)).
 
@@ -112,6 +112,8 @@ mpirun -np 8 ./sn3d&
 tail -f output_0-0.txt
 ```
 Press Ctrl+C to stop following the log file.
+
+To split a long simulation across several queued jobs, run sn3d with `-w WALLTIMELIMITHOURS`. When too little wall time remains to complete another timestep, the run finishes cleanly (writing the restart files and updating input.txt) and prints RESTART_NEEDED into the log, which the bundled cluster job scripts detect to submit a continuation job. The scripts pass the remaining SLURM allocation time automatically. Run `./sn3d -h` to list all command-line options.
 
 ### Output files
 A run writes the following into the simulation folder:
@@ -143,7 +145,7 @@ source ./setup_kilonova_1d.sh   # creates tests/kilonova_1d_testrun/
 [CI](.github/workflows/ci.yml) runs all of these on every push. It builds with `REPRODUCIBLE=ON FASTMATH=OFF MAX_NODE_SIZE=2` and compares md5 checksums of the output files against reference checksums stored in the tests/*_inputfiles folders. A change that legitimately alters the numerical results therefore needs new reference checksums, which maintainers regenerate using the "Update checksums" workflow. CI also compiles every artisoptions_*.h preset with gcc and clang, and the classic and NLTE nebular presets additionally with Apple Clang, nvc++, and hipcc (including the GPU code paths).
 
 ## Bundled scripts
-- clean.sh: Remove all output files while keeping input files and resetting the simulation to the beginning.
+- clean.sh: Remove all output files while keeping input files and resetting the simulation to the beginning. Job output folders created by the sn3d -o option are not removed and must be deleted manually.
 - movefiles.sh [DIRNAME]: Move the per-job artis output files from the simulation folder into another folder, for runs made without the sn3d -o option (the job scripts now pass -o so that the files are written there directly).
 - sumcorehourslogs.py: Calculate the summed core hours of all jobs using the timing information in the last line of the output*.txt log files. This cannot include runs where the job was terminated early.
 - sumcorehoursslurm.py: Calculate the summed core hours of all jobs from the slurm job output files.
@@ -182,7 +184,7 @@ Required when virtual packets are enabled (VPKT_ON in artisoptions.h). Sets the 
 Grid parameters, cell densities and nuclear composition.
 
 ### abundances.txt
-Per-cell elemental mass fractions (in case the set of isotopic abundances in model.txt is not complete).
+Required file with the per-cell elemental mass fractions, which include elements whose isotopic abundances are not given in model.txt.
 
 ### adata.txt
 One block per ion consisting of:

--- a/artisoptions_nltenebular.h
+++ b/artisoptions_nltenebular.h
@@ -42,7 +42,7 @@ constexpr bool UNIFORM_PELLET_ENERGIES = true;
 constexpr bool DIRECT_COL_HEAT = true;
 constexpr bool INITIAL_PACKETS_ON = false;
 
-constexpr bool USE_MODEL_INITIAL_ENERGY = true;
+constexpr bool USE_MODEL_INITIAL_ENERGY = false;
 
 constexpr int TABLESIZE = 100;
 constexpr double MINTEMP = 1000.;

--- a/globals.h
+++ b/globals.h
@@ -186,28 +186,28 @@ struct AllLevels {
   MPI_shared_array<const int> nuptrans;
 
   // Number of autoionizing transition from this level
-  MPI_shared_array<int> nautoiondowntrans;
+  MPI_shared_array<const int> nautoiondowntrans;
 
   // Number of di-el captures up from this level
-  MPI_shared_array<int> nautoionuptrans;
+  MPI_shared_array<const int> nautoionuptrans;
 
   // index into globals::allautoion for first autoion from this level
-  MPI_shared_array<int> allautoion_start;
+  MPI_shared_array<const int> allautoion_start;
 
-  MPI_shared_array<int> closestgroundlevelcont;
+  MPI_shared_array<const int> closestgroundlevelcont;
 
   // index to start of photoionisation cross-sections table in global::allphixs
-  MPI_shared_array<int> phixsstart;
+  MPI_shared_array<const int> phixsstart;
 
   // number of target levels for photoionisation
-  MPI_shared_array<int> nphixstargets;
+  MPI_shared_array<const int> nphixstargets;
 
   // index into globals::allphixstargets for the first target level
-  MPI_shared_array<int> phixstargetstart;
+  MPI_shared_array<const int> phixstargetstart;
 
   // index of the bound-free continuum (for first target) sorted by element/ion/level/phixstargetindex (not an index
   // into the nu_edge-sorted allcont list!)
-  MPI_shared_array<int> bflist_start;
+  MPI_shared_array<const int> bflist_start;
 
   // index into cellcache allmacroatomictransitions for each level. This is
   // different to the alltrans index because two types of down transitions are stored separately

--- a/grid.cc
+++ b/grid.cc
@@ -57,6 +57,10 @@ namespace grid {
 
 namespace {
 
+static_assert(!USE_MODEL_INITIAL_ENERGY || INITIAL_PACKETS_ON,
+              "USE_MODEL_INITIAL_ENERGY requires INITIAL_PACKETS_ON, because the model's initial thermal energy (the "
+              "q column of model.txt) is only injected via the initial packets");
+
 std::array<int, 3> ncoordgrid{0, 0, 0};  // propagation grid dimensions
 
 std::optional<GridType> model_type{};
@@ -142,6 +146,10 @@ constexpr auto get_ndim(const GridType gridtype) -> int {
 void set_rho_tmin(const int modelgridindex, const float x) { modelgrid_input[modelgridindex].rhoinit = x; }
 
 void set_initelectronfrac(const int modelgridindex, const float electronfrac) {
+  if (!(electronfrac >= 0. && electronfrac <= 1.001)) {
+    printlnlog("[error] input Ye {:g} for cell {} is outside the physical range [0, 1]", electronfrac, modelgridindex);
+    assert_always(false);
+  }
   modelgrid_input[modelgridindex].initelectronfrac = electronfrac;
 }
 
@@ -1905,6 +1913,10 @@ void read_ejecta_model() {
   assert_always(get_noncommentline(fmodel, line));
   auto ssline = std::istringstream{line};
   ssline >> npts_0;
+  if (npts_0 <= 0) {
+    printlnlog("[error] model.txt: could not read a positive cell count from the first line '{}'", line);
+    std::abort();
+  }
   if (ssline >> npts_1) {
     // second number on the line for 2D means the line was n_r n_z
     detected_dim = GridType::CYLINDRICAL2D;
@@ -1918,6 +1930,11 @@ void read_ejecta_model() {
   double t_model_days{NAN};
   assert_always(get_noncommentline(fmodel, line));
   std::istringstream{line} >> t_model_days;
+  // a failed extraction stores zero, which would silently scale all densities by (t_model / tmin)^3 = 0
+  if (!std::isfinite(t_model_days) || t_model_days <= 0.) {
+    printlnlog("[error] model.txt: could not read a positive snapshot time in days from line '{}'", line);
+    std::abort();
+  }
   t_model = t_model_days * DAY;
   assert_always(globals::tmin >= t_model);
 

--- a/grid.cc
+++ b/grid.cc
@@ -146,7 +146,7 @@ constexpr auto get_ndim(const GridType gridtype) -> int {
 void set_rho_tmin(const int modelgridindex, const float x) { modelgrid_input[modelgridindex].rhoinit = x; }
 
 void set_initelectronfrac(const int modelgridindex, const float electronfrac) {
-  if (!(electronfrac >= 0. && electronfrac <= 1.001)) {
+  if (std::isnan(electronfrac) || electronfrac < 0. || electronfrac > 1.001) {
     printlnlog("[error] input Ye {:g} for cell {} is outside the physical range [0, 1]", electronfrac, modelgridindex);
     assert_always(false);
   }

--- a/grid.cc
+++ b/grid.cc
@@ -509,7 +509,7 @@ void allocate_nonemptymodelcells() {
   nnetot_allcells = MPI_shared_array<float>(nonempty_npts_model, -1.);
   kappagrey_allcells = MPI_shared_array<float>(nonempty_npts_model, 0.);
   grey_depth_allcells = MPI_shared_array<float>(nonempty_npts_model, 0.);
-  thick_allcells = MPI_shared_array<int>(nonempty_npts_model, 0);
+  thick_allcells = MPI_shared_array<CellThickness>(nonempty_npts_model, CellThickness::THIN);
   if constexpr (USE_MICROCLUMPING) {
     clumpfactor_allcells = MPI_shared_array<float>(nonempty_npts_model, -1.);
   }
@@ -1027,7 +1027,7 @@ void read_grid_restart_data(const int timestep) {
       Te_allcells[nonemptymgi] = T_e;
       W_allcells[nonemptymgi] = W;
       TJ_allcells[nonemptymgi] = T_J;
-      thick_allcells[nonemptymgi] = thick;
+      thick_allcells[nonemptymgi] = static_cast<CellThickness>(thick);
       nne_allcells[nonemptymgi] = nne_in;
       nnetot_allcells[nonemptymgi] = nnetot_in;
     }
@@ -1116,7 +1116,7 @@ void assign_initial_temperatures() {
     TJ_allcells[nonemptymgi] = T_initial;
     TR_allcells[nonemptymgi] = T_initial;
     W_allcells[nonemptymgi] = 1.;
-    thick_allcells[nonemptymgi] = 0;
+    thick_allcells[nonemptymgi] = CellThickness::THIN;
   }
 
   // combine the diagnostic counts over the node communicator (the ranks of each node together cover every cell

--- a/grid.h
+++ b/grid.h
@@ -25,8 +25,15 @@ inline MPI_shared_array<float> nne_allcells;
 inline MPI_shared_array<float> nnetot_allcells;  // total electron density (free + bound).
 inline MPI_shared_array<float> kappagrey_allcells;
 inline MPI_shared_array<float> grey_depth_allcells;  // Grey optical depth to surface of the modelgridcell
-inline MPI_shared_array<int>
-    thick_allcells;  // whether the cell is optically thick (1) or not (0), or (2) thick for vpkts only
+// optical-thickness treatment of a cell. The numeric values appear in the estimators and gridsave
+// files, so they must not be renumbered
+enum class CellThickness : int {
+  THIN = 0,  // detailed opacity treatment
+  THICK = 1,  // optically thick: grey opacity treatment
+  THICK_VPKT_ONLY = 2,  // treated as optically thick for virtual packets only
+};
+
+inline MPI_shared_array<CellThickness> thick_allcells;
 inline MPI_shared_array<float> clumpfactor_allcells;
 
 inline ptrdiff_t ngrid{0};

--- a/input.cc
+++ b/input.cc
@@ -127,7 +127,7 @@ constexpr auto inputlinecomments = std::array{
     "17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.",
     "18: num_lte_timesteps",
     "19: optical_depth_is_thick num_grey_timesteps",
-    "20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)",
+    "20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)",
     "21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.",
     "22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d",
     "23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc",
@@ -2050,18 +2050,7 @@ void read_parameterfile(std::span<Packet> packets) {
       "input: cells with Thomson optical depth > {:g} are treated in grey approximation for the first {} timesteps",
       globals::optical_depth_is_thick, globals::num_grey_timesteps);
 
-  // formerly a limit on the number of bf-continua per ion. Reject any value other than the old
-  // "unlimited" setting rather than silently ignoring a limit that an old input file requests
-  assert_always(get_noncommentline(file, line));
-  int max_bf_continua = 0;
-  std::istringstream{line} >> max_bf_continua;
-  if (max_bf_continua != -1) {
-    printlnlog(
-        "[error] input.txt line 20 (max_bf_continua) has value {}, but limiting the bound-free continua is no longer "
-        "supported. Set it to -1 (all bf continua included)",
-        max_bf_continua);
-    std::abort();
-  }
+  assert_always(get_noncommentline(file, line));  // UNUSED max_bf_continua (all bf continua are always included)
 
   // for exspec: read number of MPI tasks
   assert_always(get_noncommentline(file, line));

--- a/input.cc
+++ b/input.cc
@@ -98,6 +98,14 @@ struct TempLineTransitionInput {
   int lowerlevelindex;
 };
 
+// mutable views of the per-level photoionisation arrays while read_phixs_data() builds them, before
+// they are published (move-assigned) into the read-only node-shared members of globals::alllevels
+struct PhixsLevelBuilders {
+  std::span<int> phixsstart;
+  std::span<int> nphixstargets;
+  std::span<int> phixstargetstart;
+};
+
 constexpr auto inputlinecomments = std::array{
     " 0: pre_zseed: specific random number seed if > 0 or random if negative",
     " 1: ntimesteps: number of timesteps",
@@ -137,19 +145,20 @@ static_assert(std::string_view{inputlinecomments[inputline_nprocs_exspec]}.start
 void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_inputtable, const int element,
                            const int lowerion, const int lowerlevel, const int upperion, int upperlevel_in,
                            std::vector<float>& tmpallphixs, std::vector<PhotoionTarget>& tmpallphixstargets,
-                           size_t* mem_usage_phixs, const int phixs_file_version) {
+                           size_t* mem_usage_phixs, const int phixs_file_version,
+                           const PhixsLevelBuilders& levelbuilders) {
   std::string phixsline;
   const auto phixstargetstart = static_cast<int>(tmpallphixstargets.size());
   const auto lowerionlower_uniquelevelindex = get_uniquelevelindex(element, lowerion, lowerlevel);
-  assert_always(globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
-                globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
-  globals::alllevels.phixstargetstart[lowerionlower_uniquelevelindex] = phixstargetstart;
+  assert_always(levelbuilders.phixstargetstart[lowerionlower_uniquelevelindex] == -1 ||
+                levelbuilders.phixstargetstart[lowerionlower_uniquelevelindex] == phixstargetstart);
+  levelbuilders.phixstargetstart[lowerionlower_uniquelevelindex] = phixstargetstart;
   if (upperlevel_in >= 0) {  // file gives photoionisation to a single target state only
     int upperlevel = upperlevel_in - groundstate_index_in;
     assert_always(upperlevel >= 0);
-    assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
-                  globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 1);
-    globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
+    assert_always(levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
+                  levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] == 1);
+    levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] = 1;
 
     if (SINGLE_LEVEL_TOP_ION && (upperion == get_nions(element) - 1)) {
       // top ion has only one level, so send it to that level
@@ -165,9 +174,9 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
     // read in a table of target states and probabilities and store them
     if (!SINGLE_LEVEL_TOP_ION || upperion < get_nions(element) - 1)  // in case the top ion has nlevelsmax = 1
     {
-      assert_always(globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
-                    globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] == in_nphixstargets);
-      globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
+      assert_always(levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] == 0 ||
+                    levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] == in_nphixstargets);
+      levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] = in_nphixstargets;
 
       double probability_sum = 0.;
       for (int i = 0; i < in_nphixstargets; i++) {
@@ -189,7 +198,7 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
         assert_always(false);
       }
     } else {  // file has table of target states and probabilities but our top ion is limited to one level
-      globals::alllevels.nphixstargets[lowerionlower_uniquelevelindex] = 1;
+      levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] = 1;
 
       for (int i = 0; i < in_nphixstargets; i++) {
         assert_always(get_noncommentline(phixsfile, phixsline));
@@ -202,14 +211,13 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
 
   assert_always(tmpallphixs.size() % globals::NPHIXSPOINTS == 0);
   const auto tmpphixsstart = tmpallphixs.size();
-  globals::alllevels.phixsstart[lowerionlower_uniquelevelindex] =
-      static_cast<int>(tmpphixsstart / globals::NPHIXSPOINTS);
+  levelbuilders.phixsstart[lowerionlower_uniquelevelindex] = static_cast<int>(tmpphixsstart / globals::NPHIXSPOINTS);
   tmpallphixs.resize(tmpallphixs.size() + globals::NPHIXSPOINTS);
 
   const auto levelphixstable = std::span{tmpallphixs}.subspan(tmpphixsstart, globals::NPHIXSPOINTS);
   if (phixs_file_version == 1) {
-    assert_always(get_nphixstargets(element, lowerion, lowerlevel) == 1);
-    assert_always(tmpallphixstargets[get_allphixstargetindex(lowerionlower_uniquelevelindex, 0)].levelindex == 0);
+    assert_always(levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] == 1);
+    assert_always(tmpallphixstargets[levelbuilders.phixstargetstart[lowerionlower_uniquelevelindex]].levelindex == 0);
 
     const double nu_edge = (epsilon(element, upperion, 0) - epsilon(element, lowerion, lowerlevel)) / H;
 
@@ -266,26 +274,28 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
   // upper ion's maxrecombininglevel to cover them. The topmost included ion is skipped because it has no ion
   // above it to recombine into.
   if (lowerion < get_nions(element) - 1) {
-    for (int phixstargetindex = 0; phixstargetindex < get_nphixstargets(element, lowerion, lowerlevel);
+    for (int phixstargetindex = 0; phixstargetindex < levelbuilders.nphixstargets[lowerionlower_uniquelevelindex];
          phixstargetindex++) {
       const int upperlevel =
-          tmpallphixstargets[get_allphixstargetindex(lowerionlower_uniquelevelindex, phixstargetindex)].levelindex;
+          tmpallphixstargets[levelbuilders.phixstargetstart[lowerionlower_uniquelevelindex] + phixstargetindex]
+              .levelindex;
       if (upperlevel > get_maxrecombininglevel(element, lowerion + 1)) {
         globals::elements[element].ions[lowerion + 1].maxrecombininglevel = upperlevel;
       }
     }
   }
 
-  *mem_usage_phixs += (get_nphixstargets(lowerionlower_uniquelevelindex) * sizeof(double)) + sizeof(int);
+  *mem_usage_phixs += (levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] * sizeof(double)) + sizeof(int);
   *mem_usage_phixs += globals::NPHIXSPOINTS * sizeof(float);
-  globals::nbfcontinua += get_nphixstargets(lowerionlower_uniquelevelindex);
-  if (lowerlevel == 0 && get_nphixstargets(lowerionlower_uniquelevelindex) > 0) {
+  globals::nbfcontinua += levelbuilders.nphixstargets[lowerionlower_uniquelevelindex];
+  if (lowerlevel == 0 && levelbuilders.nphixstargets[lowerionlower_uniquelevelindex] > 0) {
     globals::nbfcontinua_ground++;
   }
 }
 
 void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphixs,
-                     std::vector<PhotoionTarget>& tmpallphixstargets, std::vector<int>& ion_minphixslevel_infile) {
+                     std::vector<PhotoionTarget>& tmpallphixstargets, std::vector<int>& ion_minphixslevel_infile,
+                     const PhixsLevelBuilders& levelbuilders) {
   printlnlog("reading phixs data from {}", phixsdata_filenames[phixs_file_version]);
 
   auto phixsfile = fstream_required(phixsdata_filenames[phixs_file_version], std::ios::in);
@@ -362,7 +372,8 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
       // store only photoionisation crosssections for ions that are part of the current model atom
       if (lowerion >= 0 && upperion < get_nions(element) && lowerlevel < get_nlevels_ionising(element, lowerion)) {
         read_phixs_data_table(phixsfile, nphixspoints_inputtable, element, lowerion, lowerlevel, upperion,
-                              upperlevel_in, tmpallphixs, tmpallphixstargets, &mem_usage_phixs, phixs_file_version);
+                              upperlevel_in, tmpallphixs, tmpallphixstargets, &mem_usage_phixs, phixs_file_version,
+                              levelbuilders);
 
         skip_this_phixs_table = false;
       }
@@ -798,6 +809,10 @@ void setup_phixs_list() {
   auto groundcont_element = MPI_shared_array<int>(globals::nbfcontinua_ground);
   auto groundcont_ion = MPI_shared_array<int>(globals::nbfcontinua_ground);
 
+  // node-shared mutable array filled in by the node leaders below, published (move-assigned) into the
+  // read-only member of globals::alllevels once the writes are complete
+  auto alllevels_closestgroundlevelcont = MPI_shared_array<int>(std::ssize(globals::alllevels.epsilon), -1);
+
   if (globals::rank_in_node == 0) {
     int nextgroundcontindex = 0;
     for (int element = 0; element < get_nelements(); element++) {
@@ -864,7 +879,7 @@ void setup_phixs_list() {
           if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
             // depends only on the level, so it is found once here rather than once per target below
             const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
-            globals::alllevels.closestgroundlevelcont[uniquelevelindex] =
+            alllevels_closestgroundlevelcont[uniquelevelindex] =
                 search_groundphixslist(nu_edge_target0, element, ion, level);
           }
 
@@ -875,9 +890,8 @@ void setup_phixs_list() {
             // neither estimator is enabled, so no further guard on those options is needed here.
             // TODO: the estimators are written at this nearest-edge slot but normalised in update_grid.cc
             // at get_groundcontindex(element, ion); the two disagree if two ions share a ground threshold.
-            const int groundcontestimindex = (level == 0 && phixstargetindex == 0)
-                                                 ? globals::alllevels.closestgroundlevelcont[uniquelevelindex]
-                                                 : -1;
+            const int groundcontestimindex =
+                (level == 0 && phixstargetindex == 0) ? alllevels_closestgroundlevelcont[uniquelevelindex] : -1;
 
             allcont[allcontindex] = {
                 .nu_edge = get_phixs_threshold(element, ion, level, phixstargetindex) / H,
@@ -899,6 +913,9 @@ void setup_phixs_list() {
 
     assert_always(allcontindex == globals::nbfcontinua);
   }
+  MPI_Barrier_node();
+  globals::alllevels.closestgroundlevelcont = std::move(alllevels_closestgroundlevelcont);
+
   assert_always(globals::nbfcontinua >= 0);  // was initialised as -1 before startup
   // just so that clang-tidy doesn't throw errors on the assumption that nbfcontinua is changing
   const auto nbfcontinua = globals::nbfcontinua;
@@ -979,22 +996,26 @@ void setup_phixs_list() {
 }
 
 void read_autoion_data() {
+  // node-shared mutable arrays filled in below and then published (move-assigned) into the read-only
+  // members of globals::alllevels. When there is no autoion.txt, the initial values are published as-is
+  const auto uniquelevelcount = std::ssize(globals::alllevels.epsilon);
+  auto alllevels_allautoion_start = MPI_shared_array<int>(uniquelevelcount, -1);
+  auto alllevels_nautoiondowntrans = MPI_shared_array<int>(uniquelevelcount, 0);
+  auto alllevels_nautoionuptrans = MPI_shared_array<int>(uniquelevelcount, 0);
+
   // read in autoionisation rate data
-  if (!std::filesystem::exists("autoion.txt")) {
-    return;
-  }
+  const bool have_autoion_file = std::filesystem::exists("autoion.txt");
 
   std::vector<globals::LevelAutoion> temp_allautoion;
 
   // only the node leaders parse the file, counting transitions into rank-local arrays and publishing them to the
   // node-shared arrays below
-  const auto uniquelevelcount = std::ssize(globals::alllevels.nautoiondowntrans);
   std::vector<int> temp_nautoiondowntrans;
   std::vector<int> temp_nautoionuptrans;
   std::vector<int> temp_allautoion_start;
   ptrdiff_t nautoion_stored = 0;  // for the collective node-shared allocation below
 
-  if (globals::rank_in_node == 0) {
+  if (have_autoion_file && globals::rank_in_node == 0) {
     reserve_resize(temp_nautoiondowntrans, uniquelevelcount);
     std::ranges::fill(temp_nautoiondowntrans, 0);
     reserve_resize(temp_nautoionuptrans, uniquelevelcount);
@@ -1108,11 +1129,14 @@ void read_autoion_data() {
   globals::allautoion = MPI_shared_array<globals::LevelAutoion>(nautoion_stored);
   if (globals::rank_in_node == 0) {
     std::ranges::copy(temp_allautoion, globals::allautoion.begin());
-    std::ranges::copy(temp_nautoiondowntrans, globals::alllevels.nautoiondowntrans.begin());
-    std::ranges::copy(temp_nautoionuptrans, globals::alllevels.nautoionuptrans.begin());
-    std::ranges::copy(temp_allautoion_start, globals::alllevels.allautoion_start.begin());
+    std::ranges::copy(temp_nautoiondowntrans, alllevels_nautoiondowntrans.begin());
+    std::ranges::copy(temp_nautoionuptrans, alllevels_nautoionuptrans.begin());
+    std::ranges::copy(temp_allautoion_start, alllevels_allautoion_start.begin());
   }
   MPI_Barrier_node();
+  globals::alllevels.allautoion_start = std::move(alllevels_allautoion_start);
+  globals::alllevels.nautoiondowntrans = std::move(alllevels_nautoiondowntrans);
+  globals::alllevels.nautoionuptrans = std::move(alllevels_nautoionuptrans);
 
   // Plan is that autoionizing levels will be explicitly included in the NLTE population solver, but that their level
   // populations do not need to be accurately known - so if the ion has a superlevel already, then we will try to attach
@@ -1120,7 +1144,7 @@ void read_autoion_data() {
   // know how many autoionizing levels they have. So count those up now (only the node leaders, since the counts are
   // written to the node-shared ion data).
 
-  if (globals::rank_in_node == 0) {
+  if (have_autoion_file && globals::rank_in_node == 0) {
     int nlevels_autoion_sum = 0;
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);
@@ -1156,6 +1180,17 @@ void read_phixs_data() {
   std::vector<float> tmpallphixs;
   std::vector<PhotoionTarget> tmpallphixstargets;
 
+  // node-shared mutable arrays that the (node-leader-only) file parsing below fills in, published
+  // (move-assigned) into the read-only members of globals::alllevels once the writes are complete
+  const auto uniquelevelcount = std::ssize(globals::alllevels.epsilon);
+  auto alllevels_phixsstart = MPI_shared_array<int>(uniquelevelcount, -1);
+  auto alllevels_nphixstargets = MPI_shared_array<int>(uniquelevelcount, 0);
+  auto alllevels_phixstargetstart = MPI_shared_array<int>(uniquelevelcount, -1);
+  auto alllevels_bflist_start = MPI_shared_array<int>(uniquelevelcount, -1);
+  const auto levelbuilders = PhixsLevelBuilders{.phixsstart = alllevels_phixsstart.span(),
+                                                .nphixstargets = alllevels_nphixstargets.span(),
+                                                .phixstargetstart = alllevels_phixstargetstart.span()};
+
   // read in photoionisation cross sections
   phixs_file_version_exists[0] = false;
   phixs_file_version_exists[1] = std::filesystem::exists(phixsdata_filenames[1]);
@@ -1181,11 +1216,11 @@ void read_phixs_data() {
   // rank-local totals parsed from the files are broadcast within the node below
   if (globals::rank_in_node == 0) {
     if (phixs_file_version_exists[2]) {
-      read_phixs_file(2, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[2]);
+      read_phixs_file(2, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[2], levelbuilders);
     }
 
     if (phixs_file_version_exists[1]) {
-      read_phixs_file(1, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[1]);
+      read_phixs_file(1, tmpallphixs, tmpallphixstargets, ion_minphixslevel_infile[1], levelbuilders);
     }
 
     // every ion with any photoionisation data must include a cross-section from the ground state, so an excited
@@ -1231,6 +1266,11 @@ void read_phixs_data() {
   MPI_Bcast_safe(globals::nbfcontinua_ground, 0, globals::mpi_comm_node);
   MPI_Barrier_node();
 
+  // the node leaders have finished writing the per-level photoionisation arrays, so publish them as read-only
+  globals::alllevels.phixsstart = std::move(alllevels_phixsstart);
+  globals::alllevels.nphixstargets = std::move(alllevels_nphixstargets);
+  globals::alllevels.phixstargetstart = std::move(alllevels_phixstargetstart);
+
   int cont_index = 0;
   ptrdiff_t nbftables = 0;
   for (int element = 0; element < get_nelements(); element++) {
@@ -1241,7 +1281,7 @@ void read_phixs_data() {
         const int nphixstargets = get_nphixstargets(element, ion, level);
         const auto uniquelevelindex = get_uniquelevelindex(element, ion, level);
         if (globals::rank_in_node == 0) {
-          globals::alllevels.bflist_start[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
+          alllevels_bflist_start[uniquelevelindex] = (nphixstargets > 0) ? cont_index : -1;
         }
         cont_index += nphixstargets;
         if (nphixstargets > 0) {
@@ -1253,6 +1293,8 @@ void read_phixs_data() {
   if (globals::rank_in_node == 0) {
     assert_always(cont_index == std::ssize(tmpallphixstargets));
   }
+  MPI_Barrier_node();
+  globals::alllevels.bflist_start = std::move(alllevels_bflist_start);
 
   if (cont_index > 0) {
     // copy the photoionisation tables into one contiguous block of memory
@@ -1523,14 +1565,8 @@ void create_shared_levellist(std::vector<TempEnergyLevel>& temp_alllevels) {
   auto alllevels_epsilon = MPI_shared_array<double>(nlevels);
   auto alllevels_statweight = MPI_shared_array<float>(nlevels);
   auto alllevels_matransblock_start = MPI_shared_array<int>(nlevels);
-  globals::alllevels.allautoion_start = MPI_shared_array<int>(nlevels, -1);
-  globals::alllevels.nautoiondowntrans = MPI_shared_array<int>(nlevels, 0);
-  globals::alllevels.nautoionuptrans = MPI_shared_array<int>(nlevels, 0);
-  globals::alllevels.closestgroundlevelcont = MPI_shared_array<int>(nlevels, -1);
-  globals::alllevels.phixsstart = MPI_shared_array<int>(nlevels, -1);
-  globals::alllevels.nphixstargets = MPI_shared_array<int>(nlevels, 0);
-  globals::alllevels.phixstargetstart = MPI_shared_array<int>(nlevels, -1);
-  globals::alllevels.bflist_start = MPI_shared_array<int>(nlevels, -1);
+  // the remaining members of globals::alllevels (autoion, photoionisation, and bound-free list arrays)
+  // are built and published later, by read_autoion_data(), read_phixs_data(), and setup_phixs_list()
   if (globals::rank_in_node == 0) {
     int chtransindex = 0;
     for (auto i = 0ZU; i < temp_alllevels.size(); i++) {

--- a/input.cc
+++ b/input.cc
@@ -119,7 +119,7 @@ constexpr auto inputlinecomments = std::array{
     "17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.",
     "18: num_lte_timesteps",
     "19: optical_depth_is_thick num_grey_timesteps",
-    "20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)",
+    "20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)",
     "21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.",
     "22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d",
     "23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc",
@@ -2014,11 +2014,18 @@ void read_parameterfile(std::span<Packet> packets) {
       "input: cells with Thomson optical depth > {:g} are treated in grey approximation for the first {} timesteps",
       globals::optical_depth_is_thick, globals::num_grey_timesteps);
 
-  // Limit the number of bf-continua
+  // formerly a limit on the number of bf-continua per ion. Reject any value other than the old
+  // "unlimited" setting rather than silently ignoring a limit that an old input file requests
   assert_always(get_noncommentline(file, line));
   int max_bf_continua = 0;
   std::istringstream{line} >> max_bf_continua;
-  assert_always(max_bf_continua == -1);
+  if (max_bf_continua != -1) {
+    printlnlog(
+        "[error] input.txt line 20 (max_bf_continua) has value {}, but limiting the bound-free continua is no longer "
+        "supported. Set it to -1 (all bf continua included)",
+        max_bf_continua);
+    std::abort();
+  }
 
   // for exspec: read number of MPI tasks
   assert_always(get_noncommentline(file, line));
@@ -2164,6 +2171,14 @@ void read_atomicdata() {
 
   setup_nlte_levels();
 }
+
+// the hybrid timestep schemes switch between logarithmic and fixed-width timesteps at a transition time, so
+// both of those values must be set (the pure schemes ignore them, and the presets ship them as -1.)
+static_assert(TIMESTEP_SIZE_METHOD == TimeStepSizeMethod::LOGARITHMIC ||
+                  TIMESTEP_SIZE_METHOD == TimeStepSizeMethod::CONSTANT ||
+                  (FIXED_TIMESTEP_WIDTH > 0. && TIMESTEP_TRANSITION_TIME > 0.),
+              "The hybrid TIMESTEP_SIZE_METHOD options require FIXED_TIMESTEP_WIDTH and TIMESTEP_TRANSITION_TIME "
+              "(both in days) to be set to positive values");
 
 // initialise the time steps
 void setup_timesteps() {

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -103,7 +103,7 @@ auto calculate_cooling_rates_ion(const int nonemptymgi, const int element, const
       const auto upper_statweight = stat_weight(ionuniquelevelindexstart + upper);
       const double C =
           nnlevel *
-          col_excitation_ratecoeff(T_e, clumpednne, upper_statweight, alltransindex, epsilon_trans, statweight) *
+          col_excitation_ratecoeff(T_e, clumpednne, epsilon_trans, upper_statweight, statweight, alltransindex) *
           epsilon_trans;
       C_ion += C;
       if constexpr (!update_cellcache_contribs) {
@@ -368,7 +368,8 @@ DEVICE_FUNC void calculate_cellcache_cooling_rates_ion(const int nonemptymgi, co
 DEVICE_FUNC void do_kpkt_blackbody(Packet& pkt) {
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.cellindex);
 
-  if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() && grid::thick_allcells[nonemptymgi] != 1) {
+  if (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value() &&
+      grid::thick_allcells[nonemptymgi] != grid::CellThickness::THICK) {
     pkt.nu_cmf = sample_planck_times_expansion_opacity(nonemptymgi, get_rngstate(pkt));
   } else {
     pkt.nu_cmf = sample_planck_montecarlo(grid::Te_allcells[nonemptymgi], get_rngstate(pkt));
@@ -533,7 +534,7 @@ DEVICE_FUNC void do_kpkt(Packet& pkt, const double t2, const int nts) {
       const auto upper_statweight = stat_weight(upperuniquelevelindex);
       const double C =
           nnlevel *
-          col_excitation_ratecoeff(T_e, clumpednne, upper_statweight, alltransindex, epsilon_trans, statweight) *
+          col_excitation_ratecoeff(T_e, clumpednne, epsilon_trans, upper_statweight, statweight, alltransindex) *
           epsilon_trans;
       contrib += C;
       // Strict comparison ensures that a zero target skips leading transitions with zero contribution.

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -74,7 +74,8 @@ THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
   testmodeassert_valid_ion(element, ion);
 
   assert_testmodeonly(!globals::lte_iteration);
-  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);  // should use use phi_lte instead
+  assert_testmodeonly(grid::thick_allcells[nonemptymgi] !=
+                      grid::CellThickness::THICK);  // should use use phi_lte instead
 
   assert_testmodeonly(!elem_has_nlte_levels(element));  // don't use this function if the NLTE solver is active
 
@@ -96,9 +97,10 @@ THREADLOCALONHOST CellWarningMarker ionfract_zeroed_warned;
 
   const double Alpha_sp = get_ion_spontrecombcoeff(uniqueionindex, T_e);
   constexpr bool include_collisional_recombination = false;
-  const double Col_rec = include_collisional_recombination
-                             ? calculate_ionrecombcoeff(nonemptymgi, T_e, element, ion + 1, false, true, false, false)
-                             : 0.;
+  const double Col_rec =
+      include_collisional_recombination
+          ? calculate_ionrecombcoeff(nonemptymgi, T_e, element, ion + 1, {.collisional_not_radiative = true})
+          : 0.;
 
   const double gamma_nt = NT_ON ? nonthermal::nt_ionisation_ratecoeff(nonemptymgi, element, ion) : 0.;
 
@@ -469,7 +471,7 @@ void set_groundlevelpops(const int nonemptymgi, const int element, const float n
 }
 
 auto calculate_ion_balance_nne(const int nonemptymgi) -> void {
-  const bool force_saha = globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1;
+  const bool force_saha = globals::lte_iteration || grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK;
 
   // upper bound on nne: at most one free electron per nucleon, i.e. fully ionised hydrogen
   const double nne_max = grid::get_rho(nonemptymgi) / MH;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -129,7 +129,7 @@ DEVICE_FUNC void calculate_macroatom_transitionrates(std::span<double> levelrate
         nonemptymgi, upper_statweight, alltrans.einstein_A[alltransindex], epsilon_trans, nnlevel,
         get_cellcache_levelpop(nonemptymgi, upper_uniquelevelindex), statweight, alltransindex, t_mid);
     const double C =
-        col_excitation_ratecoeff(T_e, clumpednne, upper_statweight, alltransindex, epsilon_trans, statweight);
+        col_excitation_ratecoeff(T_e, clumpednne, epsilon_trans, upper_statweight, statweight, alltransindex);
     const double NT = nonthermal::nt_excitation_ratecoeff(nonemptymgi, level, upper, alltransindex);
 
     sum_internal_up_same += (R + C + NT) * epsilon_current;
@@ -366,7 +366,8 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
 
   const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
 
-  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);  // macroatom should not be used in thick cells
+  assert_testmodeonly(grid::thick_allcells[nonemptymgi] !=
+                      grid::CellThickness::THICK);  // macroatom should not be used in thick cells
 
   const int element = pktmastate.element;
   int ion = pktmastate.ion;
@@ -748,8 +749,8 @@ void macroatom_open_file() {
 }
 
 [[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(const float T_e, const float clumpednne,
-                                                          const double upperstatweight, const int alltransindex,
-                                                          const double epsilon_trans, const double lowerstatweight)
+                                                          const double epsilon_trans, const double upperstatweight,
+                                                          const double lowerstatweight, const int alltransindex)
     -> double {
   const auto coll_strength = globals::alltrans.coll_str[alltransindex];
   const double eoverkt = epsilon_trans / (KB * T_e);

--- a/macroatom.h
+++ b/macroatom.h
@@ -51,9 +51,10 @@ DEVICE_FUNC void calculate_cellcache_macroatom_transitionrates(int nonemptymgi, 
                                                             int alltransindex) -> double;
 
 // Collisional excitation rate. Multiply by the lower-level population to obtain a rate per second.
-[[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float clumpednne, double upperstatweight,
-                                                          int alltransindex, double epsilon_trans,
-                                                          double lowerstatweight) -> double;
+// (same parameter order as col_deexcitation_ratecoeff)
+[[gnu::pure]] [[nodiscard]] auto col_excitation_ratecoeff(float T_e, float clumpednne, double epsilon_trans,
+                                                          double upperstatweight, double lowerstatweight,
+                                                          int alltransindex) -> double;
 
 // Sobolev-escape radiative deexcitation rate; multiply by the upper-level population to obtain a rate per second.
 // Kromer & Sim (2009), Section 3.5.2, doi:10.1111/j.1365-2966.2009.15256.x.

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -567,7 +567,7 @@ void nltepop_matrix_add_boundbound(const int nonemptymgi, const int element, con
           s_renorm[level];
 
       const double C =
-          col_excitation_ratecoeff(T_e, clumpednne, upper_statweight, alltransindex, epsilon_trans, statweight) *
+          col_excitation_ratecoeff(T_e, clumpednne, epsilon_trans, upper_statweight, statweight, alltransindex) *
           s_renorm[level];
 
       const double NTC =
@@ -1696,7 +1696,8 @@ void nltepop_open_file() {
 
 void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
   const auto modelgridindex = grid::get_mgi_of_nonemptymgi(nonemptymgi);
-  if (globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1) {  // NLTE solver hasn't been run yet
+  if (globals::lte_iteration ||
+      grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {  // NLTE solver hasn't been run yet
     return;
   }
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -1823,8 +1823,8 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
               nnlevel_upper, statweight_lower, alltransindex, t_mid);
 
           const double collexc_ratecoeff =
-              col_excitation_ratecoeff(T_e, grid::get_clumpfactor(nonemptymgi) * nne, statweight_upper, alltransindex,
-                                       epsilon_trans, statweight_lower);
+              col_excitation_ratecoeff(T_e, grid::get_clumpfactor(nonemptymgi) * nne, epsilon_trans, statweight_upper,
+                                       statweight_lower, alltransindex);
 
           const double exc_ratecoeff = radexc_ratecoeff + collexc_ratecoeff + ntcollexc_ratecoeff;
           const auto coll_str = globals::alltrans.coll_str[alltransindex];
@@ -2529,7 +2529,7 @@ DEVICE_FUNC void do_ntlepton_deposit(Packet& pkt) {
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(modelgridindex);
 
   // macroatom should not be activated in thick cells
-  if (NT_ON && NT_SOLVE_SPENCERFANO && grid::thick_allcells[nonemptymgi] != 1) {
+  if (NT_ON && NT_SOLVE_SPENCERFANO && grid::thick_allcells[nonemptymgi] != grid::CellThickness::THICK) {
     // here there is some probability to cause ionisation or excitation to a macroatom packet
     // instead of converting directly to k-packet (unless the heating channel is selected)
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -135,6 +135,13 @@ static_assert(NT_MAX_AUGER_ELECTRONS == 0 || !NT_USE_VALENCE_IONPOTENTIAL,
               "Overriding the shell potential with the valence potential is not compatible with including Auger "
               "electrons, because the shell potential is used to calculate the energy of Auger electrons.");
 
+static_assert(!NT_SOLVE_SPENCERFANO || NT_ON,
+              "NT_SOLVE_SPENCERFANO does nothing without NT_ON, because non-thermal deposition is never handled");
+
+static_assert(!NT_EXCITATION_ON || (NT_ON && NT_SOLVE_SPENCERFANO),
+              "NT_EXCITATION_ON does nothing without NT_ON and NT_SOLVE_SPENCERFANO, because non-thermal excitation "
+              "rates are only calculated from the Spencer-Fano solution");
+
 // energy grid on which solution is sampled [eV]
 constexpr auto engrid(int index) -> double { return SF_EMIN + (index * DELTA_E); }
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -48,6 +48,9 @@ constexpr double bins_T_R_max = 250000;
 static_assert(RADFIELDBINS_T_E_SUPERBIN_NU_MAX >= RADFIELDBINS_NU_MAX,
               "The T_e superbin upper boundary must be greater than or equal to the upper boundary of the other bins");
 
+static_assert(!DETAILED_BF_ESTIMATORS_ON || !USE_LUT_PHOTOION,
+              "USE_LUT_PHOTOION must be false when DETAILED_BF_ESTIMATORS_ON is true");
+
 std::vector<double> J_normfactor;
 
 struct RadFieldBinSolution {

--- a/radfield.cc
+++ b/radfield.cc
@@ -908,7 +908,7 @@ void normalise_bf_estimators(const int nts, const int nts_prev, const int titer,
     const auto bfestimcount = std::ssize(globals::bfestim_nu_edge);
     const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
     for (auto nonemptymgi = 0Z; nonemptymgi < nonempty_npts_model; nonemptymgi++) {
-      if (grid::thick_allcells[nonemptymgi] == 1) {
+      if (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {
         continue;
       }
       const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);

--- a/ratecoeff.cc
+++ b/ratecoeff.cc
@@ -336,12 +336,9 @@ void read_recombrate_file() {
         const double input_rrc_low_n = std::lerp(T_highestbelow.rrc_low_n, T_lowestabove.rrc_low_n, x);
         const double input_rrc_total = std::lerp(T_highestbelow.rrc_total, T_lowestabove.rrc_total, x);
 
-        constexpr bool assume_lte = true;
-        constexpr bool per_groundmultipletpop = true;
-        constexpr bool collisional_not_radiative = false;
+        constexpr auto rrc_options = IonRecombCoeffOptions{.assume_lte = true, .per_groundmultipletpop = true};
 
-        double rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative,
-                                              false, per_groundmultipletpop);
+        double rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, rrc_options);
         printlnlog("    rrc (initial): {:10.3e} [cm^3/s]", rrc);
 
         if (!(rrc > 0.)) {
@@ -364,8 +361,7 @@ void read_recombrate_file() {
 
             scale_levels(0, phixs_multiplier);
 
-            rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
-                                           per_groundmultipletpop);
+            rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, rrc_options);
             printlnlog("    rrc (after low-n scaling): {:10.3e} [cm^3/s]", rrc);
           }
         }
@@ -384,7 +380,8 @@ void read_recombrate_file() {
           printlnlog("    input_rrc_total is negative, so not scaling to the total recombination rate");
         } else if (rrc < input_rrc_total) {
           const double rrc_superlevel = calculate_ionrecombcoeff(
-              -1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, true, per_groundmultipletpop);
+              -1, Te_estimate, element, ion,
+              {.assume_lte = true, .lower_superlevel_only = true, .per_groundmultipletpop = true});
           printlnlog("  rrc(superlevel): {:10.3e} [cm^3/s]", rrc_superlevel);
 
           if (rrc_superlevel > 0) {
@@ -408,8 +405,7 @@ void read_recombrate_file() {
           scale_levels(0, phixs_multiplier);
         }
 
-        rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, assume_lte, collisional_not_radiative, false,
-                                       per_groundmultipletpop);
+        rrc = calculate_ionrecombcoeff(-1, Te_estimate, element, ion, rrc_options);
         printlnlog("    rrc (final): {:10.3e} [cm^3/s]", rrc);
       }
     }
@@ -653,8 +649,8 @@ DEVICE_FUNC auto select_continuum_nu(int element, const int lowerion, const int 
 
 // multiply by upper ion population (or ground population if per_groundmultipletpop is true) and nne to get a rate
 auto calculate_ionrecombcoeff(const int nonemptymgi, const float T_e, const int element, const int upperion,
-                              const bool assume_lte, const bool collisional_not_radiative,
-                              const bool lower_superlevel_only, const bool per_groundmultipletpop) -> double {
+                              const IonRecombCoeffOptions options) -> double {
+  const auto [assume_lte, collisional_not_radiative, lower_superlevel_only, per_groundmultipletpop] = options;
   if (upperion <= 0) {
     return 0.;
   }

--- a/ratecoeff.h
+++ b/ratecoeff.h
@@ -28,9 +28,17 @@ void setup_photoion_luts();
 [[nodiscard]] auto calculate_iongamma_per_ionpop(int nonemptymgi, int element, int lowerion,
                                                  bool collisional_not_radiative, bool force_bfintegral) -> double;
 
-[[nodiscard]] auto calculate_ionrecombcoeff(int nonemptymgi, float T_e, int element, int upperion, bool assume_lte,
-                                            bool collisional_not_radiative, bool lower_superlevel_only,
-                                            bool per_groundmultipletpop) -> double;
+struct IonRecombCoeffOptions {
+  bool assume_lte = false;
+  bool collisional_not_radiative = false;
+  bool lower_superlevel_only = false;
+  bool per_groundmultipletpop = false;
+};
+
+// pass nonemptymgi = -1 (no cell) with options.assume_lte = true for the startup recombination-rate calibration,
+// which uses LTE populations at the given temperature instead of a cell's solved populations
+[[nodiscard]] auto calculate_ionrecombcoeff(int nonemptymgi, float T_e, int element, int upperion,
+                                            IonRecombCoeffOptions options) -> double;
 
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_ion_spontrecombcoeff(int uniqueionindex, float T_e) -> double;
 

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -568,7 +568,7 @@ auto do_rpkt_step(Packet& pkt, const double t2, ContinuumOpacity& chi_rpkt_cont)
   // Get distance to the next physical event (continuum or bound-bound)
   double edist = -1;
   bool event_is_boundbound = true;
-  const bool thickcell = (nonemptymgi >= 0) && (grid::thick_allcells[nonemptymgi] == 1);
+  const bool thickcell = (nonemptymgi >= 0) && (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK);
   if (nonemptymgi < 0) {
     // for empty cells no physical event occurs. The packets just propagate.
     edist = std::numeric_limits<double>::max();
@@ -1019,7 +1019,7 @@ DEVICE_FUNC void emit_rpkt(Packet& pkt) {
 
 template <bool USECELLHISTANDUPDATEPHIXSLIST>
 void calculate_chi_rpkt_cont(const double nu_cmf, ContinuumOpacity& chi_rpkt_cont, const int nonemptymgi) {
-  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != 1);
+  assert_testmodeonly(grid::thick_allcells[nonemptymgi] != grid::CellThickness::THICK);
   if ((nonemptymgi == chi_rpkt_cont.nonemptymgi) && (globals::timestep == chi_rpkt_cont.timestep) &&
       (fabs((chi_rpkt_cont.nu / nu_cmf) - 1.0) < 1e-4)) {
     // calculated values are a match already

--- a/scripts/artis-cosma8.sh
+++ b/scripts/artis-cosma8.sh
@@ -53,8 +53,10 @@ if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
     sbatch -J artis_$(basename $(pwd)) ./artis/scripts/artis-cosma8.sh
     # sbatch $SLURM_JOB_NAME
-fi
-
-if [ -f packets00_0000.out ]; then
-    sbatch -J exspec_$(basename $(pwd)) ./artis/scripts/exspec-zip-cosma8.sh
+else
+    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
+    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    if [ -f packets00_0000.out ]; then
+        sbatch -J exspec_$(basename $(pwd)) ./artis/scripts/exspec-zip-cosma8.sh
+    fi
 fi

--- a/scripts/artis-juwels.sh
+++ b/scripts/artis-juwels.sh
@@ -36,8 +36,10 @@ echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
     sbatch --job-name="$SLURM_JOB_NAME" ./artis/scripts/artis-juwels.sh
-fi
-
-if [ -f packets00_0000.out ]; then
-    sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-juwels.sh
+else
+    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
+    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    if [ -f packets00_0000.out ]; then
+        sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-juwels.sh
+    fi
 fi

--- a/scripts/artis-kelvin2.sh
+++ b/scripts/artis-kelvin2.sh
@@ -33,8 +33,10 @@ if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
     sbatch ./artis/scripts/artis-kelvin2.sh
     # sbatch $SLURM_JOB_NAME
-fi
-
-if [ -f packets00_0000.out ]; then
-    sbatch ./artis/scripts/exspec-zip-kelvin2.sh
+else
+    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
+    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    if [ -f packets00_0000.out ]; then
+        sbatch ./artis/scripts/exspec-zip-kelvin2.sh
+    fi
 fi

--- a/scripts/artis-meluxina.sh
+++ b/scripts/artis-meluxina.sh
@@ -41,8 +41,10 @@ echo "ntasks: $SLURM_NTASKS -> CPU core hrs: $cpuhrs"
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
     sbatch --job-name="$SLURM_JOB_NAME" ./artis/scripts/artis-meluxina.sh
-fi
-
-if [ -f packets00_0000.out ]; then
-    sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-meluxina.sh
+else
+    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
+    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    if [ -f packets00_0000.out ]; then
+        sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-meluxina.sh
+    fi
 fi

--- a/scripts/mergeangleres.py
+++ b/scripts/mergeangleres.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import re
 from pathlib import Path
 
 
@@ -7,7 +8,18 @@ def resfilepath(basefolder: Path | str, fileprefix: str, abin: int) -> Path:
     return Path(basefolder, f"{fileprefix}_res_{abin:02d}.out")
 
 
+def get_mabins() -> int:
+    # one output file is written per direction bin (MABINS = NPHIBINS * NCOSTHETABINS in exspec.h).
+    # Parse the expected count from the source folder that this script belongs to, so that a changed
+    # bin count cannot silently break the merge. Counting the files on disk instead would treat the
+    # contiguous prefix left behind by an interrupted exspec run as a complete set
+    exspec_h = (Path(__file__).resolve().parent.parent / "exspec.h").read_text(encoding="utf-8")
+    bincounts = {name: int(value) for name, value in re.findall(r"constexpr int (NPHIBINS|NCOSTHETABINS) = (\d+);", exspec_h)}
+    return bincounts["NPHIBINS"] * bincounts["NCOSTHETABINS"]
+
+
 def main() -> None:
+    mabins = get_mabins()
     for basefolder in [Path(), Path("speclc_angle_res")]:
         if not basefolder.is_dir():
             continue
@@ -15,11 +27,8 @@ def main() -> None:
             if not resfilepath(basefolder, fileprefix, 0).is_file():
                 continue
 
-            # one file per direction bin (MABINS in exspec.h). Detect the bin count from the files on
-            # disk rather than hardcoding it, so a changed bin count cannot silently break the merge
-            files_present = sorted(basefolder.glob(f"{fileprefix}_res_*.out"))
-            input_files = [resfilepath(basefolder, fileprefix, abin) for abin in range(len(files_present))]
-            if files_present == input_files and all(input_file.stat().st_size > 0 for input_file in input_files):
+            input_files = [resfilepath(basefolder, fileprefix, abin) for abin in range(mabins)]
+            if all(input_file.is_file() and input_file.stat().st_size > 0 for input_file in input_files):
                 outfile = Path(f"{fileprefix}_res.out")
                 outfile.unlink(missing_ok=True)
                 Path(f"{fileprefix}_res.out.zst").unlink(missing_ok=True)

--- a/scripts/mergeangleres.py
+++ b/scripts/mergeangleres.py
@@ -15,8 +15,11 @@ def main() -> None:
             if not resfilepath(basefolder, fileprefix, 0).is_file():
                 continue
 
-            input_files = [resfilepath(basefolder, fileprefix, abin) for abin in range(100)]
-            if all(input_file.is_file() and input_file.stat().st_size > 0 for input_file in input_files):
+            # one file per direction bin (MABINS in exspec.h). Detect the bin count from the files on
+            # disk rather than hardcoding it, so a changed bin count cannot silently break the merge
+            files_present = sorted(basefolder.glob(f"{fileprefix}_res_*.out"))
+            input_files = [resfilepath(basefolder, fileprefix, abin) for abin in range(len(files_present))]
+            if files_present == input_files and all(input_file.stat().st_size > 0 for input_file in input_files):
                 outfile = Path(f"{fileprefix}_res.out")
                 outfile.unlink(missing_ok=True)
                 Path(f"{fileprefix}_res.out.zst").unlink(missing_ok=True)

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -924,9 +924,6 @@ void print_options_help(std::FILE* stream, const char* progname) {
 auto main(int argc, char* argv[]) -> int {
   real_time_start = std::chrono::steady_clock::now();
 
-  // if DETAILED_BF_ESTIMATORS_ON is true, USE_LUT_PHOTOION must be false
-  assert_always(!DETAILED_BF_ESTIMATORS_ON || !USE_LUT_PHOTOION);
-
   if constexpr (VPKT_ON) {
     vpkt::nvpkt_created = 0;
     vpkt::nvpkt_esc_from_rpkt = 0;
@@ -938,11 +935,7 @@ auto main(int argc, char* argv[]) -> int {
 
   globals::setup_mpi_vars();
 
-#ifdef WALLTIMELIMITSECONDS
-  int walltimelimitseconds = WALLTIMELIMITSECONDS;
-#else
   int walltimelimitseconds = -1;
-#endif
 
   std::string walltimehours_str;
   int opt = 0;

--- a/tests/classicmode_1d_3dgrid_inputfiles/input-newrun.txt
+++ b/tests/classicmode_1d_3dgrid_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 5                        # 18: num_lte_timesteps
 8.0 999                  # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/classicmode_1d_3dgrid_inputfiles/input-newrun.txt
+++ b/tests/classicmode_1d_3dgrid_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 5                        # 18: num_lte_timesteps
 8.0 999                  # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+-1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/classicmode_3d_inputfiles/input-newrun.txt
+++ b/tests/classicmode_3d_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 5                        # 18: num_lte_timesteps
 3.0 999                  # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/classicmode_3d_inputfiles/input-newrun.txt
+++ b/tests/classicmode_3d_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 5                        # 18: num_lte_timesteps
 3.0 999                  # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+-1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/kilonova_1d_inputfiles/input-newrun.txt
+++ b/tests/kilonova_1d_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 999                      # 18: num_lte_timesteps
 0.0 5                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+-1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/kilonova_1d_inputfiles/input-newrun.txt
+++ b/tests/kilonova_1d_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 999                      # 18: num_lte_timesteps
 0.0 5                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/kilonova_2d_inputfiles/input-newrun.txt
+++ b/tests/kilonova_2d_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 999                      # 18: num_lte_timesteps
 0.0 5                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+-1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/kilonova_2d_inputfiles/input-newrun.txt
+++ b/tests/kilonova_2d_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 999                      # 18: num_lte_timesteps
 0.0 5                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/nebular_1d_3dgrid_inputfiles/input-newrun.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 4                        # 18: num_lte_timesteps
 0.0 4                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+-1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/nebular_1d_3dgrid_inputfiles/input-newrun.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 4                        # 18: num_lte_timesteps
 0.0 4                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/input-newrun.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 3                        # 18: num_lte_timesteps
 8.0 2                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+-1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/input-newrun.txt
+++ b/tests/nltephotospheric_dynamic_ion_range_1d_1dgrid_inputfiles/input-newrun.txt
@@ -18,7 +18,7 @@
 1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
 3                        # 18: num_lte_timesteps
 8.0 2                    # 19: optical_depth_is_thick num_grey_timesteps
--1                       # 20: UNUSED max_bf_continua: must be -1 (all bound-free continua are included)
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
 4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
 1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
 0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -51,7 +51,7 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
              mgi, titer, grid::TR_allcells[nonemptymgi], T_e, grid::W_allcells[nonemptymgi],
              grid::TJ_allcells[nonemptymgi]);
   std::println(estimators_file, " grey_depth {:g} thick {} nne {:g} Ye {:g} tdays {:7.2f}",
-               grid::grey_depth_allcells[nonemptymgi], grid::thick_allcells[nonemptymgi], nne, Y_e,
+               grid::grey_depth_allcells[nonemptymgi], static_cast<int>(grid::thick_allcells[nonemptymgi]), nne, Y_e,
                globals::timesteps[timestep].mid / DAY);
 
   if (globals::total_nlte_levels > 0) {
@@ -433,15 +433,15 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
     // W == 1 indicates that this modelgrid cell was treated grey in the
     // last timestep. Therefore it has no valid Gamma estimators and must be treated in LTE at restart.
-    if (grid::thick_allcells[nonemptymgi] != 1 && grid::W_allcells[nonemptymgi] == 1) {
+    if (grid::thick_allcells[nonemptymgi] != grid::CellThickness::THICK && grid::W_allcells[nonemptymgi] == 1) {
       printlnlog(
           "force modelgrid cell {} to grey/LTE thick = 1 for update grid since existing W == 1. (will not have gamma "
           "estimators)",
           mgi);
-      grid::thick_allcells[nonemptymgi] = 1;
+      grid::thick_allcells[nonemptymgi] = grid::CellThickness::THICK;
     }
 
-    printlnlog("mgi {} thick: {} (during grid update)", mgi, grid::thick_allcells[nonemptymgi]);
+    printlnlog("mgi {} thick: {} (during grid update)", mgi, static_cast<int>(grid::thick_allcells[nonemptymgi]));
 
     for (int element = 0; element < get_nelements(); element++) {
       calculate_cellpartfuncts(nonemptymgi, element);
@@ -468,7 +468,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 #endif
 
     // lte_iteration really means either ts 0 or nts < globals::num_lte_timesteps
-    if (globals::lte_iteration || grid::thick_allcells[nonemptymgi] == 1) {
+    if (globals::lte_iteration || grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {
       // LTE mode or grey mode (where temperature doesn't matter but is calculated anyway)
 
       const auto T_J = radfield::get_T_J_from_J(nonemptymgi);
@@ -557,14 +557,14 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
   if ((grey_optical_depth >= globals::optical_depth_is_thick) && (nts < globals::num_grey_timesteps)) {
     printlnlog("timestep {} cell {} is treated in grey approximation (chi_grey {:g} [cm2/g], tau {:g} >= {:g})", nts,
                mgi, grid::kappagrey_allcells[nonemptymgi], grey_optical_depth, globals::optical_depth_is_thick);
-    grid::thick_allcells[nonemptymgi] = 1;
+    grid::thick_allcells[nonemptymgi] = grid::CellThickness::THICK;
   } else if (VPKT_ON && (grey_optical_depth > vpkt::optical_depth_is_thick_vpkt)) {
-    grid::thick_allcells[nonemptymgi] = 2;
+    grid::thick_allcells[nonemptymgi] = grid::CellThickness::THICK_VPKT_ONLY;
   } else {
-    grid::thick_allcells[nonemptymgi] = 0;
+    grid::thick_allcells[nonemptymgi] = grid::CellThickness::THIN;
   }
 
-  if (grid::thick_allcells[nonemptymgi] == 1) {
+  if (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {
     // cooling rates calculation can be skipped for thick cells
     // flag with negative numbers to indicate that the rates are invalid
     const auto ioncooling_contribs = kpkt::get_cell_ion_cooling_contribs(nonemptymgi);
@@ -592,7 +592,7 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
 
   if constexpr (RPKT_USE_EXPANSION_OPACITIES || VPKT_USE_EXPANSION_OPACITIES ||
                 RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
-    if (grid::thick_allcells[nonemptymgi] != 1) {
+    if (grid::thick_allcells[nonemptymgi] != grid::CellThickness::THICK) {
       calculate_expansion_opacities(nonemptymgi);
     }
   }

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -296,7 +296,8 @@ void do_packet(Packet& pkt, const double t2, const int nts, ContinuumOpacity& ch
     case TYPE_KPKT: {
       const int nonemptymgi = grid::get_propcell_nonemptymgi(pkt.cellindex);
       assert_testmodeonly(nonemptymgi >= 0);  // k-packets can only exist in non-empty cells
-      if (grid::thick_allcells[nonemptymgi] == 1 || RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
+      if (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK ||
+          RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
         kpkt::do_kpkt_blackbody(pkt);
       } else {
         kpkt::do_kpkt(pkt, t2, nts);
@@ -347,7 +348,7 @@ auto get_packet_cellcachegroupid(const Packet& pkt) -> std::optional<int> {
     return std::nullopt;  // for empty cell, no cell cache required
   }
   const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
-  if (grid::thick_allcells[nonemptymgi] == 1) {
+  if (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {
     return std::nullopt;  // for thick cell, no cell cache required
   }
   if (!cellcache_singleslot) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -434,7 +434,7 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
         const auto nonemptymgi = grid::get_nonemptymgi_of_mgi(mgi);
 
         // kill vpkt with pass through a thick cell
-        if (grid::thick_allcells[nonemptymgi] != 0) {
+        if (grid::thick_allcells[nonemptymgi] != grid::CellThickness::THIN) {
           return false;
         }
       }
@@ -949,7 +949,7 @@ auto trace_vpkts(const Packet& pkt, const enum packet_type type_before_rpkt) -> 
   // Cut on vpkts
   const auto nonemptymgi = grid::get_propcell_nonemptymgi(pkt.cellindex);
 
-  if (grid::thick_allcells[nonemptymgi] != 0) {
+  if (grid::thick_allcells[nonemptymgi] != grid::CellThickness::THIN) {
     return;
   }
 

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -44,6 +44,8 @@ namespace {
 static_assert(!VPKT_ON || POL_ON,
               "POL_ON must be true if VPKT_ON is true because vpkt needs stokes parameters to be tracked");
 
+static_assert(!VPKT_WRITE_CONTRIBS || VPKT_ON, "VPKT_WRITE_CONTRIBS does nothing without VPKT_ON");
+
 struct StokesParams {
   double I = 0.;
   double Q = 0.;


### PR DESCRIPTION
This PR implements a set of usability and misuse-resistance improvements from a review of the build system, CI, input handling, and internal APIs. Every change is either behaviour-neutral (verified, see below) or converts a silent failure into a loud one.

## Build system and CI

- **Fail early with an actionable message when `artisoptions.h` is missing.** Previously a missing preset selection produced a `no such file` error from every translation unit interleaved across parallel jobs (surfacing hours later inside batch jobs); `make sn3dwhole` failed with an even more opaque "No rule to make target". `make clean` is exempt so a fresh clone can still be cleaned.
- **Include `MAX_NODE_SIZE` in the build directory name.** It was the only option that changes `CXXFLAGS` without changing `BUILD_DIR`, so switching it silently reused objects compiled with the old value — and touching one source in between produced mixed objects, an ODR violation on the inline `setup_mpi_vars()` that consumes the macro. This is exactly the flag the docs say to pass when reproducing CI checksums.
- **Warn when `artisoptions.h` is a symlink but make was started without `--check-symlink-times`** (condensed to `L` in `MAKEFLAGS`). Without it, a preset switch via `ln -sf` can leave the previous preset's binary looking up to date. This advice previously lived only in a Makefile comment and `scripts/aliases.sh`.
- **Actually compile the remaining `artisoptions_*.h` presets in CI.** The "Compile all remaining option files" loops copied each preset with `cp -p`, preserving the checkout-time mtime — older than the objects built moments earlier — so make skipped the build and the presets other than classic and nltenebular were never compiled, despite the docs claiming full coverage. Both the Linux and macOS jobs had the bug.

## Cluster job scripts

- **Queue exspec only when the simulation is finished.** Four of the five cluster scripts submitted the exspec job in parallel with resubmitting an unfinished simulation; `exspec-after.sh` deletes the `packets_*.tmp`/`gridsave_*.tmp` restart files, so post-processing could destroy the restart files of the queued continuation job. All scripts now use the if/else structure that `artis-virgo-slurmjob.sh` already had.
- **`mergeangleres.py` no longer hardcodes 100 direction bins** (which had to match `MABINS` in exspec.h, or the merge silently did nothing). The bin count is detected from the files on disk, and missing/empty files still fail loudly.

## Input validation (previously silent failure modes)

- **model.txt**: reject a non-positive cell count and a non-positive snapshot time. A failed extraction stores zero, and `t_model = 0` previously passed every assert and scaled all densities by `(t_model/tmin)^3 = 0` — an empty model with no error.
- **Ye**: reject electron fractions outside [0, 1], matching the checks the other composition setters already had.
- **input.txt line 20 (`max_bf_continua`)** is now genuinely ignored like the other unused lines (it previously had to be exactly -1, contradicting its UNUSED label).

## Compile-time enforcement of documented option constraints

Now that CI compiles every preset, prose-documented constraints become `static_assert`s enforced for free:

- `DETAILED_BF_ESTIMATORS_ON` with `USE_LUT_PHOTOION` was asserted inside sn3d's `main()`, so exspec and unittests never checked it.
- `USE_MODEL_INITIAL_ENERGY` without `INITIAL_PACKETS_ON` silently discarded the `q` column of model.txt. The nltenebular preset had exactly this inert combination, so its `USE_MODEL_INITIAL_ENERGY` is set to false (no behaviour change).
- `NT_SOLVE_SPENCERFANO`/`NT_EXCITATION_ON` without `NT_ON`, and `VPKT_WRITE_CONTRIBS` without `VPKT_ON`, were silently inert.
- The hybrid `TIMESTEP_SIZE_METHOD` options previously aborted at runtime — after minutes of atomic-data loading — when `FIXED_TIMESTEP_WIDTH`/`TIMESTEP_TRANSITION_TIME` were left at the presets' -1 placeholders.

## API misuse-resistance (all behaviour-neutral)

- **`col_excitation_ratecoeff()` now takes its parameters in the same order as its detailed-balance partner `col_deexcitation_ratecoeff()`.** The pair previously permuted four parameters relative to each other and was called two lines apart, inviting silent transposition of the two statistical weights.
- **`calculate_ionrecombcoeff()`'s four adjacent bool parameters** (called as `(..., false, true, false, false)`) are now a named options struct filled with designated initializers, and the `nonemptymgi = -1` calibration sentinel is documented.
- **The tri-state cell optical-thickness flag** (magic 0/1/2 in an `int` array, compared at 26 sites across 12 files) is now the scoped enum `grid::CellThickness`. Numeric values are unchanged and still written as integers to the estimators and gridsave files.
- **The remaining mutable members of `globals::alllevels`** (autoionisation, photoionisation, and bound-free list arrays) are now `MPI_shared_array<const int>`, built in mutable locals during input and move-published once complete — the pattern the other alllevels members already used. They were previously writable by any code for the whole simulation.

## Documentation

README now documents `sn3d -w` and the RESTART_NEEDED resubmission mechanism, marks `abundances.txt` as required, notes that `clean.sh` does not remove `-o` job folders, and uses the same compiledb invocation as `.clangd` and CI. The never-defined `WALLTIMELIMITSECONDS` macro is removed.

## Verification

- All six presets compile with gcc 14 (`-Werror`); unit tests pass for the classic (87/87) and nebular (86/86) presets.
- **No stored checksums need regeneration**: the kilonova_1d test was run end-to-end (sn3d 4 ranks + exspec, `REPRODUCIBLE=ON MAX_NODE_SIZE=2 FASTMATH=OFF`) with binaries built before and after the API/refactor commits, twice (once for the argument-order/options-struct/enum commit, once for the alllevels const-ification) — all 23 output files are bit-identical in both comparisons.
- The Makefile guard and warning were tested across flag/symlink/goal combinations, and `mergeangleres.py` against complete, gappy, and non-default bin-count file sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo)_