### PR TITLE
Update the NVHPC SDK to 26.5

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -352,13 +352,15 @@ jobs:
             # own stdexec header. __any_ptr and __any_cptr have a using declaration for the operator=
             # of the base class, and then declare their own operator=. The C++ rules say that the
             # second declaration hides the first one, but the frontend takes it as a repetition.
-            # Neither --diag_suppress nor a diag_suppress pragma removes this error, so this step
-            # deletes the two using declarations. Remove this step when the SDK compiles again.
+            # --diag_suppress and a diag_suppress pragma do not remove this error.
+            # This step deletes the two using declarations.
+            # Remove this step when the SDK compiles again.
             - name: Correct the stdexec header of the SDK
               run: |
                   pattern='using __any_ptr_base<_Interface>::operator=;'
-                  # the SDK gives more than one path to this file, e.g. a directory for the year and
-                  # a directory for the version, so resolve each path and correct each file one time
+                  # the SDK gives more than one path to this file.
+                  # One directory has the year and one directory has the version.
+                  # Resolve each path, and then correct each file one time.
                   for path in /opt/nvidia/hpc_sdk/Linux_x86_64/*/compilers/include-stdexec/stdexec/__detail/__any.hpp; do
                       readlink -f "$path"
                   done | sort -u | while read -r header; do

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -377,13 +377,13 @@ jobs:
               run: |
                   cp -v -p artisoptions_classic.h artisoptions.h
                   make clean
-                  make STDPAR=ON GPU=ON -j$(nproc) sn3d exspec
+                  make STDPAR=ON GPU=ON GPUARCH=80 -j$(nproc) sn3d exspec
 
             - name: Compile nebular mode STDPAR=ON GPU=ON
               run: |
                   cp -v -p artisoptions_nltenebular.h artisoptions.h
                   make clean
-                  make STDPAR=ON GPU=ON -j$(nproc) sn3d exspec
+                  make STDPAR=ON GPU=ON GPUARCH=80 -j$(nproc) sn3d exspec
 
             - name: Compile nebular mode STDPAR=ON
               run: |

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -318,11 +318,8 @@ jobs:
         # NVIDIA's container registry serves the SDK preinstalled, avoiding the apt repository on
         # developer.download.nvidia.com, which (as of 2026-07) returns 404 for the SDK debs when
         # fetched from GitHub's runner network (same approach as the AMD ROCm job above).
-        # 26.1 is the previously-validated SDK version: 26.5's bundled stdexec headers fail to
-        # compile with its own frontend in -stdpar=gpu mode ("operator= has already been declared"
-        # in include-stdexec/stdexec/__detail/__any.hpp)
         container:
-            image: nvcr.io/nvidia/nvhpc:26.1-devel-cuda13.1-ubuntu24.04
+            image: nvcr.io/nvidia/nvhpc:26.5-devel-cuda13.2-ubuntu24.04
         steps:
             - uses: actions/checkout@v7
               with:
@@ -330,11 +327,9 @@ jobs:
 
             - name: Install gcc
               run: |
-                  apt-get update
-                  apt-get install -y --no-install-recommends software-properties-common
-                  add-apt-repository -y ppa:ubuntu-toolchain-r/test
-                  apt-get update
+                  # Ubuntu 24.04 supplies gcc-14, so this step needs no toolchain PPA.
                   # gfortran-14 completes the toolchain that nvc++ validates when passed --gcc-toolchain
+                  apt-get update
                   apt-get install -y --no-install-recommends gcc-14 g++-14 gfortran-14
                   update-alternatives \
                        --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 \

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -359,8 +359,8 @@ jobs:
               run: |
                   pattern='using __any_ptr_base<_Interface>::operator=;'
                   # the SDK gives more than one path to this file.
-                  # One directory has the year and one directory has the version.
-                  # Resolve each path, and then correct each file one time.
+                  # One directory has the year. One directory has the version.
+                  # Resolve each path. Correct each file one time.
                   for path in /opt/nvidia/hpc_sdk/Linux_x86_64/*/compilers/include-stdexec/stdexec/__detail/__any.hpp; do
                       readlink -f "$path"
                   done | sort -u | while read -r header; do

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -348,6 +348,31 @@ jobs:
                   apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev git
                   git config --global --add safe.directory /__w/artis/artis
 
