### PR TITLE
Add the CI test kilonova_2d_timedepnlte

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
                         kilonova_2d,
                         kilonova_2d_barnesthermalisation,
                         kilonova_2d_expansionopac,
+                        kilonova_2d_timedepnlte,
                         kilonova_2d_xcomgammaphotoion,
                         nebular_1d_3dgrid,
                         nebular_1d_3dgrid_limitbfest,
@@ -69,7 +70,7 @@ jobs:
                   echo "count=$(python3 -c 'import multiprocessing; print(multiprocessing.cpu_count())')" >> $GITHUB_OUTPUT
 
             - name: Cache test atomic data
-              if: ${{ !startsWith(matrix.testname, 'classicmode') }}
+              if: ${{ !startsWith(matrix.testname, 'classicmode') && !startsWith(matrix.testname, 'kilonova_2d_timedepnlte') }}
               uses: actions/cache@v6
               id: cache-testatomicdata
               with:
@@ -91,6 +92,14 @@ jobs:
               with:
                   path: tests/atomicdata_hefeconi_fe_i_to_vii.tar.xz
                   key: tests/atomicdata_hefeconi_fe_i_to_vii.tar.xz
+
+            - name: Cache test atomic data kilonova_2d_timedepnlte
+              if: ${{ startsWith(matrix.testname, 'kilonova_2d_timedepnlte') }}
+              uses: actions/cache@v6
+              id: cache-testatomicdata-sryzrlace
+              with:
+                  path: tests/atomicdata_sryzrlace.tar.zst
+                  key: tests/atomicdata_sryzrlace.tar.zst
 
             - name: Download/extract test data
               working-directory: tests/
@@ -256,10 +265,16 @@ jobs:
                   artistools plotspectra -t 4-6 -plotvspecpol 0 1 2 --frompackets ${{ matrix.testname }}_testrun
 
             - name: Plot spectrum kilonova
-              if: always() && inputs.testmode != 'ON' && startsWith(matrix.testname, 'kilonova')
+              if: always() && inputs.testmode != 'ON' && startsWith(matrix.testname, 'kilonova') && !startsWith(matrix.testname, 'kilonova_2d_timedepnlte')
               working-directory: tests/
               run: |
                   artistools plotspectra --frompackets -t 1.5 ${{ matrix.testname }}_testrun
+
+            - name: Plot spectrum kilonova_2d_timedepnlte
+              if: always() && inputs.testmode != 'ON' && startsWith(matrix.testname, 'kilonova_2d_timedepnlte')
+              working-directory: tests/
+              run: |
+                  artistools plotspectra --frompackets -t 8.5 ${{ matrix.testname }}_testrun
 
             - name: Upload plot files
               if: always() && inputs.testmode != 'ON' && inputs.uploadoutputfiles == 'ON'

--- a/anderson.h
+++ b/anderson.h
@@ -30,8 +30,9 @@ class AndersonAccelerator {
     }
 
     State result = g;
-    const std::size_t m = std::min(nstored_, depth_);
-    if (m > 0) {
+    // a singular system (e.g. a 2-cycle, where two residual differences are exact negatives) makes
+    // the solve fail. A smaller depth then gets a try, down to the plain map output
+    for (std::size_t m = std::min(nstored_, depth_); m > 0; m--) {
       // consecutive differences: entry j is (pair k-j) - (pair k-j-1), with pair k = (x, g, residual)
       std::array<State, MAXDEPTH> dres_chain{};
       std::array<State, MAXDEPTH> dg_chain{};
@@ -74,6 +75,7 @@ class AndersonAccelerator {
             result[i] -= gamma[j] * dg_chain[j][i];
           }
         }
+        break;
       }
     }
 

