### PR TITLE
Stop the endless resubmission of jobs that completed a partial timestep range

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ These files go in the simulation folder, which should always contain the ARTIS s
 Run-time configuration with:
 - the random number seed, which must be a fixed value for reproducible runs
 - number of timesteps
-- the first and last timestep of this job, so that a long simulation can be split over several resubmitted jobs
+- the first and last timestep of this job. Normally the last timestep should be set to the number of timesteps: long simulations are split over resubmitted jobs by the wall-time mechanism (sn3d -w), which advances the start timestep on each restart but never the last one. Setting an earlier last timestep makes the simulation stop there (e.g. to inspect or post-process partial results) until input.txt is edited to continue
 - the start and end time in days
 - whether the run continues from the restart files of a previous job
 - number of pure LTE timesteps

--- a/input.cc
+++ b/input.cc
@@ -1958,6 +1958,12 @@ void read_parameterfile(std::span<Packet> packets) {
   std::istringstream{line} >> globals::timestep_initial >>
       globals::timestep_finish;  // number of start and end time step
   printlnlog("input: timestep_start {} timestep_finish {}", globals::timestep_initial, globals::timestep_finish);
+  if (globals::timestep_finish < globals::ntimesteps) {
+    printlnlog(
+        "input: note that the simulation will stop after timestep {}, before the final timestep {}. Restarts advance "
+        "the start timestep but never timestep_finish, so continuing past it will require editing input.txt",
+        globals::timestep_finish - 1, globals::ntimesteps - 1);
+  }
   assert_always(globals::timestep_initial < globals::ntimesteps);
   assert_always(globals::timestep_initial <= globals::timestep_finish);
   assert_always(globals::timestep_finish <= globals::ntimesteps);

--- a/scripts/exspec-after.sh
+++ b/scripts/exspec-after.sh
@@ -2,7 +2,14 @@
 
 # only compress the files if we successfully ran exspec
 if [[ -f emission.out || -f emission.out.zst || -f emissionpol.out ]]; then
-  rm packets_*.tmp gridsave_*.tmp vspecpol_*.tmp vpkt_grid_*.tmp
+  # remove the restart files only when the simulation has completed all of its timesteps. After a run
+  # that deliberately stopped at an earlier timestep_finish, they are needed to continue the model
+  # (when in doubt, e.g. if the log is unavailable, keep them: they can always be deleted manually)
+  if grep -qs "No need for restart" output_0-0.txt; then
+    rm -f packets_*.tmp gridsave_*.tmp vspecpol_*.tmp vpkt_grid_*.tmp
+  else
+    echo "The simulation has not completed all of its timesteps, so keeping the restart files"
+  fi
 
   mkdir -p speclc_angle_res
   mv *_res_*.out* speclc_angle_res/ || true

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -1189,8 +1189,18 @@ auto main(int argc, char* argv[]) -> int {
 
   MPI_Barrier_allranks();
 
-  if ((globals::ntimesteps > globals::timestep_finish) || terminate_early) {
+  if (terminate_early) {
     printlnlog("RESTART_NEEDED to continue model");
+  } else if (globals::ntimesteps > globals::timestep_finish) {
+    // The requested timestep range is complete but the model has not reached the last timestep. A restart with
+    // an unchanged input.txt could only redo the final saved timestep, because update_parameterfile() advances
+    // the start timestep but never timestep_finish. So deliberately do not print RESTART_NEEDED here: the
+    // cluster job scripts detect that marker to resubmit a continuation job, and before this case was
+    // separated from terminate_early, they resubmitted identical no-progress jobs forever
+    printlnlog(
+        "Completed the requested timestep range, but the model has only run {} of {} timesteps. To continue the "
+        "model, increase timestep_finish in input.txt and resubmit",
+        globals::timestep_finish, globals::ntimesteps);
   } else {
     printlnlog("No need for restart");
   }


### PR DESCRIPTION
Fixes the infinite-resubmission loop that occurs when `timestep_finish` is set below `ntimesteps` and a cluster job script is in use.

## The loop

1. A job completes its requested range `[timestep_start, timestep_finish)`. Its last restart-file write (at the start of the final timestep) rewrote input.txt to `timestep_finish - 1, timestep_finish` — `update_parameterfile()` advances the start timestep but never `timestep_finish`.
2. Because `ntimesteps > timestep_finish`, the run printed `RESTART_NEEDED to continue model`, which the cluster scripts (`artis-cosma8.sh` etc.) grep for and resubmit.
3. The resubmitted job resumes at `timestep_finish - 1`, redoes that single already-completed timestep, and stops. Since it starts at its own `timestep_initial`, it never calls `save_grid_and_packets()`, so input.txt is not rewritten.
4. It prints `RESTART_NEEDED` again → identical no-progress jobs are submitted forever, burning allocation one redundant timestep at a time.

## The fix

`RESTART_NEEDED` is now printed only when a restart can actually make progress, i.e. on early termination from the wall-time limit (`sn3d -w`), where input.txt has been rewritten to a later start point. When the requested range completes short of `ntimesteps`, the run instead prints an explanatory message telling the user to increase `timestep_finish` — and deliberately not the marker, so the job scripts stop resubmitting. With the script fix from #526, they will instead start post-processing of the partial results, which is the sensible outcome of a deliberate early stop.

Supporting changes:

- **`exspec-after.sh` keeps the restart files unless the simulation is complete.** Since post-processing now runs after a partial range, its cleanup would have deleted the `packets_*.tmp`/`gridsave_*.tmp` files that the new message tells the user they can resume from (caught by the automated review). The restart files are removed only when the sn3d log shows the model completed all of its timesteps; when the log says otherwise or is unavailable, they are kept — they can be deleted manually but not recovered.
- At startup, when `timestep_finish < ntimesteps`, a note in the log says the simulation will stop early and that restarts never advance `timestep_finish`.
- The README description of the timestep range (which actively encouraged the dangerous configuration: "so that a long simulation can be split over several resubmitted jobs") now explains that splitting over jobs is done by the wall-time mechanism, and that an early `timestep_finish` is a deliberate stop that requires editing input.txt to continue.

No output file changes; only log text and the script. The only consumers of `RESTART_NEEDED` are the five cluster scripts' greps, and CI does not use it.

## Verification

Reproduced the scenario with the kilonova_1d test (`ntimesteps = 20`, requested range `000 009`):

- Job 1 (fresh run): completes timesteps 0–8, prints the new "Completed the requested timestep range, but the model has only run 9 of 20 timesteps..." message, and does not print `RESTART_NEEDED`.
- Job 2 (resubmission simulation: rerun with the input.txt that job 1 rewrote): resumes from the gridsave, redoes the final timestep, and also prints the message without `RESTART_NEEDED` — so a job-script loop terminates at the first resubmission it would previously have made, and prior to this change both jobs printed `RESTART_NEEDED`.
- The wall-time path is unchanged: `terminate_early` still prints `RESTART_NEEDED`.
- The `exspec-after.sh` guard was tested in all three states: complete run (restart files removed), partial range (kept, with a message), and missing log (kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo