### PR TITLE
Harden the flat index arithmetic of the NLTE population array

### DIFF
--- a/nltepop.cc
+++ b/nltepop.cc
@@ -465,7 +465,7 @@ void nltepop_reset_element(const int nonemptymgi, const int element) {
   grid::set_elements_lowermost_ion(nonemptymgi, element, 0);
   for (int ion = 0; ion < get_nions(element); ion++) {
     const int nlte_start = get_allnltelevelsindexstart(element, ion);
-    std::fill_n(&nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + nlte_start],
+    std::fill_n(&nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) + nlte_start],
                 get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0), -1.);
   }
 }
@@ -880,15 +880,15 @@ void set_nlte_levelpop_over_rho(const int nonemptymgi, const int element, const 
                                 const double value) {
   assert_testmodeonly(level > 0);  // ground state is stored separately
   assert_testmodeonly(level <= get_nlevels_excited_nlte(element, ion));
-  nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + get_allnltelevelsindexstart(element, ion) + level -
-                    1] = value;
+  nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) +
+                    get_allnltelevelsindexstart(element, ion) + level - 1] = value;
 }
 
 void set_nlte_superlevelpop_over_rho_over_slpartfunc(const int nonemptymgi, const int element, const int ion,
                                                      const double value) {
   assert_testmodeonly(ion_has_superlevel(element, ion));
   const int sl_nlte_index = get_allnltelevelsindexstart(element, ion) + get_nlevels_excited_nlte(element, ion);
-  nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + sl_nlte_index] = value;
+  nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) + sl_nlte_index] = value;
 }
 
 void set_element_pops_lte(const int nonemptymgi, const int element) {
@@ -2209,5 +2209,5 @@ DEVICE_FUNC auto get_nlte_levelpop_over_rho(const int nonemptymgi, const int ele
                                                                                const int ion) -> double {
   assert_testmodeonly(ion_has_superlevel(element, ion));
   const int sl_nlte_index = get_allnltelevelsindexstart(element, ion) + get_nlevels_excited_nlte(element, ion);
-  return nltepops_allcells[(nonemptymgi * globals::total_nlte_levels) + sl_nlte_index];
+  return nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) + sl_nlte_index];
 }

--- a/radfield.cc
+++ b/radfield.cc
@@ -678,13 +678,18 @@ void initialise_prev_titer_photoionestimators() {
     for (int element = 0; element < get_nelements(); element++) {
       const int nions = get_nions(element);
       for (int ion = 0; ion < nions - 1; ion++) {
+        const int groundcontindex = get_groundcontindex(element, ion);
+        if (groundcontindex < 0) {
+          // an ion without a ground photoionisation table has no estimator slot
+          continue;
+        }
         if constexpr (USE_LUT_PHOTOION) {
           globals::gammaestimator_save[(static_cast<ptrdiff_t>(nonemptymgi) * globals::nbfcontinua_ground) +
-                                       get_groundcontindex(element, ion)] = -1.;
+                                       groundcontindex] = -1.;
         }
         if constexpr (USE_ION_BFHEATING_ESTIMATORS) {
           globals::bfheatingestimator_save[(static_cast<ptrdiff_t>(nonemptymgi) * globals::nbfcontinua_ground) +
-                                           get_groundcontindex(element, ion)] = -1.;
+                                           groundcontindex] = -1.;
         }
       }
     }


### PR DESCRIPTION
## Problem

Four sites computed `nonemptymgi * globals::total_nlte_levels` with `int` operands: `nltepop_reset_element()`, `set_nlte_levelpop_over_rho()`, `set_nlte_superlevelpop_over_rho_over_slpartfunc()`, and `get_nlte_superlevelpop_over_rho_over_slpartfunc()`. The read path `get_nlte_levelpop_over_rho()` already casts to `ptrdiff_t`, and the allocation and the restart loops are also `ptrdiff_t` safe. The product overflows (undefined behaviour) once the nonempty cells times the total NLTE levels reach 2^31, e.g. ~500k cells with ~4500 NLTE level slots. The writes then wrap while the excited-level reads stay correct, so a large 3D NLTE model would silently put level populations into the slots of a different cell.

A second small issue: `initialise_prev_titer_photoionestimators()` indexed the DO_TITER save arrays with `get_groundcontindex(element, ion)` without the `< 0` guard that every other user has. The function gives -1 for an ion whose ground level has no photoionisation table, and the write then went before the start of the array. No preset or Makefile path defines `DO_TITER`, so this path is currently inactive.

## Fix

- Cast the four flat-index sites to `ptrdiff_t`, in the same form as the read path.
- Skip an ion with `get_groundcontindex() < 0` in the DO_TITER initialisation. The block is compiled out by default, so it was also syntax-checked with `-DDO_TITER`.

## Effect on the results

The results do not change. The overflow needs a model beyond current production sizes, and the DO_TITER path is inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)