### PR TITLE
Track header dependencies on nvhpc builds too

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -182,8 +182,7 @@ jobs:
 
             - name: Compile all remaining option files
               run: |
-                  # no -p here: a preserved (checkout-time) mtime would be older than the objects built in the
-                  # previous steps, so make would consider everything up to date and skip compiling the preset
+                  # no -p: a preserved (older) mtime would make the preset build look already up to date
                   for file in $(find . -name "artisoptions_*.h" ! -name "artisoptions_classic.h" ! -name "artisoptions_nltenebular.h"); do
                       cp -v "$file" artisoptions.h
                       make -j$(nproc) sn3d
@@ -266,8 +265,7 @@ jobs:
 
             - name: LLVM Clang Compile all remaining option files
               run: |
-                  # no -p here: a preserved (checkout-time) mtime would be older than the objects built in the
-                  # previous steps, so make would consider everything up to date and skip compiling the preset
+                  # no -p: a preserved (older) mtime would make the preset build look already up to date
                   for file in $(find . -name "artisoptions_*.h" ! -name "artisoptions_classic.h" ! -name "artisoptions_nltenebular.h"); do
                       cp -v "$file" artisoptions.h
                       make -j$(nproc) sn3d

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,14 @@ BUILD_DIR = build/$(COMPILER_NAME)-$(COMPILER_VERSION_NUMBER)_$(CPU_ARCH)
 
 CXXFLAGS += -std=$(CXX_STD) $(ARCH_FLAGS) -Wall -Wextra -Wpedantic -Wredundant-decls -Wno-unused-parameter -Wsign-compare -Wshadow -isystem third_party
 
+# generate and use .d header dependency files, so that edits to any included header (e.g. artisoptions.h
+# through the symlink) trigger recompilation of the objects that include it. These must apply to every
+# compiler: nvc++ supports the same GCC-style dependency options, and excluding it here previously meant
+# that header edits did not rebuild anything on nvhpc builds
+CXXFLAGS += -MD -MP
+
 ifneq ($(COMPILER_NAME),nvhpc)
-	CXXFLAGS += -Wunused-macros -Werror -Wextra-semi -Wno-unknown-pragmas -Wno-error=cast-function-type -MD -MP -Wno-unused-function
+	CXXFLAGS += -Wunused-macros -Werror -Wextra-semi -Wno-unknown-pragmas -Wno-error=cast-function-type -Wno-unused-function
 endif
 
 ifeq ($(REPRODUCIBLE),ON)
@@ -330,7 +336,9 @@ $(info build directory: $(BUILD_DIR))
 
 all: sn3d exspec
 
-$(BUILD_DIR)/%.o: %.cc Makefile
+# artisoptions.h is an explicit prerequisite (not only via the generated .d files) so that the most
+# consequential header dependency does not rely on the dependency generation of any one compiler
+$(BUILD_DIR)/%.o: %.cc artisoptions.h Makefile
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 check: $(sn3d_files)

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,14 @@
 # export MAKEFLAGS="--check-symlink-times --jobs=$(nproc --all)"
 .DEFAULT_GOAL := all
 
-# artisoptions.h is gitignored and must be supplied before building (normally a symlink to one of the
-# artisoptions_*.h presets). Check for it up front, so that a missing file gives one actionable message
-# instead of a 'no such file' error from every translation unit, interleaved across parallel jobs.
-# 'make clean' is exempt, so that a tree without artisoptions.h can still be cleaned.
+# artisoptions.h is gitignored and must be supplied (normally as a symlink to a preset). Check up front
+# to give one actionable message rather than a compiler error per translation unit. 'make clean' is exempt
 ifneq ($(strip $(filter-out clean,$(if $(MAKECMDGOALS),$(MAKECMDGOALS),all))),)
   ifeq ($(wildcard artisoptions.h),)
     $(error artisoptions.h not found. Select a compile-time option preset, e.g. 'ln -s artisoptions_classic.h artisoptions.h'. Symlinking (rather than copying) keeps it in sync when the preset changes. The options are documented in artisoptions_doc.md)
   endif
-  # Without --check-symlink-times, make compares timestamps through the symlink, so switching presets
-  # with 'ln -sf' can leave a build silently up to date with the previous preset's options. The flag is
-  # condensed into the letter 'L' in the first (dashless) word of MAKEFLAGS.
+  # without --check-symlink-times ('L' in the first dashless word of MAKEFLAGS), make compares timestamps
+  # through the symlink, so a preset switch via ln -sf may not trigger a rebuild
   ifneq ($(shell test -L artisoptions.h && echo is_symlink),)
     ifeq (,$(findstring L,$(filter-out -%,$(firstword $(MAKEFLAGS)))))
       $(warning artisoptions.h is a symlink, but make was started without --check-symlink-times: switching presets with ln -sf may not trigger a rebuild. Recommended: export MAKEFLAGS="--check-symlink-times --jobs=$$(nproc --all)")
@@ -103,10 +100,8 @@ BUILD_DIR = build/$(COMPILER_NAME)-$(COMPILER_VERSION_NUMBER)_$(CPU_ARCH)
 
 CXXFLAGS += -std=$(CXX_STD) $(ARCH_FLAGS) -Wall -Wextra -Wpedantic -Wredundant-decls -Wno-unused-parameter -Wsign-compare -Wshadow -isystem third_party
 
-# generate and use .d header dependency files, so that edits to any included header (e.g. artisoptions.h
-# through the symlink) trigger recompilation of the objects that include it. These must apply to every
-# compiler: nvc++ supports the same GCC-style dependency options, and excluding it here previously meant
-# that header edits did not rebuild anything on nvhpc builds
+# generate and use .d header dependency files, so that header edits trigger recompilation of the
+# objects that include them (every compiler, including nvc++, supports these GCC-style options)
 CXXFLAGS += -MD -MP
 
 ifneq ($(COMPILER_NAME),nvhpc)
@@ -213,8 +208,7 @@ endif
 
 ifneq ($(MAX_NODE_SIZE),)
 	CXXFLAGS += -DMAX_NODE_SIZE=$(MAX_NODE_SIZE)
-	# like every other option that changes CXXFLAGS, this must go into the build directory name, or
-	# changing it would reuse (or worse, mix with) objects compiled with a different node size
+	# must be in the build directory name like every other option that changes CXXFLAGS
 	BUILD_DIR := $(BUILD_DIR)_maxnodesize$(MAX_NODE_SIZE)
 endif
 
@@ -336,8 +330,7 @@ $(info build directory: $(BUILD_DIR))
 
 all: sn3d exspec
 
-# artisoptions.h is an explicit prerequisite (not only via the generated .d files) so that the most
-# consequential header dependency does not rely on the dependency generation of any one compiler
+# artisoptions.h is explicit so the most consequential header dependency does not rely on .d generation
 $(BUILD_DIR)/%.o: %.cc artisoptions.h Makefile
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 

