### PR TITLE
Reject a repeated photoionisation target level

### DIFF
--- a/input.cc
+++ b/input.cc
@@ -190,6 +190,25 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
 
         probability_sum += phixstargetprobability;
       }
+
+      // the file must give each target level only once. A repeated target level makes two continua that differ
+      // only in their probabilities. It also hides an error in the atomic data
+      for (int i = 0; i < in_nphixstargets; i++) {
+        for (int j = i + 1; j < in_nphixstargets; j++) {
+          if (tmpallphixstargets[phixstargetstart + i].levelindex ==
+              tmpallphixstargets[phixstargetstart + j].levelindex) {
+            printlnlog(
+                "[error] {}: Z={} ionstage {} level {}: the photoionisation table gives the level {} as target {} "
+                "and also as target {}. Each target level must occur only once. The two level numbers use the "
+                "numbering of the file",
+                phixsdata_filenames[phixs_file_version], get_atomicnumber(element), get_ionstage(element, lowerion),
+                lowerlevel + groundstate_index_in,
+                tmpallphixstargets[phixstargetstart + i].levelindex + groundstate_index_in, i, j);
+            assert_always(false);
+          }
+        }
+      }
+
       if (fabs(probability_sum - 1.0) > 0.01) {
         printlnlog(
             "[error] photoionisation table for Z={} ionstage {} level {} has target probabilities that sum to "
@@ -1780,7 +1799,16 @@ void write_bflist_file() {
 
           const int et = -1 - i;
 
-          assert_always(et == get_emtype_continuum(element, ion, level, phixstargetindex));
+          // the position in bflist and the emission type of the continuum must agree, because
+          // get_bflistindex_from_emtype_continuum() decodes an emission type back into a bflist index
+          const int et_oflevel = get_emtype_continuum(element, ion, level, phixstargetindex);
+          if (et != et_oflevel) {
+            printlnlog(
+                "[error] write_bflist_file: Z={} ionstage {} level {} target {} has the emission type {}, but "
+                "position {} in bflist gives the emission type {}",
+                get_atomicnumber(element), get_ionstage(element, ion), level, phixstargetindex, et_oflevel, i, et);
+            assert_always(false);
+          }
 
           // check the we don't overload the same packet emission type numbers
           // as the special values for free-free scattering and not set


### PR DESCRIPTION
## What this changes

`read_phixs_data_table()` accepted a target table that gave the same upper level more than once. Such a table makes two continua that differ only in their probabilities. It also hides an error in the atomic data.

The code now reports the file, the atomic number, the ionstage, the level, the two target indices, and the repeated target level, and then stops. Example:

```
[error] phixsdata_v2.txt: Z=8 ionstage 4 level 96: the photoionisation table gives the level 1 as target 0 and also as target 1. Each target level must occur only once. The two level numbers use the numbering of the file
```

The two level numbers use the numbering of the file, so you can find the table with them.

`write_bflist_file()` also names the atomic number, the ionstage, the level, and the target index if the position in `bflist` disagrees with the emission type of the continuum. Before this change the assertion gave only the expression.

## Why

A repeated target level made a version of ARTIS before #524 stop in `write_bflist_file()`. That version found the target index with a search on the upper level, which is not a unique key. #524 corrected the index, so the current code runs, but it makes two identical continua for each such level. The data is still wrong, so the code must report it.

## Results

The results do not change. A run that passed the old assertion also passes the new test.

## Tests

- `make` and `make OPTIMIZE=OFF` compile clean.
- `./unittests`: 162 of 162 checks passed.
- I looked at the photoionisation files of the test data. `atomicdata_feconi` has 13790 tables and `atomicdata_hefeconi_fe_i_to_vii` has 20538 tables. Neither has a repeated target level, so the end-to-end tests are not affected. `atomicdata_classic` uses the v1 format, which gives one target for each table.
- A full kilonova dataset with 9 such tables (in O IV and F II) stops with the message above. The message agrees with the table at line 291073 of that `phixsdata_v2.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)