### PR TITLE
Use the ion's own slot for the ground continuum estimator writes

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -254,9 +254,10 @@ struct AllCont {
   MPI_shared_array<const int> uniquelevelindex;
   MPI_shared_array<const double> probability;
   // index into the ground-level continuum estimator arrays, or -1 for continua that do not feed them
-  // (only a ground level's first photoionisation target does). This is the nearest-nu_edge slot found by
-  // search_groundphixslist(), the same value closestgroundlevelcont holds, which is not necessarily the
-  // ion's own get_groundcontindex() slot when two ions share a ground-state threshold.
+  // (only a ground level's first photoionisation target does). This is the ion's own
+  // get_groundcontindex() slot, the same slot where update_grid.cc normalises and applies the
+  // estimators. setup_phixs_list() checks that the nearest-nu_edge search agrees for every ground
+  // level, so a dataset with two identical ground thresholds stops at startup.
   MPI_shared_array<const int> groundcontestimindex;
   MPI_shared_array<const int> bfestimindex;
 };

--- a/globals.h
+++ b/globals.h
@@ -256,7 +256,7 @@ struct AllCont {
   // index into the ground-level continuum estimator arrays, or -1 for continua that do not feed them
   // (only a ground level's first photoionisation target does). This is the ion's own
   // get_groundcontindex() slot, the same slot where update_grid.cc normalises and applies the
-  // estimators. setup_phixs_list() checks that the nearest-nu_edge search agrees for every ground
+  // estimators. setup_phixs_list() checks that the nearest-edge search agrees for every ground
   // level, so a dataset with two identical ground thresholds stops at startup.
   MPI_shared_array<const int> groundcontestimindex;
   MPI_shared_array<const int> bfestimindex;

--- a/input.cc
+++ b/input.cc
@@ -865,17 +865,24 @@ void setup_phixs_list() {
             const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
             alllevels_closestgroundlevelcont[uniquelevelindex] =
                 search_groundphixslist(nu_edge_target0, element, ion, level);
+            if (level == 0) {
+              // update_grid.cc normalises and applies the ground continuum estimators at the
+              // groundcontindex slot, and the writes below use the same slot. The nearest-edge search
+              // gives another ion's slot only when two ions have an identical ground threshold, which
+              // would silently mix the estimators of the two ions.
+              assert_always(alllevels_closestgroundlevelcont[uniquelevelindex] == groundcontindex);
+            }
           }
 
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             assert_always(allcontindex < std::ssize(allcont));
 
-            // See AllCont::groundcontestimindex. closestgroundlevelcont is left at its -1 initialiser when
-            // neither estimator is enabled, so no further guard on those options is needed here.
-            // TODO: the estimators are written at this nearest-edge slot but normalised in update_grid.cc
-            // at get_groundcontindex(element, ion); the two disagree if two ions share a ground threshold.
+            // See AllCont::groundcontestimindex. The value stays -1 when neither estimator is
+            // enabled, because the estimator arrays then do not exist.
             const int groundcontestimindex =
-                (level == 0 && phixstargetindex == 0) ? alllevels_closestgroundlevelcont[uniquelevelindex] : -1;
+                (level == 0 && phixstargetindex == 0 && (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS))
+                    ? groundcontindex
+                    : -1;
 
             allcont[allcontindex] = {
                 .nu_edge = get_phixs_threshold(element, ion, level, phixstargetindex) / H,

--- a/input.cc
+++ b/input.cc
@@ -868,17 +868,25 @@ void setup_phixs_list() {
             if (level == 0) {
               // update_grid.cc normalises and applies the ground continuum estimators at the
               // groundcontindex slot, and the writes below use the same slot. The nearest-edge search
-              // gives another ion's slot only when two ions have an identical ground threshold, which
-              // would silently mix the estimators of the two ions.
-              assert_always(alllevels_closestgroundlevelcont[uniquelevelindex] == groundcontindex);
+              // gives another ion's slot only when two ions have an identical ground threshold. That
+              // case would silently mix the estimators of the two ions.
+              if (const int foundslot = alllevels_closestgroundlevelcont[uniquelevelindex];
+                  foundslot != groundcontindex) {
+                printlnlog(
+                    "[error] element {} ion {} has the ground continuum slot {}, but the nearest-edge search "
+                    "found the slot {} of element {} ion {}. Two ions have an identical ground threshold {:g}.",
+                    element, ion, groundcontindex, foundslot, globals::groundcont_element[foundslot],
+                    globals::groundcont_ion[foundslot], nu_edge_target0);
+                std::abort();
+              }
             }
           }
 
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             assert_always(allcontindex < std::ssize(allcont));
 
-            // See AllCont::groundcontestimindex. The value stays -1 when neither estimator is
-            // enabled, because the estimator arrays then do not exist.
+            // See AllCont::groundcontestimindex. The value stays -1 when no option enables an
+            // estimator, because the estimator arrays then do not exist.
             const int groundcontestimindex =
                 (level == 0 && phixstargetindex == 0 && (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS))
                     ? groundcontindex


### PR DESCRIPTION
## Problem

The Monte Carlo contributions to `gammaestimator` and `bfheatingestimator` went to the nearest-edge slot that `search_groundphixslist()` found for the ground level. `update_grid.cc` normalises and applies the estimators at `get_groundcontindex(element, ion)`. The two slots differ when two ions have an identical ground threshold, e.g. from duplicate energy-0 levels in the atomic data (the tie resolves to the lower slot). One ion then read a zero estimator, so `iongamma_is_zero()` reported zero photoionisation for it, and the other ion read a mixed slot. The code carried a TODO comment for exactly this mismatch.

## Fix

- Set `groundcontestimindex` from the ion's own `groundcontindex`, which is the slot where the estimators are normalised and applied.
- Assert at startup that the nearest-edge search agrees for every ground level. A dataset with two identical ground thresholds now stops at startup instead of a silent estimator mix.
- Update the `AllCont::groundcontestimindex` comment in globals.h.

## Effect on the results

The results do not change for a dataset with unique ground thresholds, because the two slots are then identical. The excited-level nearest-edge association (`closestgroundlevelcont`, used by ratecoeff.cc and thermalbalance.cc) keeps its behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)