--- a/grid.cc
+++ b/grid.cc
@@ -1930,7 +1930,7 @@ void read_ejecta_model() {
   double t_model_days{NAN};
   assert_always(get_noncommentline(fmodel, line));
   std::istringstream{line} >> t_model_days;
-  // a failed extraction stores zero, which would silently scale all densities by (t_model / tmin)^3 = 0
+  // a failed extraction stores zero, which would zero all densities via the (t_model / tmin)^3 scaling
   if (!std::isfinite(t_model_days) || t_model_days <= 0.) {
     printlnlog("[error] model.txt: could not read a positive snapshot time in days from line '{}'", line);
     std::abort();

--- a/grid.h
+++ b/grid.h
@@ -25,8 +25,7 @@ inline MPI_shared_array<float> nne_allcells;
 inline MPI_shared_array<float> nnetot_allcells;  // total electron density (free + bound).
 inline MPI_shared_array<float> kappagrey_allcells;
 inline MPI_shared_array<float> grey_depth_allcells;  // Grey optical depth to surface of the modelgridcell
-// optical-thickness treatment of a cell. The numeric values appear in the estimators and gridsave
-// files, so they must not be renumbered
+// optical-thickness treatment of a cell. Do not renumber: the values appear in the estimators and gridsave files
 enum class CellThickness : int {
   THIN = 0,  // detailed opacity treatment
   THICK = 1,  // optically thick: grey opacity treatment

--- a/input.cc
+++ b/input.cc
@@ -99,7 +99,7 @@ struct TempLineTransitionInput {
 };
 
 // mutable views of the per-level photoionisation arrays while read_phixs_data() builds them, before
-// they are published (move-assigned) into the read-only node-shared members of globals::alllevels
+// they are published into the read-only members of globals::alllevels
 struct PhixsLevelBuilders {
   std::span<int> phixsstart;
   std::span<int> nphixstargets;
@@ -809,8 +809,7 @@ void setup_phixs_list() {
   auto groundcont_element = MPI_shared_array<int>(globals::nbfcontinua_ground);
   auto groundcont_ion = MPI_shared_array<int>(globals::nbfcontinua_ground);
 
-  // node-shared mutable array filled in by the node leaders below, published (move-assigned) into the
-  // read-only member of globals::alllevels once the writes are complete
+  // filled in by the node leaders below, then published as a read-only globals::alllevels member
   auto alllevels_closestgroundlevelcont = MPI_shared_array<int>(std::ssize(globals::alllevels.epsilon), -1);
 
   if (globals::rank_in_node == 0) {
@@ -996,8 +995,8 @@ void setup_phixs_list() {
 }
 
 void read_autoion_data() {
-  // node-shared mutable arrays filled in below and then published (move-assigned) into the read-only
-  // members of globals::alllevels. When there is no autoion.txt, the initial values are published as-is
+  // filled in below and published as read-only globals::alllevels members (with no autoion.txt, the
+  // initial values are published as-is)
   const auto uniquelevelcount = std::ssize(globals::alllevels.epsilon);
   auto alllevels_allautoion_start = MPI_shared_array<int>(uniquelevelcount, -1);
   auto alllevels_nautoiondowntrans = MPI_shared_array<int>(uniquelevelcount, 0);
@@ -1180,8 +1179,7 @@ void read_phixs_data() {
   std::vector<float> tmpallphixs;
   std::vector<PhotoionTarget> tmpallphixstargets;
 
-  // node-shared mutable arrays that the (node-leader-only) file parsing below fills in, published
-  // (move-assigned) into the read-only members of globals::alllevels once the writes are complete
+  // filled in by the node-leader-only parsing below, then published as read-only globals::alllevels members
   const auto uniquelevelcount = std::ssize(globals::alllevels.epsilon);
   auto alllevels_phixsstart = MPI_shared_array<int>(uniquelevelcount, -1);
   auto alllevels_nphixstargets = MPI_shared_array<int>(uniquelevelcount, 0);
@@ -1266,7 +1264,7 @@ void read_phixs_data() {
   MPI_Bcast_safe(globals::nbfcontinua_ground, 0, globals::mpi_comm_node);
   MPI_Barrier_node();
 
-  // the node leaders have finished writing the per-level photoionisation arrays, so publish them as read-only
+  // the writes are complete, so publish as read-only
   globals::alllevels.phixsstart = std::move(alllevels_phixsstart);
   globals::alllevels.nphixstargets = std::move(alllevels_nphixstargets);
   globals::alllevels.phixstargetstart = std::move(alllevels_phixstargetstart);
@@ -1565,8 +1563,8 @@ void create_shared_levellist(std::vector<TempEnergyLevel>& temp_alllevels) {
   auto alllevels_epsilon = MPI_shared_array<double>(nlevels);
   auto alllevels_statweight = MPI_shared_array<float>(nlevels);
   auto alllevels_matransblock_start = MPI_shared_array<int>(nlevels);
-  // the remaining members of globals::alllevels (autoion, photoionisation, and bound-free list arrays)
-  // are built and published later, by read_autoion_data(), read_phixs_data(), and setup_phixs_list()
+  // the remaining alllevels members are built and published by read_autoion_data(), read_phixs_data(),
+  // and setup_phixs_list()
   if (globals::rank_in_node == 0) {
     int chtransindex = 0;
     for (auto i = 0ZU; i < temp_alllevels.size(); i++) {
@@ -2203,8 +2201,7 @@ void read_atomicdata() {
   setup_nlte_levels();
 }
 
-// the hybrid timestep schemes switch between logarithmic and fixed-width timesteps at a transition time, so
-// both of those values must be set (the pure schemes ignore them, and the presets ship them as -1.)
+// the pure timestep schemes ignore these two values, and the presets ship them as -1.
 static_assert(TIMESTEP_SIZE_METHOD == TimeStepSizeMethod::LOGARITHMIC ||
                   TIMESTEP_SIZE_METHOD == TimeStepSizeMethod::CONSTANT ||
                   (FIXED_TIMESTEP_WIDTH > 0. && TIMESTEP_TRANSITION_TIME > 0.),

--- a/ratecoeff.h
+++ b/ratecoeff.h
@@ -35,8 +35,8 @@ struct IonRecombCoeffOptions {
   bool per_groundmultipletpop = false;
 };
 
-// pass nonemptymgi = -1 (no cell) with options.assume_lte = true for the startup recombination-rate calibration,
-// which uses LTE populations at the given temperature instead of a cell's solved populations
+// nonemptymgi = -1 (no cell) with options.assume_lte = true is used by the startup recombination-rate
+// calibration, which takes LTE populations at the given temperature
 [[nodiscard]] auto calculate_ionrecombcoeff(int nonemptymgi, float T_e, int element, int upperion,
                                             IonRecombCoeffOptions options) -> double;
 

--- a/scripts/artis-cosma8.sh
+++ b/scripts/artis-cosma8.sh
@@ -54,8 +54,7 @@ then
     sbatch -J artis_$(basename $(pwd)) ./artis/scripts/artis-cosma8.sh
     # sbatch $SLURM_JOB_NAME
 else
-    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
-    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    # post-processing can remove restart files, so only queue it when no continuation job was submitted
     if [ -f packets00_0000.out ]; then
         sbatch -J exspec_$(basename $(pwd)) ./artis/scripts/exspec-zip-cosma8.sh
     fi

--- a/scripts/artis-juwels.sh
+++ b/scripts/artis-juwels.sh
@@ -37,8 +37,7 @@ if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
     sbatch --job-name="$SLURM_JOB_NAME" ./artis/scripts/artis-juwels.sh
 else
-    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
-    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    # post-processing can remove restart files, so only queue it when no continuation job was submitted
     if [ -f packets00_0000.out ]; then
         sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-juwels.sh
     fi

--- a/scripts/artis-kelvin2.sh
+++ b/scripts/artis-kelvin2.sh
@@ -34,8 +34,7 @@ then
     sbatch ./artis/scripts/artis-kelvin2.sh
     # sbatch $SLURM_JOB_NAME
 else
-    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
-    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    # post-processing can remove restart files, so only queue it when no continuation job was submitted
     if [ -f packets00_0000.out ]; then
         sbatch ./artis/scripts/exspec-zip-kelvin2.sh
     fi

--- a/scripts/artis-meluxina.sh
+++ b/scripts/artis-meluxina.sh
@@ -42,8 +42,7 @@ if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
     sbatch --job-name="$SLURM_JOB_NAME" ./artis/scripts/artis-meluxina.sh
 else
-    # only start post-processing when the simulation is finished: exspec-after.sh deletes the
-    # packets_*.tmp/gridsave_*.tmp restart files that a queued continuation job would need
+    # post-processing can remove restart files, so only queue it when no continuation job was submitted
     if [ -f packets00_0000.out ]; then
         sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-meluxina.sh
     fi

--- a/scripts/exspec-after.sh
+++ b/scripts/exspec-after.sh
@@ -2,9 +2,8 @@
 
 # only compress the files if we successfully ran exspec
 if [[ -f emission.out || -f emission.out.zst || -f emissionpol.out ]]; then
-  # remove the restart files only when the simulation has completed all of its timesteps. After a run
-  # that deliberately stopped at an earlier timestep_finish, they are needed to continue the model
-  # (when in doubt, e.g. if the log is unavailable, keep them: they can always be deleted manually)
+  # keep the restart files unless the simulation has completed all of its timesteps: a run stopped
+  # at an earlier timestep_finish needs them to continue
   if grep -qs "No need for restart" output_0-0.txt; then
     rm -f packets_*.tmp gridsave_*.tmp vspecpol_*.tmp vpkt_grid_*.tmp
   else

--- a/scripts/mergeangleres.py
+++ b/scripts/mergeangleres.py
@@ -9,10 +9,8 @@ def resfilepath(basefolder: Path | str, fileprefix: str, abin: int) -> Path:
 
 
 def get_mabins() -> int:
-    # one output file is written per direction bin (MABINS = NPHIBINS * NCOSTHETABINS in exspec.h).
-    # Parse the expected count from the source folder that this script belongs to, so that a changed
-    # bin count cannot silently break the merge. Counting the files on disk instead would treat the
-    # contiguous prefix left behind by an interrupted exspec run as a complete set
+    # one output file per direction bin (MABINS = NPHIBINS * NCOSTHETABINS), with the expected count
+    # parsed from the exspec.h of the source folder that this script belongs to
     exspec_h = (Path(__file__).resolve().parent.parent / "exspec.h").read_text(encoding="utf-8")
     bincounts = {name: int(value) for name, value in re.findall(r"constexpr int (NPHIBINS|NCOSTHETABINS) = (\d+);", exspec_h)}
     return bincounts["NPHIBINS"] * bincounts["NCOSTHETABINS"]

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -1192,11 +1192,9 @@ auto main(int argc, char* argv[]) -> int {
   if (terminate_early) {
     printlnlog("RESTART_NEEDED to continue model");
   } else if (globals::ntimesteps > globals::timestep_finish) {
-    // The requested timestep range is complete but the model has not reached the last timestep. A restart with
-    // an unchanged input.txt could only redo the final saved timestep, because update_parameterfile() advances
-    // the start timestep but never timestep_finish. So deliberately do not print RESTART_NEEDED here: the
-    // cluster job scripts detect that marker to resubmit a continuation job, and before this case was
-    // separated from terminate_early, they resubmitted identical no-progress jobs forever
+    // the requested range is complete, and a restart with an unchanged input.txt cannot progress
+    // (update_parameterfile() never advances timestep_finish). Do not print RESTART_NEEDED, which the
+    // cluster job scripts detect to resubmit a continuation job
     printlnlog(
         "Completed the requested timestep range, but the model has only run {} of {} timesteps. To continue the "
         "model, increase timestep_finish in input.txt and resubmit",


### PR DESCRIPTION
The `-MD -MP` flags that generate the `.d` header dependency files were bundled into the same Makefile line as the warning flags that nvc++ doesn't get:

```make
ifneq ($(COMPILER_NAME),nvhpc)
	CXXFLAGS += -Wunused-macros -Werror ... -MD -MP -Wno-unused-function
endif
```

So nvhpc builds had no header dependency tracking at all — the `-include $(sn3d_dep)` lines included nothing. Editing any header, **including switching `artisoptions.h` to a different preset**, did not trigger a rebuild, silently leaving a binary compiled with the old physics options. Since nvhpc is the GPU path, GPU users were the ones most exposed.

## Changes

- `-MD -MP` moves out of the compiler guard and applies to every compiler; nvc++ supports the same GCC-style dependency-file options. The warning flags and `-Werror` stay gcc/clang/hipcc-only, unchanged.
- `artisoptions.h` becomes an explicit prerequisite of the object pattern rule, so the most consequential header dependency holds even if a compiler's dependency generation ever misbehaves (the whole-program `sn3dwhole` target already listed it, which made the two paths inconsistent).

## Verification

With gcc 14 locally:
- Full build clean; `.d` files generated for all objects.
- Touching the preset through the `artisoptions.h` symlink → all 21 sn3d translation units rebuild.
- Touching a single header (`rpkt.h`) → only its 11 includers rebuild.
- A no-op build recompiles nothing, so the explicit prerequisite introduces no spurious rebuilds.

The nvc++ path can't be tested in my environment; the NVIDIA NVHPC container job in CI exercises it on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo)_