### PR TITLE
Escape through the spherical surface when no cell boundary lies ahead

### DIFF
--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -785,8 +785,6 @@ void barnes_thermalisation(Packet& pkt) {
 
   // determine average initial density via kinetic energy
   const double E_kin = grid::get_ejecta_kinetic_energy();
-  // the grid-mapped mass matches the cells that the kinetic energy sums, which mtot_input does
-  // not after the mapping or the spherical escape surface removes mass
   const double m_ej = grid::get_ejecta_mass();
   const double v_ej = sqrt(E_kin * 2 / m_ej);
 

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -785,10 +785,13 @@ void barnes_thermalisation(Packet& pkt) {
 
   // determine average initial density via kinetic energy
   const double E_kin = grid::get_ejecta_kinetic_energy();
-  const double v_ej = sqrt(E_kin * 2 / grid::mtot_input);
+  // the grid-mapped mass matches the cells that the kinetic energy sums, which mtot_input does
+  // not after the mapping or the spherical escape surface removes mass
+  const double m_ej = grid::get_ejecta_mass();
+  const double v_ej = sqrt(E_kin * 2 / m_ej);
 
   // t_ineff = sqrt(rho_0 * R_0 * t_0^2 * mean_gamma_opac), expressed via the paper's scaling relation.
-  const double t_ineff = 1.4 * DAY * sqrt(grid::mtot_input / (5.e-3 * MSUN)) * ((0.2 * CLIGHT) / v_ej);
+  const double t_ineff = 1.4 * DAY * sqrt(m_ej / (5.e-3 * MSUN)) * ((0.2 * CLIGHT) / v_ej);
   const double tau = pow2(t_ineff / pkt.prop_time);
   const double f_gamma = 1. - exp(-tau);
 

--- a/grid.cc
+++ b/grid.cc
@@ -82,6 +82,11 @@ std::array<std::vector<double>, 3> coord_pos_min_tmin{};
 std::vector<int> propcell_mgi;
 std::vector<int> propcell_nonemptymgi;
 
+// with FORCE_SPHERICAL_ESCAPE_SURFACE: 1 for a propagation cell whose inner corner lies outside the
+// spherical escape surface. boundary_distance() runs for every packet step, so the per-cell radius
+// comparison is precomputed here instead of repeated there.
+std::vector<uint8_t> propcell_outside_escape_surface;
+
 std::vector<int> modelgrid_numpropcells;
 std::vector<int> nonemptymgi_of_mgi;
 std::vector<int> mgi_of_nonemptymgi;
@@ -512,8 +517,17 @@ void allocate_nonemptymodelcells() {
   reserve_resize(totmassnuclide_blanked, decay::get_num_nuclides());
   std::ranges::fill(totmassnuclide_blanked, 0.);
 
+  if constexpr (FORCE_SPHERICAL_ESCAPE_SURFACE) {
+    reserve_resize(propcell_outside_escape_surface, ngrid);
+  }
+
   for (int cellindex = 0; cellindex < ngrid; cellindex++) {
     const auto radial_pos_mid = get_cellradialposmid(cellindex);
+
+    if constexpr (FORCE_SPHERICAL_ESCAPE_SURFACE) {
+      propcell_outside_escape_surface[cellindex] =
+          (get_cell_r_inner(cellindex, get_propgridtype()) > globals::rmax) ? 1 : 0;
+    }
 
     if (FORCE_SPHERICAL_ESCAPE_SURFACE && radial_pos_mid > globals::vmax * globals::tmin) {
       // for 1D models, the final shell outer v should already be at vmax
@@ -2627,7 +2641,9 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
                                                  const int cellindex) -> std::tuple<double, int> {
   const auto prop_gridtype = get_propgridtype();
   if constexpr (FORCE_SPHERICAL_ESCAPE_SURFACE) {
-    if (get_cell_r_inner(cellindex, prop_gridtype) > globals::rmax) {
+    // allocate_nonemptymodelcells() precomputed the radius comparison per cell, because this
+    // function runs for every packet step
+    if (propcell_outside_escape_surface[cellindex] != 0) {
       return {0., -99};
     }
   }

--- a/grid.cc
+++ b/grid.cc
@@ -2919,8 +2919,17 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
 
       // Truncation must act on whole cells to keep the volumes and the packet statistics valid.
       // The trapped packet never leaves this cell. The arrival time is constant along a free ray,
-      // so a mid-cell escape is valid only for a cell with no matter.
-      assert_always(get_propcell_modelgridindex(cellindex) < 0);
+      // so a mid-cell escape is valid only for a cell with no matter. A matter cell can trap
+      // packets only when the cell diagonal spans from below vmax to above CLIGHT, so a finer
+      // grid removes this stop.
+      if (get_propcell_modelgridindex(cellindex) >= 0) {
+        printlnlog(
+            "[error] a packet cannot reach any boundary of matter cell {}, because every boundary recedes faster "
+            "than light. The cell reaches from inside the escape surface to beyond the light speed, so the grid is "
+            "too coarse. Use more grid cells per axis.",
+            cellindex);
+        assert_always(false);
+      }
 
       const double r_surface = globals::rmax * tstart / globals::tmin;
       if (dot(pos, pos) >= pow2(r_surface)) {

--- a/grid.cc
+++ b/grid.cc
@@ -2883,6 +2883,20 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
     assert_always(false);
   }
 
+  if constexpr (FORCE_SPHERICAL_ESCAPE_SURFACE) {
+    if (next_cellindex == -1) {
+      // No cell boundary lies ahead of the packet: every velocity component of the packet is inside
+      // the range of the receding boundary velocities of its cell. Only a corner-region cell of a
+      // grid with vmax > CLIGHT / sqrt(3) has such a range. The packet still overtakes the slower
+      // spherical escape surface, because that surface expands at vmax < CLIGHT. The packet
+      // therefore escapes where its ray meets the expanding sphere.
+      distance = expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, CLIGHT_PROP,
+                                                                   globals::rmax * tstart / globals::tmin, tstart);
+      assert_always(distance >= 0.);
+      next_cellindex = -99;
+    }
+  }
+
   assert_always((next_cellindex == -99) || ((next_cellindex >= 0) && (next_cellindex < ngrid)));
 
   const double maxboundarydist =

--- a/grid.cc
+++ b/grid.cc
@@ -1377,13 +1377,22 @@ void setup_nstart_ndo() {
 }
 
 // set up a uniform cuboidal grid.
+// Stop the run when the grid corners expand faster than light and nothing removes them. The
+// propagation cannot treat a superluminal boundary, so the setup must either cut the corners with
+// FORCE_SPHERICAL_ESCAPE_SURFACE or use a smaller vmax.
+void require_subluminal_corners(const double vmax_corner) {
+  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
+  if (!FORCE_SPHERICAL_ESCAPE_SURFACE && vmax_corner >= CLIGHT) {
+    printlnlog(
+        "[error] the grid corners expand faster than light. Enable FORCE_SPHERICAL_ESCAPE_SURFACE in "
+        "artisoptions.h to remove the superluminal corners, or reduce vmax.");
+    std::abort();
+  }
+}
+
 void setup_grid_cartesian_3d() {
   // vmax is per coordinate, but the simulation volume corners will have a higher expansion velocity than the sides
-  const double vmax_corner = sqrt(3 * pow2(globals::vmax));
-  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
-  if (!FORCE_SPHERICAL_ESCAPE_SURFACE) {
-    assert_always(vmax_corner < CLIGHT);
-  }
+  require_subluminal_corners(sqrt(3 * pow2(globals::vmax)));
 
   // Set grid size for uniform xyz grid
   if (get_modelgridtype() == GridType::CARTESIAN3D) {
@@ -1428,9 +1437,7 @@ void setup_grid_spherical_1d() {
 }
 
 void setup_grid_cylindrical_2d() {
-  const double vmax_corner = sqrt(2 * pow2(globals::vmax));
-  printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
-  assert_always(vmax_corner < CLIGHT);
+  require_subluminal_corners(sqrt(2 * pow2(globals::vmax)));
 
   assert_always(get_modelgridtype() == GridType::CYLINDRICAL2D);
 

--- a/grid.cc
+++ b/grid.cc
@@ -83,8 +83,8 @@ std::vector<int> propcell_mgi;
 std::vector<int> propcell_nonemptymgi;
 
 // with FORCE_SPHERICAL_ESCAPE_SURFACE: 1 for a propagation cell whose inner corner lies outside the
-// spherical escape surface. boundary_distance() runs for every packet step, so the per-cell radius
-// comparison is precomputed here instead of repeated there.
+// spherical escape surface. boundary_distance() runs for every packet step, so
+// allocate_nonemptymodelcells() precomputes the per-cell radius comparison.
 std::vector<uint8_t> propcell_outside_escape_surface;
 
 std::vector<int> modelgrid_numpropcells;
@@ -2566,10 +2566,8 @@ void init_grid() {
     assign_initial_temperatures();
   }
 
-  double mtot_mapped = 0.;
-  for (int mgi = 0; mgi < get_npts_model(); mgi++) {
-    mtot_mapped += get_rho_tmin(mgi) * get_modelcell_assocvolume_tmin(mgi);
-  }
+  // this call also fills the cached value before the packet propagation threads read it
+  const double mtot_mapped = get_ejecta_mass();
   printlnlog("Total grid-mapped mass: {:9.3e} [Msun] ({:.1f}% of input mass)", mtot_mapped / MSUN,
              mtot_mapped / mtot_input * 100.);
 
@@ -2901,19 +2899,28 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
 
   if constexpr (FORCE_SPHERICAL_ESCAPE_SURFACE) {
     if (next_cellindex == -1) {
-      // No cell boundary lies ahead of the packet: every velocity component of the packet is inside
-      // the range of the receding boundary velocities of its cell. Only a corner-region cell of a
-      // grid with vmax > CLIGHT / sqrt(3) has such a range. The packet still overtakes the slower
-      // spherical escape surface, because that surface expands at vmax < CLIGHT. The packet
-      // therefore escapes where its ray meets the expanding sphere.
-      const double r_surface = globals::rmax * tstart / globals::tmin;
-      if (vec_len(pos) >= r_surface) {
-        // A cell that straddles the sphere keeps positions outside the surface, so the packet can
-        // already be outside it. The intersection then lies behind the packet, so escape here.
-        return {0., -99};
+      // No receding cell boundary lies ahead of the packet, so it escapes through the slower
+      // spherical escape surface. The comoving coordinates of a packet converge to a point with
+      // speed CLIGHT. Only a cell whose fastest corner is above CLIGHT can hold this state. A
+      // slower cell here is a sign of a defective boundary intersection, and the run then stops
+      // as it did before this escape path existed.
+      double cornerspeed_squared = 0.;
+      for (int d = 0; d < get_ndim(prop_gridtype); d++) {
+        cornerspeed_squared += pow2(std::max(std::abs(cellcoordmin[d]), std::abs(cellcoordmax[d])) / globals::tmin);
       }
-      distance = expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, CLIGHT_PROP, r_surface, tstart);
-      assert_always(distance >= 0.);
+      assert_always(cornerspeed_squared > pow2(CLIGHT_PROP));
+
+      const double r_surface = globals::rmax * tstart / globals::tmin;
+      if (dot(pos, pos) >= pow2(r_surface)) {
+        // A cell that straddles the sphere keeps positions outside the surface. The intersection
+        // then lies behind the packet, so it escapes at its current position.
+        distance = 0.;
+      } else {
+        const double speed = vec_len(dir) * CLIGHT_PROP;  // just in case dir is not normalised
+        // A ray that grazes the surface within rounding has no valid forward intersection and
+        // gives -1. The packet is then at the surface itself, so the distance clamps to zero.
+        distance = std::max(expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, speed, r_surface, tstart), 0.);
+      }
       next_cellindex = -99;
     }
   }

--- a/grid.cc
+++ b/grid.cc
@@ -2910,6 +2910,11 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
       }
       assert_always(cornerspeed_squared > pow2(CLIGHT_PROP));
 
+      // Truncation must act on whole cells to keep the volumes and the packet statistics valid.
+      // The trapped packet never leaves this cell. The arrival time is constant along a free ray,
+      // so a mid-cell escape is valid only for a cell with no matter.
+      assert_always(get_propcell_modelgridindex(cellindex) < 0);
+
       const double r_surface = globals::rmax * tstart / globals::tmin;
       if (dot(pos, pos) >= pow2(r_surface)) {
         // A cell that straddles the sphere keeps positions outside the surface. The intersection

--- a/grid.cc
+++ b/grid.cc
@@ -2890,8 +2890,13 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
       // grid with vmax > CLIGHT / sqrt(3) has such a range. The packet still overtakes the slower
       // spherical escape surface, because that surface expands at vmax < CLIGHT. The packet
       // therefore escapes where its ray meets the expanding sphere.
-      distance = expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, CLIGHT_PROP,
-                                                                   globals::rmax * tstart / globals::tmin, tstart);
+      const double r_surface = globals::rmax * tstart / globals::tmin;
+      if (vec_len(pos) >= r_surface) {
+        // A cell that straddles the sphere keeps positions outside the surface, so the packet can
+        // already be outside it. The intersection then lies behind the packet, so escape here.
+        return {0., -99};
+      }
+      distance = expanding_shell_intersection<BoundaryType::UPPER>(pos, dir, CLIGHT_PROP, r_surface, tstart);
       assert_always(distance >= 0.);
       next_cellindex = -99;
     }

--- a/grid.h
+++ b/grid.h
@@ -162,6 +162,22 @@ inline auto get_ejecta_kinetic_energy() {
   return E_kin;
 }
 
+// The grid-mapped mass [g] of the ejecta: the sum over the nonempty cells, consistent with
+// get_ejecta_kinetic_energy(). The staircase mapping and the FORCE_SPHERICAL_ESCAPE_SURFACE
+// blanking make this differ from mtot_input, the analytic mass of the input model.
+inline auto get_ejecta_mass() {
+  static const double M_ejecta = [] {
+    double mtot = 0.;
+    for (int nonemptymgi = 0; nonemptymgi < get_nonempty_npts_model(); nonemptymgi++) {
+      const int mgi = get_mgi_of_nonemptymgi(nonemptymgi);
+      mtot += get_rho_tmin(mgi) * grid::get_modelcell_assocvolume_tmin(mgi);
+    }
+    return mtot;
+  }();
+
+  return M_ejecta;
+}
+
 }  // namespace grid
 
 #endif  // GRID_H

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -68,11 +68,14 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
     pkt.type = deposit_type;
   } else if constexpr (PARTICLE_THERMALISATION_SCHEME == ParticleThermalisationScheme::BARNES) {
     const double E_kin = grid::get_ejecta_kinetic_energy();
-    const double v_ej = std::sqrt(E_kin * 2 / grid::mtot_input);
+    // the grid-mapped mass matches the cells that the kinetic energy sums, which mtot_input does
+    // not after the mapping or the spherical escape surface removes mass
+    const double m_ej = grid::get_ejecta_mass();
+    const double v_ej = std::sqrt(E_kin * 2 / m_ej);
 
     const double prefactor = (pkt.type == TYPE_NONTHERMAL_PREDEPOSIT_ALPHA) ? 7.74 : 7.4;
     const double tau_ineff =
-        prefactor * DAY * std::sqrt(grid::mtot_input / (5.e-3 * MSUN)) * std::pow((0.2 * CLIGHT) / v_ej, 3. / 2.);
+        prefactor * DAY * std::sqrt(m_ej / (5.e-3 * MSUN)) * std::pow((0.2 * CLIGHT) / v_ej, 3. / 2.);
     const double f_p = std::log1p(2. * ts * ts / tau_ineff / tau_ineff) / (2. * ts * ts / tau_ineff / tau_ineff);
     deposit_or_escape(f_p);
   } else if constexpr (PARTICLE_THERMALISATION_SCHEME == ParticleThermalisationScheme::WOLLAEGER) {

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -68,8 +68,6 @@ void do_nonthermal_predeposit(Packet& pkt, const int nts, const double ts_end) {
     pkt.type = deposit_type;
   } else if constexpr (PARTICLE_THERMALISATION_SCHEME == ParticleThermalisationScheme::BARNES) {
     const double E_kin = grid::get_ejecta_kinetic_energy();
-    // the grid-mapped mass matches the cells that the kinetic energy sums, which mtot_input does
-    // not after the mapping or the spherical escape surface removes mass
     const double m_ej = grid::get_ejecta_mass();
     const double v_ej = std::sqrt(E_kin * 2 / m_ej);
 


### PR DESCRIPTION
Corrections from a full review of the FORCE_SPHERICAL_ESCAPE_SURFACE feature. The option truncates a 2D cylindrical or 3D Cartesian model to a spherical escape surface at any vmax: it blanks the corner cells and escapes packets at the sphere. These corrections complete the option for the whole vmax range, including vmax > CLIGHT / sqrt(3), where `setup_grid_cartesian_3d()` skips the `vmax_corner < CLIGHT` assertion because the option removes the superluminal corners.

## Escape when no cell boundary lies ahead

The escape check at the top of `boundary_distance()` only covers a cell whose inner corner lies outside `rmax`. A cell that straddles the sphere runs the full crossing arithmetic. With vmax > CLIGHT / sqrt(3) and a cell diagonal above CLIGHT - vmax, the cell's boundary-velocity box reaches past CLIGHT, and a packet with a near-diagonal direction crosses no cell boundary: every boundary recedes faster than the packet moves. `distance` and `next_cellindex` then kept their initial values and `assert_always` stopped the run. Examples: vmax = 0.9c aborts below ~32 cells per axis, vmax = 0.95c below ~66. At vmax far below CLIGHT this state cannot occur, so those runs keep their exact behaviour.

Such a packet still overtakes the spherical escape surface, because the surface expands at vmax < CLIGHT. `boundary_distance()` now returns the intersection of the ray with the expanding sphere as an escape, through the existing `expanding_shell_intersection<BoundaryType::UPPER>()` helper. A packet that is already at or outside the surface (possible inside a straddling cell) escapes at its current position. The branch asserts that the fastest corner of the cell is above CLIGHT, because only such a cell can trap a packet; a slower cell in this state is a sign of a defective boundary intersection and stops the run as before. A grazing ray with no valid forward intersection escapes at zero distance instead of stopping the run. The branch also asserts that the cell holds no matter: the truncation acts on whole cells, and a mid-cell escape from an empty cell changes no statistic, because the arrival time is constant along a free ray.

## Guidance for superluminal grid corners

A 3D Cartesian model with corner velocities above CLIGHT stopped with a bare assertion and no guidance. The setup now stops with an error that recommends `FORCE_SPHERICAL_ESCAPE_SURFACE` or a smaller vmax. The 2D cylindrical setup asserted subluminal corners without the option exemption, so a 2D run with vmax > CLIGHT / sqrt(2) stopped even with the option enabled; both setups now share one guard, and the option permits the fast 2D corners that its truncation removes.

## Consistent ejecta mass for the Barnes schemes

The Barnes particle and gamma thermalisation formulas divided the grid-mapped kinetic energy by `mtot_input`, the analytic mass of the input model. A cross-geometry mapping (staircase volumes) and the spherical escape surface truncation remove mass from the grid, so `v_ej` and `t_ineff` mixed two mass conventions (up to ~15 percent in `v_ej` when a third of the mass lies outside the sphere). The new `get_ejecta_mass()` sums the same nonempty cells as `get_ejecta_kinetic_energy()`, and both Barnes call sites use it. The mass log line in `init_grid()` uses the same helper.

## Precomputed escape flag

The escape check at the top of `boundary_distance()` computed the inner radius of the packet's cell with several coordinate reads and a square root on every packet step. `allocate_nonemptymodelcells()` now precomputes a per-cell `propcell_outside_escape_surface` flag, and the hot path reads one byte.

## Effect on the results

- The escape changes only apply to runs that previously stopped with the assertion. Runs with vmax far below CLIGHT keep their exact behaviour.
- The Barnes mass change alters the results only for a model where a cross-geometry mapping or the escape surface truncation gives a grid-mapped mass different from `mtot_input`. A directly mapped model sums the identical terms in the identical order, so the kilonova_2d_barnesthermalisation checksums do not change. The CI run of this branch confirms this: every check passes with the stored checksums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

