### PR TITLE
Clear the NLTE level populations before the Saha populations of a grey cell

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1632,11 +1632,18 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 
 }  // anonymous namespace
 
-// Clear the stored NLTE solution ranges of every element in the cell, for the paths that replace
-// the NLTE solution with Saha populations without a solve.
-void nltepop_reset_solution_ranges(const int nonemptymgi) {
+// Clear the NLTE solution of every element in the cell, for the paths that replace the NLTE
+// solution with Saha populations without a solve. The level populations get the -1 marker, so
+// the partition functions and the Saha balance then use the Boltzmann populations. A stale
+// excited population divided by a Saha ground population at the MINPOP floor would overflow
+// the partition function.
+void nltepop_reset_cell(const int nonemptymgi) {
   for (int element = 0; element < get_nelements(); element++) {
-    grid::set_elements_lowermost_ion(nonemptymgi, element, 0);
+    if (elem_has_nlte_levels(element)) {
+      nltepop_reset_element(nonemptymgi, element);
+    } else {
+      grid::set_elements_lowermost_ion(nonemptymgi, element, 0);
+    }
   }
   if constexpr (NLTE_TIME_DEPENDENT_FIRST_TIMESTEP.has_value()) {
     // the cell holds no NLTE solution, so the next timestep starts from the steady-state equations

--- a/nltepop.h
+++ b/nltepop.h
@@ -42,7 +42,7 @@ void solve_nlte_pops_element(int element, int nonemptymgi, int timestep, int nlt
 // uppermost ion of the cell (see grid.h). The cell holds no NLTE solution for the element before
 // the first solve and after a fallback to LTE, and the range is then {-1, -1}. The charge transfer
 // reactions read the range, and the NLTE iteration loop watches it for a change.
-void nltepop_reset_solution_ranges(int nonemptymgi);
+void nltepop_reset_cell(int nonemptymgi);
 [[nodiscard]] auto elem_has_nlte_solution(int nonemptymgi, int element) -> bool;
 [[nodiscard]] auto get_nlte_solution_range(int nonemptymgi, int element) -> std::pair<int, int>;
 // GTH solve for the stationary distribution of the NLTE rate matrix, exposed here so that unittests.cc can test

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -553,13 +553,14 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
             1.);
       }
 
+      // the Saha populations replace the NLTE solution. The partition functions must not read the
+      // stale NLTE level populations, and the charge transfer reactions must not read the stored
+      // ion ranges of the last NLTE solve
+      nltepop_reset_cell(nonemptymgi);
       for (int element = 0; element < get_nelements(); element++) {
         calculate_cellpartfuncts(nonemptymgi, element);
       }
       calculate_ion_balance_nne(nonemptymgi);
-      // the Saha populations replace the NLTE solution, so the charge transfer reactions must not
-      // read the stored ion ranges of the last NLTE solve
-      nltepop_reset_solution_ranges(nonemptymgi);
       // no thermal balance: the k-packets keep their full energy
       kpkt::reset_radiative_energy_factor(nonemptymgi);
     } else {


### PR DESCRIPTION
## Summary

A cell that had an NLTE solution can go to the grey/LTE path in a later timestep, e.g. when no packet entered it (`W == 1`). That path computed the partition functions before it cleared the NLTE solution, and `nltepop_reset_solution_ranges()` cleared only the ion ranges. The stale excited populations stayed in the cell. The next grey timestep divided them by a Saha ground population at the `MINPOP` floor, and the partition function overflowed a `float`. The assertion in `calculate_partfunct()` then stopped the run.

Found with a new 2D kilonova test with time-dependent NLTE (follow-up PR), where low density outer cells get no packets in some timesteps.

## Change

- `nltepop_reset_solution_ranges()` becomes `nltepop_reset_cell()`. It writes the `-1` marker into the NLTE level populations of every NLTE element (with `nltepop_reset_element()`), which also clears the ion ranges and the time-dependent solution time.
- The grey path in `update_grid_cell()` calls it before the partition functions and the Saha balance.

## Results

The results change only for a cell that goes from an NLTE solution to the grey path. The stored checksums may change if a test has such a cell. Local check of `nebular_1d_3dgrid` on macOS: see the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