--- a/anderson.h
+++ b/anderson.h
@@ -1,0 +1,135 @@
+// Anderson acceleration of a fixed-point iteration x = G(x) for a small state vector (see
+// NLTE_OUTER_ANDERSON_DEPTH). The accelerator keeps the last iterates and their map outputs, and
+// combines them so that the residual of the combination is minimal in the least-squares sense.
+
+#ifndef ANDERSON_H
+#define ANDERSON_H
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+// N: dimension of the state. MAXDEPTH: the maximum number of previous residual differences.
+template <std::size_t N, std::size_t MAXDEPTH>
+class AndersonAccelerator {
+ public:
+  using State = std::array<double, N>;
+
+  explicit constexpr AndersonAccelerator(const std::size_t depth) : depth_(std::min(depth, MAXDEPTH)) {}
+
+  // Forget the history. Call this when the map changes, e.g. when the set of solved ions changes.
+  constexpr void reset() { nstored_ = 0; }
+
+  // Give the iterate x and its map output g = G(x). Return the next iterate. With no history, or with a
+  // depth of zero, the result is g (plain successive substitution).
+  [[nodiscard]] constexpr auto next(const State& x, const State& g) -> State {
+    State residual{};
+    for (std::size_t i = 0; i < N; i++) {
+      residual[i] = g[i] - x[i];
+    }
+
+    State result = g;
+    const std::size_t m = std::min(nstored_, depth_);
+    if (m > 0) {
+      // consecutive differences: entry j is (pair k-j) - (pair k-j-1), with pair k = (x, g, residual)
+      std::array<State, MAXDEPTH> dres_chain{};
+      std::array<State, MAXDEPTH> dg_chain{};
+      {
+        State r_newer = residual;
+        State g_newer = g;
+        for (std::size_t j = 0; j < m; j++) {
+          const auto& [xprev, gprev, rprev] = history_[(nstored_ - 1 - j) % MAXDEPTH];
+          for (std::size_t i = 0; i < N; i++) {
+            dres_chain[j][i] = r_newer[i] - rprev[i];
+            dg_chain[j][i] = g_newer[i] - gprev[i];
+          }
+          r_newer = rprev;
+          g_newer = gprev;
+        }
+      }
+
+      // normal equations (m x m) for the coefficients gamma: minimise |residual - sum_j gamma_j dres_chain[j]|
+      std::array<std::array<double, MAXDEPTH>, MAXDEPTH> ata{};
+      std::array<double, MAXDEPTH> atb{};
+      for (std::size_t a = 0; a < m; a++) {
+        for (std::size_t b = 0; b < m; b++) {
+          double sum = 0.;
+          for (std::size_t i = 0; i < N; i++) {
+            sum += dres_chain[a][i] * dres_chain[b][i];
+          }
+          ata[a][b] = sum;
+        }
+        double sum = 0.;
+        for (std::size_t i = 0; i < N; i++) {
+          sum += dres_chain[a][i] * residual[i];
+        }
+        atb[a] = sum;
+      }
+
+      std::array<double, MAXDEPTH> gamma{};
+      if (solve_small_system(ata, atb, m, gamma)) {
+        for (std::size_t j = 0; j < m; j++) {
+          for (std::size_t i = 0; i < N; i++) {
+            result[i] -= gamma[j] * dg_chain[j][i];
+          }
+        }
+      }
+    }
+
+    history_[nstored_ % MAXDEPTH] = {x, g, residual};
+    nstored_++;
+    return result;
+  }
+
+ private:
+  struct Entry {
+    State x{};
+    State g{};
+    State residual{};
+  };
+
+  // Gaussian elimination with partial pivoting for the m x m normal equations. Return false when the
+  // system is singular, so that the caller falls back to the plain map output.
+  static constexpr auto solve_small_system(std::array<std::array<double, MAXDEPTH>, MAXDEPTH> a,
+                                           std::array<double, MAXDEPTH> b, const std::size_t m,
+                                           std::array<double, MAXDEPTH>& solution) -> bool {
+    for (std::size_t col = 0; col < m; col++) {
+      std::size_t pivot = col;
+      for (std::size_t row = col + 1; row < m; row++) {
+        if (std::abs(a[row][col]) > std::abs(a[pivot][col])) {
+          pivot = row;
+        }
+      }
+      if (!(std::abs(a[pivot][col]) > 0.)) {
+        return false;
+      }
+      std::swap(a[col], a[pivot]);
+      std::swap(b[col], b[pivot]);
+      for (std::size_t row = col + 1; row < m; row++) {
+        const double factor = a[row][col] / a[col][col];
+        for (std::size_t k = col; k < m; k++) {
+          a[row][k] -= factor * a[col][k];
+        }
+        b[row] -= factor * b[col];
+      }
+    }
+    for (std::size_t col = m; col-- > 0;) {
+      double sum = b[col];
+      for (std::size_t k = col + 1; k < m; k++) {
+        sum -= a[col][k] * solution[k];
+      }
+      solution[col] = sum / a[col][col];
+      if (!std::isfinite(solution[col])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::size_t depth_;
+  std::size_t nstored_{0};
+  std::array<Entry, MAXDEPTH> history_{};
+};
+
+#endif  // ANDERSON_H

--- a/artisoptions_christinenonthermal.h
+++ b/artisoptions_christinenonthermal.h
@@ -20,6 +20,10 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE = false;
 
 constexpr int NLTEITER = 30;
 
+constexpr int NLTE_OUTER_ANDERSON_DEPTH = 0;
+
+constexpr double NLTE_OUTER_RELTOL = 0.04;
+
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) {
   if (element_z < 22) {
     return 200;

--- a/artisoptions_classic.h
+++ b/artisoptions_classic.h
@@ -20,6 +20,10 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE = false;
 
 constexpr int NLTEITER = 30;
 
+constexpr int NLTE_OUTER_ANDERSON_DEPTH = 0;
+
+constexpr double NLTE_OUTER_RELTOL = 0.04;
+
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) { return 0; }
 
 constexpr bool LTEPOP_EXCITATION_USE_TJ = true;

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -16,6 +16,25 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE;
 // maximum number of NLTE/Te/Spencer-Fano iterations
 constexpr int NLTEITER;
 
+// Anderson acceleration of the NLTE/Te/Spencer-Fano iteration. The iteration maps the electron temperature
+// and the electron density of one pass to the values of the next pass. With a depth above zero, the
+// accelerator combines the last iterates so that the residual of the combination is minimal, and the
+// next pass starts from that combination. A depth of 2 is a good choice. Zero keeps the plain successive
+// substitution.
+//
+// The accelerator forgets its history when an element falls back to LTE or changes its solved ion range,
+// because the map is then discontinuous. A step that leaves [MINTEMP, MAXTEMP] is rejected. The populations
+// of a converged cell come from a plain element solve at the final T_e and nne.
+constexpr int NLTE_OUTER_ANDERSON_DEPTH;
+
+// Relative tolerance of the NLTE/Te/Spencer-Fano iteration for nne and T_e. With a depth of zero the loop
+// stops when the change between two passes is below the tolerance, as before. With acceleration the loop
+// tests an estimate of the remaining error instead: the change times rho / (1 - rho), where rho is the
+// ratio of the last two changes (limited to 0.95). nne and T_e each get their own ratio, and the larger
+// estimate counts. The estimate is the error of a linear contraction with that ratio, so the tolerance then
+// means an error and not a change.
+constexpr double NLTE_OUTER_RELTOL;
+
 // Specify how many levels will be treated in full NLTE, not including the ground state or the superlevel.
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage);
 

--- a/artisoptions_kilonova_lte.h
+++ b/artisoptions_kilonova_lte.h
@@ -20,6 +20,10 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE = false;
 
 constexpr int NLTEITER = 30;
 
+constexpr int NLTE_OUTER_ANDERSON_DEPTH = 0;
+
+constexpr double NLTE_OUTER_RELTOL = 0.04;
+
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) { return 0; }
 
 constexpr bool LTEPOP_EXCITATION_USE_TJ = true;

--- a/artisoptions_nltenebular.h
+++ b/artisoptions_nltenebular.h
@@ -20,6 +20,10 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE = false;
 
 constexpr int NLTEITER = 30;
 
+constexpr int NLTE_OUTER_ANDERSON_DEPTH = 0;
+
+constexpr double NLTE_OUTER_RELTOL = 0.04;
+
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) {
   if (element_z == 26 && ionstage == 2) {
     return 197;

--- a/artisoptions_nltephotospheric_dynamic_ion_range.h
+++ b/artisoptions_nltephotospheric_dynamic_ion_range.h
@@ -20,6 +20,10 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE = false;
 
 constexpr int NLTEITER = 30;
 
+constexpr int NLTE_OUTER_ANDERSON_DEPTH = 0;
+
+constexpr double NLTE_OUTER_RELTOL = 0.04;
+
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) {
   if (element_z < 20) {
     return 100;

--- a/artisoptions_nltewithoutnonthermal.h
+++ b/artisoptions_nltewithoutnonthermal.h
@@ -20,6 +20,10 @@ constexpr bool FORCE_SPHERICAL_ESCAPE_SURFACE = false;
 
 constexpr int NLTEITER = 30;
 
+constexpr int NLTE_OUTER_ANDERSON_DEPTH = 0;
+
+constexpr double NLTE_OUTER_RELTOL = 0.04;
+
 constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) {
   if (element_z == 26 && ionstage == 2) {
     return 197;

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -1632,11 +1632,18 @@ void nltepop_apply_solution(const int element, const int nonemptymgi, const int 
 
 }  // anonymous namespace
 
-// Clear the stored NLTE solution ranges of every element in the cell, for the paths that replace
-// the NLTE solution with Saha populations without a solve.
-void nltepop_reset_solution_ranges(const int nonemptymgi) {
+// Clear the NLTE solution of every element in the cell, for the paths that replace the NLTE
+// solution with Saha populations without a solve. The level populations get the -1 marker, so
+// the partition functions and the Saha balance then use the Boltzmann populations. A stale
+// excited population divided by a Saha ground population at the MINPOP floor would overflow
+// the partition function.
+void nltepop_reset_cell(const int nonemptymgi) {
   for (int element = 0; element < get_nelements(); element++) {
-    grid::set_elements_lowermost_ion(nonemptymgi, element, 0);
+    if (elem_has_nlte_levels(element)) {
+      nltepop_reset_element(nonemptymgi, element);
+    } else {
+      grid::set_elements_lowermost_ion(nonemptymgi, element, 0);
+    }
   }
   if constexpr (NLTE_TIME_DEPENDENT_FIRST_TIMESTEP.has_value()) {
     // the cell holds no NLTE solution, so the next timestep starts from the steady-state equations

--- a/nltepop.h
+++ b/nltepop.h
@@ -42,7 +42,7 @@ void solve_nlte_pops_element(int element, int nonemptymgi, int timestep, int nlt
 // uppermost ion of the cell (see grid.h). The cell holds no NLTE solution for the element before
 // the first solve and after a fallback to LTE, and the range is then {-1, -1}. The charge transfer
 // reactions read the range, and the NLTE iteration loop watches it for a change.
-void nltepop_reset_solution_ranges(int nonemptymgi);
+void nltepop_reset_cell(int nonemptymgi);
 [[nodiscard]] auto elem_has_nlte_solution(int nonemptymgi, int element) -> bool;
 [[nodiscard]] auto get_nlte_solution_range(int nonemptymgi, int element) -> std::pair<int, int>;
 // GTH solve for the stationary distribution of the NLTE rate matrix, exposed here so that unittests.cc can test

--- a/tests/kilonova_2d_timedepnlte_inputfiles/input-newrun.txt
+++ b/tests/kilonova_2d_timedepnlte_inputfiles/input-newrun.txt
@@ -1,0 +1,24 @@
+1281360349               #  0: pre_zseed: specific random number seed if > 0 or random if negative
+8                        #  1: ntimesteps: number of timesteps
+000 004                  #  2: timestep_start timestep_finish: timestep number range start (inclusive) and stop (not inclusive)
+7.0 010                  #  3: tmin_days tmax_days: start and end times [day]
+1.33  1.330000001        #  4: UNUSED nusyn_min_mev nusyn_max_mev: lowest and highest frequency to synthesise [MeV]
+80                       #  5: UNUSED nsyn_time: number of times for synthesis
+3. 0.037                 #  6: UNUSED start and end times for synthesis
+2                        #  7: UNUSED (now autodetected) model.txt number of dimensions (1, 2, or 3)
+4                        #  8: UNUSED compute r-light curve (1: no estimators, 2: thin cells, 3: thick cells, 4: gamma-ray heating)
+1                        #  9: UNUSED n_out_it: number of iterations
+1.0                      # 10: UNUSED change speed of light by some factor. Change constants.h CLIGHT_PROP instead
+-1                       # 11: UNUSED gamma_kappagrey: if >0: use grey opacity for gammas, if <0: use detailed opacity
+0 0 1                    # 12: UNUSED syn_dir: x, y, and z components of unit vector (now always 0,0,1)
+5                        # 13: UNUSED opacity_case: opacity choice
+1.0e-10                  # 14: UNUSED rho_crit_para: free parameter for calculation of rho_crit
+-1                       # 15: UNUSED debug_packet: (>=0: activate debug output for packet id, <0: ignore)
+0                        # 16: simulation_continued_from_saved: (0: start new simulation, 1: continue from gridsave and packets files)
+1e-6                     # 17: UNUSED rfcut: wavelength at which the radiation field switches from the nebular approximation to LTE.
+2                        # 18: num_lte_timesteps
+0.0 0                    # 19: optical_depth_is_thick num_grey_timesteps
+-1                       # 20: UNUSED max_bf_continua: (ignored; all bound-free continua are included)
+4                        # 21: nprocs_exspec: extract spectra for n MPI tasks. sn3d will set this on start of new sim.
+1                        # 22: UNUSED do_emission_res: this is always true for exspec, sometimes true during sn3d
+0.001 1000               # 23: UNUSED kpktdiffusion_timescale n_kpktdiffusion_timesteps: now set in kpkt.cc

--- a/tests/kilonova_2d_timedepnlte_inputfiles/input-resume.txt
+++ b/tests/kilonova_2d_timedepnlte_inputfiles/input-resume.txt
@@ -1,0 +1,24 @@
+1281360349               # pre_zseed: specific random number seed if > 0 or random if negative
+8                        # globals::ntimesteps: number of timesteps
+003 008                  # timestep_start timestep_finish: number of start and end time step
+7.0 010                  # tmin_days tmax_days: start and end times [day]
+1.33  1.330000001        # nusyn_min_mev nusyn_max_mev: lowest and highest frequency to synthesise [MeV]
+80                       # nsyn_time: number of times for synthesis
+3. 0.037                 # start and end times for synthesis
+2                        # model_type: number of dimensions (1, 2, or 3)
+4                        # compute r-light curve (1: no estimators, 2: thin cells, 3: thick cells, 4: gamma-ray heating)
+1                        # n_out_it: UNUSED number of iterations
+1.0                      # CLIGHT/CLIGHT: change speed of light by some factor
+-1                       # use grey opacity for gammas?
+0 0 1                    # syn_dir: x, y, and z components of unit vector (will be normalised after input or randomised if zero length)
+5                        # opacity_case: opacity choice
+1.0e-10                  # rho_crit_para: free parameter for calculation of rho_crit
+-1                       # UNUSED debug_packet: (>=0: activate debug output for packet id, <0: ignore)
+1                        # simulation_continued_from_saved: (0: start new simulation, 1: continue from gridsave and packets files)
+1e-6                     # UNUSED rfcut_angstroms: wavelength (in Angstroms) at which the parameterisation of the radiation field switches from the nebular approximation to LTE.
+2                        # num_lte_timesteps
+0.0 0                    # cell_is_optically_thick num_grey_timesteps
+-1                       # UNUSED max_bf_continua: (>0: max bound-free continua per ion, <0 unlimited)
+4                        # nprocs_exspec: extract spectra for n MPI tasks
+1                        # do_emission_res: Extract line-of-sight dependent information of last emission for spectrum_res (1: yes, 2: no)
+0.001 1000               # kpktdiffusion_timescale n_kpktdiffusion_timesteps: kpkts diffuse x of a time step's length for the first y time steps

--- a/tests/setup_kilonova_2d_timedepnlte.sh
+++ b/tests/setup_kilonova_2d_timedepnlte.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env zsh
+
+set -x
+
+runfolder=kilonova_2d_timedepnlte_testrun
+
+if [ ! -f atomicdata_sryzrlace.tar.zst ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_sryzrlace.tar.zst; fi
+
+mkdir -p $runfolder
+
+cd $runfolder
+
+# the model files of the kilonova_2d test. The atomic data archive supplies compositiondata.txt
+rsync -av --exclude="compositiondata.txt" --exclude="input-*.txt" --exclude="results_md5*" ../kilonova_2d_inputfiles/ ./
+
+tar -xf ../atomicdata_sryzrlace.tar.zst --directory ./
+
+rsync -av ../kilonova_2d_timedepnlte_inputfiles/ ./
+
+ln -s ../../ artis
+
+cp artis/artisoptions_nltenebular.h artisoptions.h
+
+xz -f -d -v -T0 *.xz
+
+sed -i'' -e 's/constexpr int MPKTS.*/constexpr int MPKTS = 200000;/g' artisoptions.h
+
+sed -i'' -e 's/constexpr int TABLESIZE.*/constexpr int TABLESIZE = 20;/g' artisoptions.h
+sed -i'' -e 's/constexpr double MINTEMP.*/constexpr double MINTEMP = 1000.;/g' artisoptions.h
+sed -i'' -e 's/constexpr double MAXTEMP.*/constexpr double MAXTEMP = 20000.;/g' artisoptions.h
+
+perl -0777 -i -pe 's|constexpr int ION_NLEVELS_EXCITED_NLTE\(int element_z, int ionstage\) \{.*?\n\}|constexpr int ION_NLEVELS_EXCITED_NLTE(int element_z, int ionstage) { return 30; }|s' artisoptions.h
+
+sed -i'' -e 's/constexpr int FIRST_NLTE_RADFIELD_TIMESTEP.*/constexpr int FIRST_NLTE_RADFIELD_TIMESTEP = 2;/g' artisoptions.h
+sed -i'' -e 's/constexpr int DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP.*/constexpr int DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP = 2;/g' artisoptions.h
+
+sed -i'' -e 's/constexpr std::optional<int> NLTE_TIME_DEPENDENT_FIRST_TIMESTEP.*/constexpr std::optional<int> NLTE_TIME_DEPENDENT_FIRST_TIMESTEP = 3;/g' artisoptions.h
+
+sed -i'' -e 's/constexpr int NLTE_OUTER_ANDERSON_DEPTH.*/constexpr int NLTE_OUTER_ANDERSON_DEPTH = 2;/g' artisoptions.h
+sed -i'' -e 's/constexpr double NLTE_OUTER_RELTOL.*/constexpr double NLTE_OUTER_RELTOL = 0.01;/g' artisoptions.h
+
+sed -i'' -e 's/constexpr bool USE_CALCULATED_MEANATOMICWEIGHT.*/constexpr bool USE_CALCULATED_MEANATOMICWEIGHT = true;/g' artisoptions.h
+sed -i'' -e 's/constexpr auto PARTICLE_THERMALISATION_SCHEME.*/constexpr auto PARTICLE_THERMALISATION_SCHEME = ParticleThermalisationScheme::TIMEDEPENDENT;/g' artisoptions.h
+
+sed -i'' -e 's/constexpr bool WRITE_EMISSIONABSORPTION_SPEC_AT_END.*/constexpr bool WRITE_EMISSIONABSORPTION_SPEC_AT_END = true;/g' artisoptions.h
+
+cd -
+
+set +x

--- a/unittests.cc
+++ b/unittests.cc
@@ -21,6 +21,7 @@
 #include <string_view>
 #include <vector>
 
+#include "anderson.h"
 #include "artisoptions.h"
 #include "atomic.h"
 #include "chargetransfer.h"
@@ -689,6 +690,46 @@ void test_rank_outfile_name() {
   check(!match_none, "other filenames are never matched, so they cannot be deleted from an output folder");
 }
 
+void test_anderson_accelerator() {
+  std::println("Anderson accelerator...");
+  // linear map with the contraction factors 0.9 and -0.7, fixed point (10, 2)
+  const auto linear_map = [](const std::array<double, 2>& x) {
+    return std::array<double, 2>{(0.9 * x[0]) + 1.0, (-0.7 * x[1]) + 3.4};
+  };
+  const auto iterate = [&](const std::size_t depth) {
+    AndersonAccelerator<2, 4> acc(depth);
+    std::array<double, 2> x{0., 0.};
+    int iterations = 0;
+    for (; iterations < 1000; iterations++) {
+      const auto g = linear_map(x);
+      if (std::max(std::abs(g[0] - 10.), std::abs(g[1] - 2.)) < 1e-8) {
+        break;
+      }
+      x = acc.next(x, g);
+    }
+    return std::pair{iterations, x};
+  };
+  const auto [iterations_plain, x_plain] = iterate(0);
+  const auto [iterations_depth1, x_depth1] = iterate(1);
+  const auto [iterations_depth2, x_depth2] = iterate(2);
+  check(iterations_plain > 100, "plain successive substitution needs more than 100 iterations");
+  check(iterations_depth1 < iterations_plain / 4, "Anderson depth 1 needs fewer than a quarter of the iterations");
+  check(iterations_depth2 <= 4, "Anderson depth 2 solves a linear 2-D map in at most 4 iterations");
+  check(std::abs(x_depth2[0] - 10.) < 1e-6 && std::abs(x_depth2[1] - 2.) < 1e-6,
+        "Anderson depth 2 reaches the fixed point");
+
+  // with no history, or after a reset, the accelerator returns the plain map output
+  AndersonAccelerator<2, 4> acc(2);
+  const std::array<double, 2> x0{1., 1.};
+  const auto g0 = linear_map(x0);
+  check(acc.next(x0, g0) == g0, "the first Anderson step returns the map output");
+  const std::array<double, 2> x1{2., 3.};
+  const auto g1 = linear_map(x1);
+  check(acc.next(x1, g1) != g1, "the second Anderson step changes the iterate");
+  acc.reset();
+  check(acc.next(x1, g1) == g1, "after a reset the Anderson step returns the map output");
+}
+
 void test_gth_solver() {
   std::println("GTH stationary distribution solver...");
 
@@ -1015,6 +1056,7 @@ auto main() -> int {
   test_calculate_timesteps();
   test_rank_outfile_name();
   test_gth_solver();
+  test_anderson_accelerator();
   test_chargetransfer_helpers();
   test_nonthermal_solve_upper_triangular();
   // the solver/integrator throw std::domain_error only on precondition violations that this test does not trigger

--- a/unittests.cc
+++ b/unittests.cc
@@ -718,6 +718,21 @@ void test_anderson_accelerator() {
   check(std::abs(x_depth2[0] - 10.) < 1e-6 && std::abs(x_depth2[1] - 2.) < 1e-6,
         "Anderson depth 2 reaches the fixed point");
 
+  // a map with a 2-cycle: x -> c - x never converges by itself, and with depth 2 the two stored
+  // residual differences are exact negatives. The accelerator must then use depth 1 and find the
+  // midpoint, which is the fixed point
+  {
+    AndersonAccelerator<2, 4> acc_cycle(2);
+    std::array<double, 2> x{0., 10.};
+    bool reached = false;
+    for (int iteration = 0; iteration < 10 && !reached; iteration++) {
+      const std::array<double, 2> g{6. - x[0], 2. - x[1]};
+      reached = std::max(std::abs(g[0] - 3.), std::abs(g[1] - 1.)) < 1e-8;
+      x = acc_cycle.next(x, g);
+    }
+    check(reached, "Anderson depth 2 solves a 2-cycle map with the depth 1 fallback");
+  }
+
   // with no history, or after a reset, the accelerator returns the plain map output
   AndersonAccelerator<2, 4> acc(2);
   const std::array<double, 2> x0{1., 1.};

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -5,6 +5,7 @@
 #include "update_grid.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -16,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "anderson.h"
 #include "artisoptions.h"
 #include "atomic.h"
 #include "constants.h"
@@ -34,6 +36,12 @@
 #include "vpkt.h"
 
 namespace {
+
+// the largest supported NLTE_OUTER_ANDERSON_DEPTH (the history arrays of the accelerator have this size)
+constexpr std::size_t MAX_ANDERSON_DEPTH = 4;
+static_assert(NLTE_OUTER_ANDERSON_DEPTH >= 0);
+static_assert(static_cast<std::size_t>(NLTE_OUTER_ANDERSON_DEPTH) <= MAX_ANDERSON_DEPTH);
+static_assert(NLTE_OUTER_RELTOL > 0.);
 
 std::vector<HeatingCoolingRates> heatingcoolingrates_thisrankcells;
 
@@ -200,8 +208,14 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
           .count();
   printlnlog("took {:.1f} seconds", bfheating_duration);
 
-  constexpr double nne_reltol = 0.04;
-  constexpr double T_e_reltol = 0.04;
+  constexpr double nne_reltol = NLTE_OUTER_RELTOL;
+  constexpr double T_e_reltol = NLTE_OUTER_RELTOL;
+
+  // Anderson acceleration of the outer iteration (see NLTE_OUTER_ANDERSON_DEPTH). The state is
+  // (log T_e, log nne) as the element solves use it. Its map output is known after the next T_e solve.
+  AndersonAccelerator<2, MAX_ANDERSON_DEPTH> anderson(static_cast<std::size_t>(NLTE_OUTER_ANDERSON_DEPTH));
+  std::array<double, 2> x_injected{};  // the state that the element solves of the previous pass used
+  std::array<double, 2> change_prev{-1., -1.};  // the relative changes of the previous pass, for the error estimate
 
   // the ion populations and the NLTE solution ranges of the previous iteration, for the charge
   // transfer convergence test. The buffers are thread-local, so every cell reuses them.
@@ -251,6 +265,31 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
 
     const double fracdiff_T_e = fabs((grid::Te_allcells[nonemptymgi] / prev_T_e) - 1);
 
+    if constexpr (NLTE_OUTER_ANDERSON_DEPTH > 0) {
+      const std::array<double, 2> g{std::log(grid::Te_allcells[nonemptymgi]), std::log(grid::get_nne(nonemptymgi))};
+      if (nlte_iter > 0) {
+        const auto x_next = anderson.next(x_injected, g);
+        const double T_e_next = std::exp(x_next[0]);
+        const double nne_next = std::exp(x_next[1]);
+        const bool step_accepted = std::isfinite(T_e_next) && std::isfinite(nne_next) && T_e_next >= MINTEMP &&
+                                   T_e_next <= MAXTEMP && nne_next > 0.;
+        if (step_accepted) {
+          grid::Te_allcells[nonemptymgi] = static_cast<float>(T_e_next);
+          grid::set_nne(nonemptymgi, static_cast<float>(nne_next));
+          x_injected = x_next;
+        } else {
+          x_injected = g;
+        }
+        printlnlog(
+            "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: Anderson step {}: T_e {:g} nne {:e} "
+            "from the pass, T_e {:g} nne {:e} for the next pass",
+            mgi, nts, nlte_iter, step_accepted ? "accepted" : "rejected", std::exp(g[0]), std::exp(g[1]),
+            grid::Te_allcells[nonemptymgi], grid::get_nne(nonemptymgi));
+      } else {
+        x_injected = g;
+      }
+    }
+
     // charge transfer conserves nne, so the nne convergence test cannot see a population exchange
     // between two elements. Keep the ion populations of this iteration and test them below. The
     // element solves run in sequence, so an element that falls back to LTE or loses an edge ion
@@ -284,6 +323,20 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
     const double nne_prev = grid::get_nne(nonemptymgi);
     calculate_ion_balance_nne(nonemptymgi);  // sets nne
     const auto fracdiff_nne = fabs((grid::get_nne(nonemptymgi) / nne_prev) - 1);
+
+    if constexpr (NLTE_OUTER_ANDERSON_DEPTH > 0) {
+      // an element without a matrix solution makes the map discontinuous, so the history is useless
+      bool element_fell_back = false;
+      for (int element = 0; element < get_nelements(); element++) {
+        if (elem_has_nlte_levels(element) && grid::get_elem_massfrac(nonemptymgi, element) > 0. &&
+            !elem_has_nlte_solution(nonemptymgi, element)) {
+          element_fell_back = true;
+        }
+      }
+      if (element_fell_back) {
+        anderson.reset();
+      }
+    }
 
     // largest fractional change of the significant ion populations, which the charge transfer
     // reactions can move while nne stays constant
@@ -322,10 +375,34 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
         "fracdiff {:g}, prev T_e {:g} new T_e {:g} fracdiff {:g}",
         mgi, nts, nlte_iter, nne_prev, grid::get_nne(nonemptymgi), fracdiff_nne, prev_T_e,
         grid::Te_allcells[nonemptymgi], fracdiff_T_e);
+    if constexpr (NLTE_OUTER_ANDERSON_DEPTH > 0) {
+      if (nlte_solution_changed) {
+        anderson.reset();
+      }
+    }
+
+    // the test of the change, or with acceleration the test of the estimated error (see NLTE_OUTER_RELTOL)
+    double error_estimate = std::max(fracdiff_nne, fracdiff_T_e);
+    if constexpr (NLTE_OUTER_ANDERSON_DEPTH > 0) {
+      // the remaining error of a linear contraction with ratio rho is change * rho / (1 - rho). Each component
+      // gets its own ratio, because the T_e finder limits the change of T_e to a factor of two per pass.
+      const std::array<double, 2> change{fracdiff_T_e, fracdiff_nne};
+      std::array<double, 2> rho{};
+      error_estimate = 0.;
+      for (std::size_t i = 0; i < 2; i++) {
+        rho[i] = (change_prev[i] > 0.) ? std::min(change[i] / change_prev[i], 0.95) : 0.95;
+        error_estimate = std::max(error_estimate, change[i] * rho[i] / (1. - rho[i]));
+      }
+      change_prev = change;
+      printlnlog(
+          "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: T_e change {:g} contraction ratio "
+          "{:g}, nne change {:g} contraction ratio {:g}, estimated error {:g}",
+          mgi, nts, nlte_iter, change[0], rho[0], change[1], rho[1], error_estimate);
+    }
+
     // without the charge transfer option, the ion population test and the solution range test
     // always pass
-    if (fracdiff_nne <= nne_reltol && fracdiff_T_e <= T_e_reltol && fracdiff_nnion <= nne_reltol &&
-        !nlte_solution_changed) {
+    if (error_estimate <= NLTE_OUTER_RELTOL && fracdiff_nnion <= nne_reltol && !nlte_solution_changed) {
       printlnlog(
           "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: nne converged to tolerance {:g} <= {:g} "
           "and T_e to tolerance {:g} <= {:g}",

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -630,13 +630,14 @@ void update_grid_cell(const int nonemptymgi, const int nts, const int nts_prev, 
             1.);
       }
 
+      // the Saha populations replace the NLTE solution. The partition functions must not read the
+      // stale NLTE level populations, and the charge transfer reactions must not read the stored
+      // ion ranges of the last NLTE solve
+      nltepop_reset_cell(nonemptymgi);
       for (int element = 0; element < get_nelements(); element++) {
         calculate_cellpartfuncts(nonemptymgi, element);
       }
       calculate_ion_balance_nne(nonemptymgi);
-      // the Saha populations replace the NLTE solution, so the charge transfer reactions must not
-      // read the stored ion ranges of the last NLTE solve
-      nltepop_reset_solution_ranges(nonemptymgi);
       // no thermal balance: the k-packets keep their full energy
       kpkt::reset_radiative_energy_factor(nonemptymgi);
     } else {


### PR DESCRIPTION
## Summary

A new CI test `kilonova_2d_timedepnlte`. It starts from the model of `kilonova_2d` and runs from 7 to 10 days with:

- the nebular NLTE preset (`artisoptions_nltenebular.h`) with 30 excited NLTE levels per ion, `MINTEMP` 1000 K, `MAXTEMP` 20000 K, and the kilonova settings `USE_CALCULATED_MEANATOMICWEIGHT` and the time-dependent particle thermalisation;
- `NLTE_TIME_DEPENDENT_FIRST_TIMESTEP = 3` (#536);
- `NLTE_OUTER_ANDERSON_DEPTH = 2` and `NLTE_OUTER_RELTOL = 0.01` (#539);
- the atomic data set `atomicdata_sryzrlace.tar.zst` (Sr, Y, Zr, La, Ce) from the v2026.5.15 release. `ci.yml` caches it like the other data sets, and the setup script takes `compositiondata.txt` from the archive.

The run has 8 timesteps, 200000 packets, and 116 non-empty cells. Timesteps 0 and 1 are LTE, timestep 2 is a steady-state NLTE solve, and timesteps 3 to 7 are time-dependent. The first job runs timesteps 0 to 3 and the resume starts at timestep 3. The kilonova spectrum plot of this test uses 8.5 days.

This PR stacks on #539 and #540. It includes their commits until they merge. The test found the bug that #540 corrects: low density outer cells get no packets in some timesteps and go to the grey path.

## Local run (macOS, clang, 4 ranks)

- job0 55 s, job1 2 min 20 s, exspec 7 s. The checksum sets have 529 and 531 files.
- Only the five elements with atomic data can cool, but the non-thermal deposition of the whole mass heats them. The temperatures are therefore higher than in a real kilonova, and 44 of 116 cells reach `MAXTEMP` by timestep 7. The test is a regression test of the code paths, not a physics validation.
- One near-vacuum cell (`nne` of 22 cm^-3) has a 2-cycle between a Saha state at `MINTEMP` and an NLTE state at 2000 K, and reaches `NLTEITER` in every time-dependent timestep. This costs about 12 s per timestep.
- No stored checksums yet. The local checksums are from macOS and do not match Linux. A maintainer can make them with the "Update checksums" workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
