### PR TITLE
Correct the iteration bookkeeping of the NLTE solver loop

### DIFF
--- a/update_grid.cc
+++ b/update_grid.cc
@@ -372,6 +372,9 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
         significant_ions_prev = significant_ions;
         // the previous iterate belongs to the previous state, so this pass takes no step from it
         map_changed = map_changed || (nlte_iter > 0);
+        // the changes of the previous pass also belong to the previous state, so the contraction
+        // ratio of this pass and of the next pass must not compare across the two maps
+        change_prev = {-1., -1.};
       }
       const auto log_state_solved = get_log_te_nne_ionpops(nonemptymgi, significant_ions);
       if (nlte_iter > 0) {
@@ -471,8 +474,7 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
           }
           printlnlog(
               "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: Anderson step {} with {} "
-              "significant_ions "
-              "ions: T_e {:g} nne {:e} from the pass, T_e {:g} nne {:e} for the next pass",
+              "significant ions: T_e {:g} nne {:e} from the pass, T_e {:g} nne {:e} for the next pass",
               mgi, nts, nlte_iter, step_accepted ? "accepted" : "rejected", significant_ions.size(),
               std::exp(log_state_solved[0]), std::exp(log_state_solved[1]), grid::Te_allcells[nonemptymgi],
               grid::get_nne(nonemptymgi));
@@ -575,11 +577,27 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
       // the equations only, and the ion population test measures every change that it makes.
       if (fracdiff_nne <= NLTE_TE_NNE_RELTOL && fracdiff_T_e <= NLTE_TE_NNE_RELTOL &&
           fracdiff_nnion <= NLTE_TE_NNE_RELTOL) {
-        printlnlog(
-            "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: nne converged to tolerance {:g} <= "
-            "{:g} and T_e to tolerance {:g} <= {:g}",
-            mgi, nts, nlte_iter, fracdiff_nne, NLTE_TE_NNE_RELTOL, fracdiff_T_e, NLTE_TE_NNE_RELTOL);
-        break;
+        // The charge transfer rates of an element read the solved ion range of a partner element
+        // from the last solve of that partner (see sum_reaction_list() in chargetransfer.cc). The
+        // elements solve in order, so a pass that changed the range of a later element gave the
+        // earlier elements the previous range. One more sweep gives those elements the new range,
+        // as the accelerated branch does. Only the first such pass of the cell holds the
+        // convergence, because a range that oscillates would otherwise use every pass.
+        const bool hold_for_range_sweep =
+            ENABLE_CHARGE_TRANSFER_REACTIONS && nlte_solution_changed && !extra_range_sweep_used;
+        if (hold_for_range_sweep) {
+          extra_range_sweep_used = true;
+          printlnlog(
+              "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: the changes converged, but a "
+              "solution range changed. The solver makes one more sweep for the charge transfer rates.",
+              mgi, nts, nlte_iter);
+        } else {
+          printlnlog(
+              "NLTE (Spencer-Fano/Te/pops) solver mgi {} timestep {} iteration {}: nne converged to tolerance {:g} <= "
+              "{:g} and T_e to tolerance {:g} <= {:g}",
+              mgi, nts, nlte_iter, fracdiff_nne, NLTE_TE_NNE_RELTOL, fracdiff_T_e, NLTE_TE_NNE_RELTOL);
+          break;
+        }
       }
     }
     if (nlte_iter == NLTE_TE_NNE_MAXITER) {


### PR DESCRIPTION
Three corrections for the outer NLTE iteration from #549.

## Range sweep for the plain convergence test

The plain (non-accelerated) convergence test could stop on the pass that changed a solved ion range. The charge transfer rates of an element read the solved ion range of a partner element from the last solve of that partner (see `sum_reaction_list()` in chargetransfer.cc), and the elements solve in order. The earlier elements therefore kept charge transfer rates from the previous range, with no reciprocal transition on the partner side. #549 added the one-time `hold_for_range_sweep` to the accelerated branch for exactly this case, and the plain branch now holds the convergence in the same way. Only a build with `ENABLE_CHARGE_TRANSFER_REACTIONS = true` and `NLTE_TE_NNE_USE_ANDERSON_ACCEL = false` reaches this hold. No shipped preset combines the two options.

## change_prev reset on a set change

A mid-pass change of the significant-ion set forced `map_changed` for that pass, but the end of the pass overwrites `map_changed` with `nlte_solution_changed`. The top-of-loop reset of `change_prev` then did not fire, and the contraction ratio of the next pass compared the changes of two different maps. The set-change block now resets `change_prev` directly. The [0.5, 0.95] clamp bounds the effect, so this only sharpens the error estimate and never changes the self-consistency of the converged state.

## Log text

The Anderson step log line read "with 3 significant_ions ions".

## Effect on the results

The results do not change under any shipped preset. The range sweep needs an option combination that no preset uses, and the `change_prev` reset changes at most the pass count of a cell whose significant-ion set changes mid-iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)