### PR TITLE
Unit-test the input parsing, timestep grid, and output-file matching helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ It writes light_curve.out, spec.out, emission.out, emissiontrue.out, and absorpt
 To plot and analyse the output, use [artistools](https://github.com/artis-mcrt/artistools), a companion Python package for working with ARTIS light curves, spectra, and estimators.
 
 ### Testing
+Unit tests for the pure numeric and parsing helpers are built and run with `make unittests && ./unittests` (CI runs them for the classic and NLTE nebular presets).
+
 The tests folder contains ten small end-to-end test models. Each tests/setup_*.sh script downloads the atomic data it needs and assembles a folder that is ready to run:
 ```sh
 cd tests

--- a/input.cc
+++ b/input.cc
@@ -2208,64 +2208,63 @@ static_assert(TIMESTEP_SIZE_METHOD == TimeStepSizeMethod::LOGARITHMIC ||
               "The hybrid TIMESTEP_SIZE_METHOD options require FIXED_TIMESTEP_WIDTH and TIMESTEP_TRANSITION_TIME "
               "(both in days) to be set to positive values");
 
-// initialise the time steps
-void setup_timesteps() {
-  // t=globals::tmin is the start of the calculation. t=globals::tmax is the end of the calculation.
-  // globals::ntimesteps is the number of time steps
+// calculate the timestep grid: ntimesteps entries with start, mid, and width set, plus a zero-width
+// entry holding the end time. tmin and tmax are in seconds; the fixed width and transition time of the
+// hybrid methods are in days
+auto calculate_timesteps(const TimeStepSizeMethod method, const double tmin, const double tmax, const int ntimesteps,
+                         const double fixed_timestep_width_days, const double timestep_transition_time_days)
+    -> std::vector<globals::TimeStep> {
+  auto timesteps = std::vector<globals::TimeStep>(ntimesteps + 1);
 
-  globals::timesteps.resize(globals::ntimesteps + 1);
-
-  // Now set the individual time steps
-  switch (TIMESTEP_SIZE_METHOD) {
+  switch (method) {
     case TimeStepSizeMethod::LOGARITHMIC: {
-      for (int n = 0; n < globals::ntimesteps; n++) {  // For logarithmic steps, the logarithmic interval will be
-        const double dlogt = (log(globals::tmax) - log(globals::tmin)) / globals::ntimesteps;
-        globals::timesteps[n].start = globals::tmin * exp(n * dlogt);
-        globals::timesteps[n].mid = globals::tmin * exp((n + 0.5) * dlogt);
-        globals::timesteps[n].width = (globals::tmin * exp((n + 1) * dlogt)) - globals::timesteps[n].start;
+      for (int n = 0; n < ntimesteps; n++) {  // For logarithmic steps, the logarithmic interval will be
+        const double dlogt = (log(tmax) - log(tmin)) / ntimesteps;
+        timesteps[n].start = tmin * exp(n * dlogt);
+        timesteps[n].mid = tmin * exp((n + 0.5) * dlogt);
+        timesteps[n].width = (tmin * exp((n + 1) * dlogt)) - timesteps[n].start;
       }
       break;
     }
 
     case TimeStepSizeMethod::CONSTANT: {
-      for (int n = 0; n < globals::ntimesteps; n++) {
+      for (int n = 0; n < ntimesteps; n++) {
         // for constant timesteps
-        const double dt = (globals::tmax - globals::tmin) / globals::ntimesteps;
-        globals::timesteps[n].start = globals::tmin + (n * dt);
-        globals::timesteps[n].width = dt;
-        globals::timesteps[n].mid = globals::timesteps[n].start + (0.5 * globals::timesteps[n].width);
+        const double dt = (tmax - tmin) / ntimesteps;
+        timesteps[n].start = tmin + (n * dt);
+        timesteps[n].width = dt;
+        timesteps[n].mid = timesteps[n].start + (0.5 * timesteps[n].width);
       }
       break;
     }
 
     case TimeStepSizeMethod::LOGARITHMIC_THEN_CONSTANT: {
       // First part log, second part fixed timesteps
-      const double t_transition = TIMESTEP_TRANSITION_TIME * DAY;  // transition from logarithmic to fixed timesteps
-      const double maxtsdelta = FIXED_TIMESTEP_WIDTH * DAY;  // maximum timestep width in fixed part
-      assert_always(t_transition > globals::tmin);
-      assert_always(t_transition < globals::tmax);
-      const int nts_fixed = ceil((globals::tmax - t_transition) / maxtsdelta);
-      const double fixed_tsdelta = (globals::tmax - t_transition) / nts_fixed;
+      const double t_transition = timestep_transition_time_days * DAY;  // transition from log to fixed timesteps
+      const double maxtsdelta = fixed_timestep_width_days * DAY;  // maximum timestep width in fixed part
+      assert_always(t_transition > tmin);
+      assert_always(t_transition < tmax);
+      const int nts_fixed = ceil((tmax - t_transition) / maxtsdelta);
+      const double fixed_tsdelta = (tmax - t_transition) / nts_fixed;
       assert_always(nts_fixed > 0);
-      assert_always(nts_fixed < globals::ntimesteps);
-      const int nts_log = globals::ntimesteps - nts_fixed;
+      assert_always(nts_fixed < ntimesteps);
+      const int nts_log = ntimesteps - nts_fixed;
       assert_always(nts_log > 0);
-      assert_always(nts_log < globals::ntimesteps);
-      assert_always((nts_log + nts_fixed) == globals::ntimesteps);
-      for (int n = 0; n < globals::ntimesteps; n++) {
+      assert_always(nts_log < ntimesteps);
+      assert_always((nts_log + nts_fixed) == ntimesteps);
+      for (int n = 0; n < ntimesteps; n++) {
         if (n < nts_log) {
           // For logarithmic steps, the logarithmic interval will be
-          const double dlogt = (log(t_transition) - log(globals::tmin)) / nts_log;
-          globals::timesteps[n].start = globals::tmin * exp(n * dlogt);
-          globals::timesteps[n].mid = globals::tmin * exp((n + 0.5) * dlogt);
-          globals::timesteps[n].width = (globals::tmin * exp((n + 1) * dlogt)) - globals::timesteps[n].start;
+          const double dlogt = (log(t_transition) - log(tmin)) / nts_log;
+          timesteps[n].start = tmin * exp(n * dlogt);
+          timesteps[n].mid = tmin * exp((n + 0.5) * dlogt);
+          timesteps[n].width = (tmin * exp((n + 1) * dlogt)) - timesteps[n].start;
         } else {
           // for constant timesteps
-          const double prev_start =
-              n > 0 ? (globals::timesteps[n - 1].start + globals::timesteps[n - 1].width) : globals::tmin;
-          globals::timesteps[n].start = prev_start;
-          globals::timesteps[n].width = fixed_tsdelta;
-          globals::timesteps[n].mid = globals::timesteps[n].start + (0.5 * globals::timesteps[n].width);
+          const double prev_start = n > 0 ? (timesteps[n - 1].start + timesteps[n - 1].width) : tmin;
+          timesteps[n].start = prev_start;
+          timesteps[n].width = fixed_tsdelta;
+          timesteps[n].mid = timesteps[n].start + (0.5 * timesteps[n].width);
         }
       }
       break;
@@ -2273,32 +2272,31 @@ void setup_timesteps() {
 
     case TimeStepSizeMethod::CONSTANT_THEN_LOGARITHMIC: {
       // First part fixed timesteps, second part log timesteps
-      const double t_transition = TIMESTEP_TRANSITION_TIME * DAY;  // transition from fixed to logarithmic timesteps
-      const double maxtsdelta = FIXED_TIMESTEP_WIDTH * DAY;  // timestep width of fixed timesteps
-      assert_always(t_transition > globals::tmin);
-      assert_always(t_transition < globals::tmax);
-      const int nts_fixed = ceil((t_transition - globals::tmin) / maxtsdelta);
-      const double fixed_tsdelta = (t_transition - globals::tmin) / nts_fixed;
+      const double t_transition = timestep_transition_time_days * DAY;  // transition from fixed to log timesteps
+      const double maxtsdelta = fixed_timestep_width_days * DAY;  // timestep width of fixed timesteps
+      assert_always(t_transition > tmin);
+      assert_always(t_transition < tmax);
+      const int nts_fixed = ceil((t_transition - tmin) / maxtsdelta);
+      const double fixed_tsdelta = (t_transition - tmin) / nts_fixed;
       assert_always(nts_fixed > 0);
-      assert_always(nts_fixed < globals::ntimesteps);
-      const int nts_log = globals::ntimesteps - nts_fixed;
+      assert_always(nts_fixed < ntimesteps);
+      const int nts_log = ntimesteps - nts_fixed;
       assert_always(nts_log > 0);
-      assert_always(nts_log < globals::ntimesteps);
-      assert_always((nts_log + nts_fixed) == globals::ntimesteps);
-      for (int n = 0; n < globals::ntimesteps; n++) {
+      assert_always(nts_log < ntimesteps);
+      assert_always((nts_log + nts_fixed) == ntimesteps);
+      for (int n = 0; n < ntimesteps; n++) {
         if (n < nts_fixed) {
           // for constant timesteps
-          globals::timesteps[n].start = globals::tmin + (n * fixed_tsdelta);
-          globals::timesteps[n].width = fixed_tsdelta;
-          globals::timesteps[n].mid = globals::timesteps[n].start + (0.5 * globals::timesteps[n].width);
+          timesteps[n].start = tmin + (n * fixed_tsdelta);
+          timesteps[n].width = fixed_tsdelta;
+          timesteps[n].mid = timesteps[n].start + (0.5 * timesteps[n].width);
         } else {
           // For logarithmic time steps, the logarithmic interval will be
-          const double dlogt = (log(globals::tmax) - log(t_transition)) / nts_log;
-          const double prev_start =
-              n > 0 ? (globals::timesteps[n - 1].start + globals::timesteps[n - 1].width) : globals::tmin;
-          globals::timesteps[n].start = prev_start;
-          globals::timesteps[n].width = (t_transition * exp((n - nts_fixed + 1) * dlogt)) - globals::timesteps[n].start;
-          globals::timesteps[n].mid = globals::timesteps[n].start + (0.5 * globals::timesteps[n].width);
+          const double dlogt = (log(tmax) - log(t_transition)) / nts_log;
+          const double prev_start = n > 0 ? (timesteps[n - 1].start + timesteps[n - 1].width) : tmin;
+          timesteps[n].start = prev_start;
+          timesteps[n].width = (t_transition * exp((n - nts_fixed + 1) * dlogt)) - timesteps[n].start;
+          timesteps[n].mid = timesteps[n].start + (0.5 * timesteps[n].width);
         }
       }
       break;
@@ -2310,18 +2308,28 @@ void setup_timesteps() {
 
   // and add a dummy timestep which contains the endtime
   // of the calculation
-  globals::timesteps[globals::ntimesteps].start = globals::tmax;
-  globals::timesteps[globals::ntimesteps].mid = globals::tmax;
-  globals::timesteps[globals::ntimesteps].width = 0.;
+  timesteps[ntimesteps].start = tmax;
+  timesteps[ntimesteps].mid = tmax;
+  timesteps[ntimesteps].width = 0.;
 
   // check consistency of start + width = start_next
-  for (int n = 1; n < globals::ntimesteps; n++) {
-    const auto tsprev_end = globals::timesteps[n - 1].start + globals::timesteps[n - 1].width;
-    assert_always(fabs((tsprev_end / globals::timesteps[n].start) - 1.) < 0.001);
+  for (int n = 1; n < ntimesteps; n++) {
+    const auto tsprev_end = timesteps[n - 1].start + timesteps[n - 1].width;
+    assert_always(fabs((tsprev_end / timesteps[n].start) - 1.) < 0.001);
   }
-  const auto tsfinal_end =
-      globals::timesteps[globals::ntimesteps - 1].start + globals::timesteps[globals::ntimesteps - 1].width;
-  assert_always(fabs((tsfinal_end / globals::tmax) - 1.) < 0.001);
+  const auto tsfinal_end = timesteps[ntimesteps - 1].start + timesteps[ntimesteps - 1].width;
+  assert_always(fabs((tsfinal_end / tmax) - 1.) < 0.001);
+
+  return timesteps;
+}
+
+// initialise the time steps
+void setup_timesteps() {
+  // t=globals::tmin is the start of the calculation. t=globals::tmax is the end of the calculation.
+  // globals::ntimesteps is the number of time steps
+
+  globals::timesteps = calculate_timesteps(TIMESTEP_SIZE_METHOD, globals::tmin, globals::tmax, globals::ntimesteps,
+                                           FIXED_TIMESTEP_WIDTH, TIMESTEP_TRANSITION_TIME);
 
   const auto* const method_name = [] {
     switch (TIMESTEP_SIZE_METHOD) {

--- a/input.h
+++ b/input.h
@@ -15,13 +15,23 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <vector>
 
+#include "constants.h"
+#include "globals.h"
 #include "packet.h"
 
 void read_atomicdata();
 void read_parameterfile(std::span<Packet> packets);
 void update_parameterfile(int nts);
 void setup_timesteps();
+
+// calculate the timestep grid: ntimesteps entries with start, mid, and width set, plus a zero-width
+// entry holding the end time. tmin and tmax are in seconds; the fixed width and transition time of the
+// hybrid methods are in days
+[[nodiscard]] auto calculate_timesteps(TimeStepSizeMethod method, double tmin, double tmax, int ntimesteps,
+                                       double fixed_timestep_width_days, double timestep_transition_time_days)
+    -> std::vector<globals::TimeStep>;
 
 // return true for whitespace-only lines, and lines that are exclusively whitespace up to a '#' character
 [[nodiscard]] constexpr auto lineiscommentonly(const std::string_view line) -> bool {

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -509,6 +509,39 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
                                           : std::format("{}/{}", globals::runoutputfolder, filename);
 }
 
+// exactly match the generated per-rank output filenames: output_<rank>-<thread>.txt and the
+// estimators/nlte/radfield/macroatom _<rank>.out files, possibly with a compression extension added by
+// the post-processing scripts (e.g. exspec-after.sh runs zstd)
+[[nodiscard]] inline auto is_rank_outfile_name(std::string_view filename) -> bool {
+  const auto alldigits = [](const std::string_view str) {
+    return !str.empty() && std::ranges::all_of(str, [](const char c) { return c >= '0' && c <= '9'; });
+  };
+
+  for (const std::string_view compressext : {".zst", ".gz", ".xz"}) {
+    if (filename.ends_with(compressext)) {
+      filename.remove_suffix(compressext.size());
+      break;
+    }
+  }
+
+  if (constexpr std::string_view logprefix = "output_"; filename.starts_with(logprefix) && filename.ends_with(".txt")) {
+    const auto rank_thread = filename.substr(logprefix.size(), filename.size() - logprefix.size() - 4);
+    const auto dashpos = rank_thread.find('-');
+    return dashpos != std::string_view::npos && alldigits(rank_thread.substr(0, dashpos)) &&
+           alldigits(rank_thread.substr(dashpos + 1));
+  }
+
+  if (filename.ends_with(".out")) {
+    for (const std::string_view prefix : {"estimators_", "nlte_", "radfield_", "macroatom_"}) {
+      if (filename.starts_with(prefix)) {
+        return alldigits(filename.substr(prefix.size(), filename.size() - prefix.size() - 4));
+      }
+    }
+  }
+
+  return false;
+}
+
 [[nodiscard]] inline auto fopen_required(const std::string& filename, std::span<const char> mode) -> FILE* {
   if (mode[0] == 'r') {
     // search data folders in order to find file to read

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -831,39 +831,6 @@ auto do_timestep(const int nts, const int titer, std::vector<Packet>& packets, c
   return !do_this_full_loop;
 }
 
-// exactly match the generated per-rank output filenames: output_<rank>-<thread>.txt and the
-// estimators/nlte/radfield/macroatom _<rank>.out files, possibly with a compression extension added by
-// the post-processing scripts (e.g. exspec-after.sh runs zstd)
-[[nodiscard]] auto is_rank_outfile_name(std::string_view filename) -> bool {
-  const auto alldigits = [](const std::string_view str) {
-    return !str.empty() && std::ranges::all_of(str, [](const char c) { return c >= '0' && c <= '9'; });
-  };
-
-  for (const std::string_view compressext : {".zst", ".gz", ".xz"}) {
-    if (filename.ends_with(compressext)) {
-      filename.remove_suffix(compressext.size());
-      break;
-    }
-  }
-
-  if (constexpr std::string_view logprefix = "output_"; filename.starts_with(logprefix) && filename.ends_with(".txt")) {
-    const auto rank_thread = filename.substr(logprefix.size(), filename.size() - logprefix.size() - 4);
-    const auto dashpos = rank_thread.find('-');
-    return dashpos != std::string_view::npos && alldigits(rank_thread.substr(0, dashpos)) &&
-           alldigits(rank_thread.substr(dashpos + 1));
-  }
-
-  if (filename.ends_with(".out")) {
-    for (const std::string_view prefix : {"estimators_", "nlte_", "radfield_", "macroatom_"}) {
-      if (filename.starts_with(prefix)) {
-        return alldigits(filename.substr(prefix.size(), filename.size() - prefix.size() - 4));
-      }
-    }
-  }
-
-  return false;
-}
-
 // Create the run output folder given with the -o option and keep an output_0-0.txt symlink in the
 // simulation folder pointing at the current job's rank-0 log, so that e.g. tail -f output_0-0.txt works
 // regardless of the output folder. Without -o, remove any symlink left by a previous -o run, since

--- a/unittests.cc
+++ b/unittests.cc
@@ -467,6 +467,159 @@ void test_input_helpers() {
   check(!lineiscommentonly("1 2 3 # trailing comment"), "data line with trailing comment is not comment-only");
 }
 
+void test_parse_next_token() {
+  std::println("parse_next_token...");
+  {
+    auto remainder = std::string_view{"  42\t-7 +5  "};
+    int i = 0;
+    check(parse_next_token(remainder, i) && i == 42, "int token with leading whitespace");
+    check(parse_next_token(remainder, i) && i == -7, "negative int token after tab");
+    check(parse_next_token(remainder, i) && i == 5, "leading plus sign accepted");
+    check(!parse_next_token(remainder, i) && i == 5, "trailing whitespace has no token and value is untouched");
+  }
+  {
+    auto remainder = std::string_view{""};
+    int i = -99;
+    check(!parse_next_token(remainder, i), "empty line has no token");
+  }
+  {
+    auto remainder = std::string_view{"12abc 3"};
+    int i = -99;
+    check(!parse_next_token(remainder, i) && remainder == "12abc 3",
+          "token with trailing junk is rejected and not consumed");
+  }
+  {
+    auto remainder = std::string_view{"+-0"};
+    int i = -99;
+    check(!parse_next_token(remainder, i), "+-0 is rejected");
+  }
+  {
+    auto remainder = std::string_view{"3000000000"};
+    int i = -99;
+    check(!parse_next_token(remainder, i), "int overflow is rejected");
+  }
+  {
+    auto remainder = std::string_view{"1.5e3 -2.5 +0.25"};
+    double d = 0.;
+    check(parse_next_token(remainder, d) && d == 1500., "double token in exponent notation");
+    check(parse_next_token(remainder, d) && d == -2.5, "negative double token");
+    check(parse_next_token(remainder, d) && d == 0.25, "double token with leading plus sign");
+  }
+  for (const auto token : {"nan", "inf", "-inf", "NAN"}) {
+    auto remainder = std::string_view{token};
+    double d = 0.;
+    check(!parse_next_token(remainder, d), "nan and inf spellings are rejected");
+  }
+  {
+    auto remainder = std::string_view{"1e400"};
+    double d = -99.;
+    check(!parse_next_token(remainder, d), "double overflow is rejected");
+  }
+  {
+    auto remainder = std::string_view{"1e-400"};
+    double d = -99.;
+    check(parse_next_token(remainder, d) && d == 0., "underflow below the double range reads as zero");
+  }
+  {
+    auto remainder = std::string_view{"1e39"};
+    float f = -99.;
+    check(!parse_next_token(remainder, f), "float overflow is rejected even when the value fits in a double");
+  }
+  {
+    auto remainder = std::string_view{"1e-60"};
+    float f = -99.;
+    check(parse_next_token(remainder, f) && f == 0.f, "underflow below the float range reads as zero");
+  }
+}
+
+void test_calculate_timesteps() {
+  std::println("timestep grid calculation...");
+  const double tmin = 2. * DAY;
+  const double tmax = 50. * DAY;
+  const int nts = 40;
+
+  const auto grid_is_valid = [](const std::vector<globals::TimeStep>& ts, const int ntimesteps, const double t_start,
+                                const double t_end) {
+    bool ok = std::ssize(ts) == ntimesteps + 1;
+    ok = ok && ts[0].start == t_start;
+    ok = ok && ts[ntimesteps].start == t_end && ts[ntimesteps].mid == t_end && ts[ntimesteps].width == 0.;
+    for (int n = 0; ok && n < ntimesteps; n++) {
+      ok = ok && ts[n].width > 0.;
+      ok = ok && ts[n].mid > ts[n].start && ts[n].mid < ts[n].start + ts[n].width;
+      const double ts_end = ts[n].start + ts[n].width;
+      const double next_start = (n < ntimesteps - 1) ? ts[n + 1].start : t_end;
+      ok = ok && std::abs((ts_end / next_start) - 1.) < 0.001;
+    }
+    return ok;
+  };
+
+  {
+    const auto ts = calculate_timesteps(TimeStepSizeMethod::LOGARITHMIC, tmin, tmax, nts, -1., -1.);
+    check(grid_is_valid(ts, nts, tmin, tmax), "logarithmic grid is contiguous from tmin to tmax");
+    bool constant_ratio = true;
+    for (int n = 1; n < nts; n++) {
+      constant_ratio =
+          constant_ratio && std::abs((ts[n].start / ts[n - 1].start) / (ts[1].start / ts[0].start) - 1.) < 1e-10;
+    }
+    check(constant_ratio, "logarithmic timesteps have a constant start-time ratio");
+  }
+  {
+    const auto ts = calculate_timesteps(TimeStepSizeMethod::CONSTANT, tmin, tmax, nts, -1., -1.);
+    check(grid_is_valid(ts, nts, tmin, tmax), "constant grid is contiguous from tmin to tmax");
+    bool equal_widths = true;
+    for (int n = 0; n < nts; n++) {
+      equal_widths = equal_widths && std::abs(ts[n].width / ts[0].width - 1.) < 1e-10;
+    }
+    check(equal_widths, "constant timesteps have equal widths");
+  }
+  {
+    // 2 to 30 days logarithmic, then 1-day fixed steps to 50 days
+    const auto ts = calculate_timesteps(TimeStepSizeMethod::LOGARITHMIC_THEN_CONSTANT, tmin, tmax, nts, 1., 30.);
+    check(grid_is_valid(ts, nts, tmin, tmax), "logarithmic-then-constant grid is contiguous from tmin to tmax");
+    // ceil((50 - 30) / 1) = 20 fixed steps at the end
+    bool fixed_tail = true;
+    for (int n = nts - 20; n < nts; n++) {
+      fixed_tail = fixed_tail && std::abs(ts[n].width / DAY - 1.) < 1e-10;
+    }
+    check(fixed_tail, "logarithmic-then-constant grid ends with the fixed-width steps");
+  }
+  {
+    // 1-day fixed steps from 2 to 30 days, then logarithmic to 50 days
+    const auto ts = calculate_timesteps(TimeStepSizeMethod::CONSTANT_THEN_LOGARITHMIC, tmin, tmax, nts, 1., 30.);
+    check(grid_is_valid(ts, nts, tmin, tmax), "constant-then-logarithmic grid is contiguous from tmin to tmax");
+    // ceil((30 - 2) / 1) = 28 fixed steps at the start
+    bool fixed_head = true;
+    for (int n = 0; n < 28; n++) {
+      fixed_head = fixed_head && std::abs(ts[n].width / DAY - 1.) < 1e-10;
+    }
+    check(fixed_head, "constant-then-logarithmic grid starts with the fixed-width steps");
+  }
+  {
+    const auto ts = calculate_timesteps(TimeStepSizeMethod::LOGARITHMIC, tmin, tmax, 1, -1., -1.);
+    check(grid_is_valid(ts, 1, tmin, tmax), "a single logarithmic timestep covers the whole time range");
+  }
+}
+
+void test_rank_outfile_name() {
+  std::println("per-rank output filename matching...");
+  bool match_all = true;
+  for (const auto name :
+       {"output_0-0.txt", "output_123-45.txt", "estimators_0000.out", "nlte_0003.out", "radfield_0100.out",
+        "macroatom_0000.out", "output_0-0.txt.zst", "estimators_0000.out.gz", "radfield_0000.out.xz"}) {
+    match_all = match_all && is_rank_outfile_name(name);
+  }
+  check(match_all, "generated per-rank filenames are matched, with and without compression extensions");
+
+  bool match_none = false;
+  for (const auto name :
+       {"output_0.txt", "output_a-0.txt", "output_-0.txt", "output_0-.txt", "output_0-0.log", "estimators_00x0.out",
+        "estimators_.out", "estimators_0000.dat", "nlte_0000.OUT", "spec.out", "packets00_0000.out", "deposition.out",
+        "model.txt", "input.txt", "output_0-0.txt.bz2", "estimators_0000.out.zst.zst"}) {
+    match_none = match_none || is_rank_outfile_name(name);
+  }
+  check(!match_none, "other filenames are never matched, so they cannot be deleted from an output folder");
+}
+
 void test_gth_solver() {
   std::println("GTH stationary distribution solver...");
 
@@ -715,6 +868,9 @@ auto main() -> int {
   test_phixs_table_lookup();
   test_closest_transition_randomised();
   test_input_helpers();
+  test_parse_next_token();
+  test_calculate_timesteps();
+  test_rank_outfile_name();
   test_gth_solver();
   test_nonthermal_solve_upper_triangular();
   // the solver/integrator throw std::domain_error only on precondition violations that this test does not trigger


### PR DESCRIPTION
Adds unit tests for three helpers where a mistake has a high cost and there was no coverage (30 new checks; 117 total pass for the classic preset, 116 for nebular).

## parse_next_token()

The subtlest semantics in the input layer — leading plus signs accepted, magnitudes below the range of T reading as zero, nan/inf and overflow spellings rejected, junk tokens left unconsumed — were documented in a comment but untested. Each documented edge now has a check, including the float-vs-double range cases (`1e39` rejected for float but not double, `1e-60` reading as `0.0f`).

## calculate_timesteps() (extracted from setup_timesteps())

Every preset ships `TIMESTEP_SIZE_METHOD = LOGARITHMIC`, so the `LOGARITHMIC_THEN_CONSTANT` and `CONSTANT_THEN_LOGARITHMIC` branches were compiled by CI but **executed by nothing** — no test, no CI run, no preset. The grid computation moves into `calculate_timesteps(method, tmin, tmax, ntimesteps, fixed_width_days, transition_days)` so one binary can exercise all four branches; `setup_timesteps()` now just calls it with the compile-time options and prints the summary. The tests verify, for each method: grid size, coverage of [tmin, tmax], the zero-width end-marker entry, contiguity (`start + width == next start`), midpoints inside their steps, and the method-specific shapes (constant start-time ratio, equal widths, fixed-width head/tail of the hybrid grids).

**Behaviour-neutral, verified:** the kilonova_1d test (sn3d 4 ranks + exspec, `REPRODUCIBLE=ON MAX_NODE_SIZE=2 FASTMATH=OFF`) produces bit-identical output in all 23 files with binaries built before and after this change, so no stored checksums change.

## is_rank_outfile_name()

This predicate decides which files `setup_runoutputfolder()` **deletes** from a run output folder, so a false positive deletes a user's file. It moves from sn3d.cc's anonymous namespace to mpi_logging.h (next to the other output-file naming helpers) so the unittests binary can link it. The checks cover the generated per-rank names with and without the compression extensions the post-processing scripts add, and a set of near-miss names (`output_0.txt`, `estimators_00x0.out`, `packets00_0000.out`, `model.txt`, unknown compression extensions, double extensions) that must never match.

Also mentions `make unittests && ./unittests` in the README testing section, which previously only appeared in AGENTS.md.

## Verification

- All six presets compile with gcc 14 (`-Werror`); unit tests pass for classic (117/117) and nebular (116/116).
- A/B regression run for the `calculate_timesteps` extraction as above: bit-identical outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuMr5HsnX7fgs6SPgxF6wo)_