### PR TITLE
Make the input readers stop on corrupt data

### DIFF
--- a/grid.cc
+++ b/grid.cc
@@ -687,6 +687,11 @@ void read_elem_abundances() {
     auto abundance_file = fstream_required("abundances.txt", std::ios::in);
     std::string line;
 
+    // Every log line gets a timestamp and a flush, so a large 3D model must not warn per cell.
+    // The count gives one summary line after the loop instead.
+    int ncells_abund_unnormalised = 0;
+    constexpr int max_unnormalised_warnings = 10;
+
     // loop over propagation cells for 3D models, or modelgrid cells
     for (int mgi = 0; mgi < get_npts_model(); mgi++) {
       assert_always(get_noncommentline(abundance_file, line));
@@ -734,10 +739,13 @@ void read_elem_abundances() {
           // a 3D file holds true mass fractions and gets no normalisation, so a sum far from one is
           // a sign of a file that holds proportional values, e.g. densities
           if (threedimensional && normfactor > 0. && std::abs(normfactor - 1.) > 0.02) {
-            printlnlog(
-                "[warning] read_elem_abundances: 3D cell {} has element mass fractions that sum to {:g}. The values "
-                "are used without normalisation.",
-                cellnumberinput, normfactor);
+            ncells_abund_unnormalised++;
+            if (ncells_abund_unnormalised <= max_unnormalised_warnings) {
+              printlnlog(
+                  "[warning] read_elem_abundances: 3D cell {} has element mass fractions that sum to {:g}. The values "
+                  "are used without normalisation.",
+                  cellnumberinput, normfactor);
+            }
           }
           normfactor = 1.;
         }
@@ -760,6 +768,13 @@ void read_elem_abundances() {
           set_elem_massfrac(nonemptymgi, element, elemmassfrac);
         }
       }
+    }
+
+    if (ncells_abund_unnormalised > max_unnormalised_warnings) {
+      printlnlog(
+          "[warning] read_elem_abundances: {} cells in total have element mass fractions that do not sum to one. The "
+          "first {} are listed above.",
+          ncells_abund_unnormalised, max_unnormalised_warnings);
     }
   }
 

--- a/grid.cc
+++ b/grid.cc
@@ -696,8 +696,10 @@ void read_elem_abundances() {
       assert_always(parse_next_token(remainder, cellnumberinput));
       assert_always(cellnumberinput == mgi + first_input_cellid);
 
-      // the abundances.txt file specifies the elemental mass fractions for each model cell
-      // (or proportional to mass frac, e.g. element densities, because they will be normalised anyway)
+      // the abundances.txt file specifies the elemental mass fractions for each model cell.
+      // A 1D or 2D file may hold values proportional to the mass fractions, e.g. element densities,
+      // because those get normalised below. A 3D file must hold true mass fractions, because the 3D
+      // path applies no normalisation.
       // The abundances begin with hydrogen, helium, etc, going as far up the atomic numbers as required
       double normfactor = 0.;
       std::array<float, 150> elem_massfracs_in{};
@@ -718,8 +720,25 @@ void read_elem_abundances() {
         normfactor += elem_massfracs_in[elem_z_index];
       }
 
+      // parse_next_token() gives false at the end of the row and also for a token that is not a
+      // number, e.g. "nan". The loop above stops on both, so a bad token would silently zero every
+      // later element. Only whitespace may remain here.
+      remainder.remove_prefix(std::min(remainder.find_first_not_of(" \t\r"), remainder.size()));
+      if (!remainder.empty()) {
+        printlnlog("[error] read_elem_abundances: cell {} has an unreadable token at '{}'", cellnumberinput, remainder);
+        std::abort();
+      }
+
       if (get_numpropcells(mgi) > 0) {
         if (threedimensional || normfactor <= 0.) {
+          // a 3D file holds true mass fractions and gets no normalisation, so a sum far from one is
+          // a sign of a file that holds proportional values, e.g. densities
+          if (threedimensional && normfactor > 0. && std::abs(normfactor - 1.) > 0.02) {
+            printlnlog(
+                "[warning] read_elem_abundances: 3D cell {} has element mass fractions that sum to {:g}. The values "
+                "are used without normalisation.",
+                cellnumberinput, normfactor);
+          }
           normfactor = 1.;
         }
         const int nonemptymgi = get_nonemptymgi_of_mgi(mgi);

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -305,6 +305,9 @@ auto read_shell_configs() {
     }
     zminusone++;
   }
+  // a truncated file would leave the remaining elements with zero occupancies, and a zero-occupancy
+  // element silently gets a zero non-thermal ionisation rate
+  assert_always(zminusone == std::ssize(elements_shells_q));
   return elements_shells_q;
 }
 
@@ -755,6 +758,24 @@ void zero_all_effionpot(const ptrdiff_t nonemptymgi) {
   return std::clamp(index, 0, SFPTS - 1);
 }
 