+            # nvc++ 26.5 stops with "operator= has already been declared in the current scope" in its
+            # own stdexec header. __any_ptr and __any_cptr have a using declaration for the operator=
+            # of the base class, and then declare their own operator=. The C++ rules say that the
+            # second declaration hides the first one, but the frontend takes it as a repetition.
+            # Neither --diag_suppress nor a diag_suppress pragma removes this error, so this step
+            # deletes the two using declarations. Remove this step when the SDK compiles again.
+            - name: Correct the stdexec header of the SDK
+              run: |
+                  pattern='using __any_ptr_base<_Interface>::operator=;'
+                  # the SDK gives more than one path to this file, e.g. a directory for the year and
+                  # a directory for the version, so resolve each path and correct each file one time
+                  for path in /opt/nvidia/hpc_sdk/Linux_x86_64/*/compilers/include-stdexec/stdexec/__detail/__any.hpp; do
+                      readlink -f "$path"
+                  done | sort -u | while read -r header; do
+                      [ -f "$header" ] || continue
+                      # grep gives exit status 1 for no match, which stops a step that runs with sh -e
+                      count=$(grep -c "$pattern" "$header" || true)
+                      echo "$header has ${count:-0} of these using declarations"
+                      if [ "${count:-0}" -eq 0 ]; then
+                          echo "the SDK needs no correction. Remove this step."
+                      else
+                          sed -i "/$pattern/d" "$header"
+                      fi
+                  done
+
             - name: Compile classic mode STDPAR=ON GPU=ON
               run: |
                   cp -v -p artisoptions_classic.h artisoptions.h

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,15 @@ endif
 
 ifeq ($(COMPILER_NAME),nvhpc)
 	ifeq ($(GPU),ON)
-			CXXFLAGS += -gpu=mem:unified -gpu=ccnative
+			# ccnative selects the compute capability of the GPU of the host. A host that has no GPU
+			# gives a warning and the default value, which changes with the SDK. GPUARCH selects a
+			# compute capability, e.g. GPUARCH=80, and makes the result independent of the host.
+			ifeq ($(GPUARCH),)
+				CXXFLAGS += -gpu=mem:unified -gpu=ccnative
+			else
+				CXXFLAGS += -gpu=mem:unified -gpu=cc$(GPUARCH)
+				BUILD_DIR := $(BUILD_DIR)_cc$(GPUARCH)
+			endif
 			CXXFLAGS += -Minfo=stdpar,accel
 # 			CXXFLAGS += -gpu=debug -g
 # 			CXXFLAGS += -gpu=maxregcount:64

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ source ./setup_kilonova_1d.sh   # creates tests/kilonova_1d_testrun/
 - GPU=ON: Required to compile for GPUs. Works around incompatible function calls and uses a Simpson-rule integrator in place of Gauss-Kronrod.
 - OPENMP=ON: Parallelise with OpenMP threads within each MPI rank. Cannot be combined with STDPAR.
 - STDPAR=ON: Parallelise with C++ standard library parallel algorithms, either on multicore CPUs or, together with GPU=ON, on GPUs.
+
+- GPUARCH=N: With nvc++ and GPU=ON, compile for compute capability N (e.g. GPUARCH=80) in place of the GPU of the host. A host that has no GPU needs this option to get a defined target.
 - OPTIMIZE=OFF: Compile without optimisation. This is the quickest way to check that everything still compiles.
 - PGO=GENERATE and PGO=USE: Profile-guided optimisation with gcc or clang. Build with GENERATE, run a representative simulation to collect profile data, then rebuild with USE.
 

--- a/vectors.h
+++ b/vectors.h
@@ -216,9 +216,9 @@ DEVICE_FUNC constexpr void set_pkt_restframe_from_cmf(Packet& pkt) {
   // for ref_1 use (from triple product rule)
   const double n_xylen = std::sqrt(pow2(dir[0]) + pow2(dir[1]));
   if (n_xylen == 0.) {
-    // if n is along z axis, we can just use x and y as the meridian frame axes. nvc++ 26.5 writes an
-    // invalid constant into the device code if these two vectors go directly into the return value
-    // ("parse integer constant must have integer type"), so give each vector a name first.
+    // if n is along z axis, we can just use x and y as the meridian frame axes.
+    // Each vector has a name here. nvc++ 26.5 writes an invalid constant for a vector that goes
+    // directly into the return value. The device compiler then stops.
     const Vec3d ref1_zaxis{1., 0., 0.};
     const Vec3d ref2_zaxis{0., 1., 0.};
     return {ref1_zaxis, ref2_zaxis};

--- a/vectors.h
+++ b/vectors.h
@@ -216,8 +216,12 @@ DEVICE_FUNC constexpr void set_pkt_restframe_from_cmf(Packet& pkt) {
   // for ref_1 use (from triple product rule)
   const double n_xylen = std::sqrt(pow2(dir[0]) + pow2(dir[1]));
   if (n_xylen == 0.) {
-    // if n is along z axis, we can just use x and y as the meridian frame axes
-    return {Vec3d{1., 0., 0.}, Vec3d{0., 1., 0.}};
+    // if n is along z axis, we can just use x and y as the meridian frame axes. nvc++ 26.5 writes an
+    // invalid constant into the device code if these two vectors go directly into the return value
+    // ("parse integer constant must have integer type"), so give each vector a name first.
+    const Vec3d ref1_zaxis{1., 0., 0.};
+    const Vec3d ref2_zaxis{0., 1., 0.};
+    return {ref1_zaxis, ref2_zaxis};
   }
   const auto ref1 = Vec3d{-dir[0] * dir[2] / n_xylen, -dir[1] * dir[2] / n_xylen, (1 - pow2(dir[2])) / n_xylen};
 


### PR DESCRIPTION
The nvc++ job used the SDK 26.1, because 26.5 did not compile. This pull request selects 26.5 with CUDA 13.2 and corrects the three faults that stopped that job.

## The stdexec header of the SDK

nvc++ 26.5 stops with `"operator=" has already been declared in the current scope` in its own header `stdexec/__detail/__any.hpp`. `__any_ptr` and `__any_cptr` have a using declaration for the `operator=` of the base class, and then declare their own `operator=`. The C++ rules say that the second declaration hides the first one, but the frontend takes it as a repetition.

That error has the number 101. Neither `--diag_suppress 101` on the command line nor a `diag_suppress` pragma around the include of `<execution>` removes it, so the error is not discretionary. The job therefore deletes the two using declarations before it compiles. The step resolves each path first, because the SDK gives more than one path to that file. The step changes no file and gives a message if a later SDK no longer has those declarations.

## An invalid constant in the device code

nvc++ 26.5 wrote this constant into the device code for the return value of `meridian()`:

```llvm
[3 x double] [ double 1.00000000000000000e+00, double  0.0, double  0 ]
```

The last element is an integer constant with the type `double`, which the device compiler rejects with `parse integer constant must have integer type`. The compilation of `rpkt.cc` for the GPU stopped. The source gives all three elements as `double` literals, so the fault is in the compiler.

The two vectors of that branch now have a name, which avoids the constant. A test with the SDK 26.5 shows that `rpkt.cc` compiles with this change and stops without it. The change alters no numerical result.

Seven other option sets give the same error, so no option avoids it: `-O3 -fast`, `-O3`, `-O2`, `-O1`, `-O0`, `-gpu=nordc`, and `-gpu=cc90`.

## The compute capability in CI

`-gpu=ccnative` reads the GPU of the host. The runner in CI has no GPU, so nvc++ gave the warning `Cannot find valid GPU for '-gpu=ccnative'` and used its default value. That value changes with the SDK. The new option `GPUARCH` selects a compute capability, and the job uses `GPUARCH=80`. The target of the compilation in CI is now independent of the runner, as for the `gfx942` target of the ROCm job. The default stays `ccnative`, which is correct on a host that has a GPU.

## The toolchain PPA

The step that installs gcc no longer adds `ppa:ubuntu-toolchain-r/test`. Ubuntu 24.04 supplies gcc-14, g++-14, and gfortran-14 in its own archive. The job then does not stop if Launchpad is unavailable, which happened today.

## Tests

All four steps of the job compile and link with the SDK 26.5, both in CI and in a local test with the same SDK:

- the classic preset with `STDPAR=ON GPU=ON`;
- the nebular preset with `STDPAR=ON GPU=ON`;
- the nebular preset with `STDPAR=ON`;
- the nebular preset.

The full workflow is green on the head commit. The change to `vectors.h` gives the same values as before, so the numerical results do not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVEqS1QRFpFv3aaeke2neb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVEqS1QRFpFv3aaeke2neb)_