+// The exclusive row limit of the Auger electron source term of a shell: the rows [0, limit) lie
+// below the mean Auger electron energy and receive the source. The limit is 0 for a shell that
+// injects nothing, and SFPTS when the Auger energy is above the top of the grid, because every row
+// is then below it. analyse_sf_solution() subtracts the recycled Auger energy from the ionisation
+// fraction only when this limit is positive, so the two sites must use this same function.
+[[nodiscard]] constexpr auto get_auger_rowstopindex(const ShellParams& collionrow) -> int {
+  if (!SF_AUGER_CONTRIBUTION_ON || collionrow.en_auger_ev <= 0.) {
+    return 0;
+  }
+  double en_inject_ev = collionrow.en_auger_ev;
+  if constexpr (SF_AUGER_CONTRIBUTION_DISTRIBUTE_EN) {
+    // en_auger_ev is averaged to include some probability of zero Auger electrons, so a boost gives
+    // the mean energy on the condition that one or more Auger electrons exist
+    en_inject_ev /= (1. - collionrow.prob_num_auger[0]);
+  }
+  return (en_inject_ev > SF_EMAX) ? SFPTS : get_energyindex_ev_gteq(en_inject_ev);
+}
+
 // interpolate the y flux values to get the value at a given energy
 // y has units of particles / cm2 / s / eV
 [[nodiscard]] constexpr auto get_y(const std::array<double, SFPTS>& yfunc, const double energy_ev) -> double {
@@ -858,7 +879,9 @@ auto get_xs_ionisation_vector(std::array<double, SFPTS>& xs_vec, const ShellPara
     const double xs_ioniz =
         1e-14 * ((A * (1 - (1 / u))) + (B * pow2(1 - (1 / u))) + (C * std::log(u)) + (D * std::log(u) / u)) /
         (u * pow2(ionpot_ev));
-    xs_vec[i] = xs_ioniz;
+    // a fit with A + C + D < 0 dips below zero just above the threshold, and a negative cross
+    // section must not enter the matrix (the Lotz path has the same guard)
+    xs_vec[i] = std::max(xs_ioniz, 0.);
   }
 
   return startindex;
@@ -994,8 +1017,10 @@ constexpr auto xs_impactionisation(const double energy_ev, const ShellParams& co
   const double C = colliondata_ion.C;
   const double D = colliondata_ion.D;
 
-  return 1e-14 * ((A * (1 - (1 / u))) + (B * pow2((1 - (1 / u)))) + (C * std::log(u)) + (D * std::log(u) / u)) /
-         (u * pow2(ionpot_ev));
+  // the maximum keeps a fit that dips below zero just above the threshold out of the rates
+  return std::max(
+      0., 1e-14 * ((A * (1 - (1 / u))) + (B * pow2((1 - (1 / u)))) + (C * std::log(u)) + (D * std::log(u) / u)) /
+              (u * pow2(ionpot_ev)));
 }
 
 // N(E) of KF92 equation 11: the rate at which electrons appear at an energy E below the solved grid.
@@ -1606,9 +1631,13 @@ void analyse_sf_solution(const int nonemptymgi, const int timestep, const std::a
             calculate_nt_frac_ionisation_shell(nonemptymgi, element, ion, collionrow, yfunc);
         // with SF_AUGER_CONTRIBUTION_ON, the mean Auger energy per ionisation is re-injected into the
         // electron pool and gets counted in the heating/excitation fractions, so only the net energy
-        // removed per ionisation (shell potential minus Auger energy) counts as ionisation here
+        // removed per ionisation (shell potential minus Auger energy) counts as ionisation here.
+        // The subtraction only applies when the matrix really injected the source, which
+        // get_auger_rowstopindex() decides for both sites.
         const double frac_auger_recycled =
-            SF_AUGER_CONTRIBUTION_ON ? frac_ionisation_ion_shell * collionrow.en_auger_ev / collionrow.ionpot_ev : 0.;
+            (get_auger_rowstopindex(collionrow) > 0)
+                ? frac_ionisation_ion_shell * collionrow.en_auger_ev / collionrow.ionpot_ev
+                : 0.;
         frac_ionisation_ion += frac_ionisation_ion_shell - frac_auger_recycled;
         matching_subshell_count++;
 
@@ -2085,18 +2114,8 @@ void sfmatrix_add_ionisation(std::span<double> sfmatrixuppertri, const int Z, co
       // mean Auger electron energy as a delta function (or spread below it, see below).
       // shells with no Auger data have en_auger_ev == 0 (and prob_num_auger[0] == 1, which would make the
       // energy boost factor below infinite) and inject no Auger electrons
-      if (SF_AUGER_CONTRIBUTION_ON && en_auger_ev > 0.) {
-        int augerstopindex = 0;
-        if constexpr (SF_AUGER_CONTRIBUTION_DISTRIBUTE_EN) {
-          // en_auger_ev is (if LJS understands it correctly) averaged to include some probability of zero Auger
-          // electrons so we need a boost to get the average energy of Auger electrons given that there are one or more
-          const double en_boost = 1 / (1. - collionrow.prob_num_auger[0]);
-
-          augerstopindex = get_energyindex_ev_gteq(en_auger_ev * en_boost);
-        } else {
-          augerstopindex = get_energyindex_ev_gteq(en_auger_ev);
-        }
-
+      const int augerstopindex = get_auger_rowstopindex(collionrow);
+      if (augerstopindex > 0) {
         for (int i = 0; i < augerstopindex; i++) {
           const int rowoffset = uppertriangular(i, 0);
           const double en = engrid(i);

--- a/packet.cc
+++ b/packet.cc
@@ -170,8 +170,34 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
   std::getline(packets_file, line);  // read header line to make sure it matches
   assert_always(line == get_packets_text_header());
 
+  // the column count of the header line, for the completeness check of each row
+  const int ncolumns = [] {
+    std::istringstream ssheader{get_packets_text_header()};
+    std::string token;
+    int n = 0;
+    while (ssheader >> token) {
+      n++;
+    }
+    return n;
+  }();
+
+  std::string token;
   packets.reserve(MPKTS);
   while (get_noncommentline(packets_file, line)) {
+    // A complete row has exactly the column count of the header. The count check finds a truncated
+    // row even in the trailing fields that can legitimately hold "nan", where the stream state
+    // check below cannot.
+    ssline.clear();
+    ssline.str(line);
+    int ntokens = 0;
+    while (ssline >> token) {
+      ntokens++;
+    }
+    if (ntokens != ncolumns) {
+      printlnlog("[error] read_text_packets: the row has {} of {} columns: '{}'", ntokens, ncolumns, line);
+      std::abort();
+    }
+
     ssline.clear();
     ssline.str(line);
 

--- a/packet.cc
+++ b/packet.cc
@@ -192,6 +192,15 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
     pkt.escape_type = static_cast<enum packet_type>(escape_type);
 
     ssline >> pkt.emissiontype >> pkt.trueemissiontype;
+
+    // Every field up to this point is never NAN, so a failed stream here is a truncated or corrupt
+    // row, e.g. from a partial write on a full file system. A silently accepted truncated row would
+    // drop the packet from the spectra (escape_type stays 0) with no diagnostic.
+    if (ssline.fail()) {
+      printlnlog("[error] read_text_packets: could not parse the packet row '{}'", line);
+      std::abort();
+    }
+
     ssline >> pkt.em_pos[0] >> pkt.em_pos[1] >> pkt.em_pos[2];
     ssline >> pkt.absorptiontype >> pkt.absorptionfreq >> pkt.nscatterings;
     ssline >> pkt.em_time;


### PR DESCRIPTION
Four robustness corrections for silently accepted bad input. The results do not change for valid input files and the shipped datasets.

## Truncated packet rows

`read_text_packets()` accepted a truncated packet row, because the stream state is deliberately unchecked for the trailing fields that can hold NAN (`em_pos`, `absorptionfreq`, `trueem_pos`). A row truncated by a partial write (e.g. a full file system at job end) left `escape_type` at 0, so exspec silently dropped the packet from all spectra and light curves. The reader now checks the stream state after `trueemissiontype`, the last field that is never NAN, and stops with an error that prints the row.

## Truncated abundances.txt rows and 3D normalisation

`parse_next_token()` gives false both at the end of a row and for a token that is not a number, e.g. `nan` from a hydro post-processing script. `read_elem_abundances()` stopped the row on both, so every element after a bad token silently became zero, and (for 1D/2D) the surviving elements renormalised over the truncated sum. The reader now stops with an error when a row ends with an unreadable token, matching the strictness of the model.txt reader.

A 3D abundances.txt gets no normalisation (1D and 2D files do), so a 3D file scaled like a 1D one silently gave mass fractions that do not sum to one. The reader now warns when the sum deviates from one by more than 2 percent, and the comment that claimed 3D values "will be normalised anyway" is corrected.

## Younger fit cross sections

The Younger (1981) fit for an impact ionisation cross section dips below zero just above the threshold when A + C + D < 0. A negative cross section entered the Spencer-Fano matrix and the ionisation rates. Both evaluation sites now clamp to zero, as the Lotz path already did.

## Non-thermal data edges

`read_shell_configs()` accepted a truncated `electron_shell_occupancy.txt`, which left the remaining elements with zero occupancies and a silent zero non-thermal ionisation rate (`eff_ionpot` becomes inf). The reader now asserts the row count.

The Auger source term and the recycled-energy subtraction in `analyse_sf_solution()` used two independent conditions, which diverge for an Auger energy below `SF_EMIN` (subtracted but never injected) or above `SF_EMAX` (the top row was excluded although the energy lies above every row). Both sites now use one shared row limit, and an above-grid Auger energy feeds every row. The shipped Kaastra & Mewe (1993) data (Z <= 30) stays inside the old limits, so the results do not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)