### PR TITLE
Show the filter statistics and improve the packet filter script

### DIFF
--- a/scripts/filterpacketsescapedrpkt.py
+++ b/scripts/filterpacketsescapedrpkt.py
@@ -6,67 +6,116 @@ from pathlib import Path
 import artistools as at
 from artistools.packets.packets import type_ids as packet_type_ids
 
+TYPE_ESCAPE = str(packet_type_ids["TYPE_ESCAPE"])
+TYPE_RPKT = str(packet_type_ids["TYPE_RPKT"])
+
+GLOB_PATTERN = "**/packets/packets00_*.out*"
+
 
 def get_type_escapetype(line: str, type_id_index: int, escape_type_id_index: int) -> tuple[str, str]:
-    linesplit = line.split()
-    type_id = linesplit[type_id_index]
-    escape_type_id = linesplit[escape_type_id_index]
-    return type_id, escape_type_id
+    # the columns after escape_type_id stay in one string. A packet line has more than 30 columns,
+    # and this function reads two of them.
+    linesplit = line.split(maxsplit=escape_type_id_index + 1)
+    return linesplit[type_id_index], linesplit[escape_type_id_index]
+
+
+def is_escaped_rpkt(line: str, type_id_index: int, escape_type_id_index: int) -> bool:
+    """Test if the filter keeps this packet. This function is the only definition of the filter."""
+    return get_type_escapetype(line, type_id_index, escape_type_id_index) == (TYPE_ESCAPE, TYPE_RPKT)
+
+
+def format_size(size_bytes: float) -> str:
+    """Give a size in bytes as a short string, e.g. '1.2 GB'."""
+    for unit in ("B", "kB", "MB", "GB"):
+        if abs(size_bytes) < 1000:
+            return f"{size_bytes:.0f} {unit}" if unit == "B" else f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1000
+    return f"{size_bytes:.1f} TB"
+
+
+def get_column_indices(firstline: str) -> tuple[int, int]:
+    """Give the column index of type_id and of escape_type_id. An old file has no header."""
+    if firstline.startswith("#"):
+        header_cols = firstline.split()
+        return header_cols.index("type_id"), header_cols.index("escape_type_id")
+    return 2, 15
+
+
+def find_packets_files(paths: list[Path]) -> list[Path]:
+    """Find the packets files under each of the paths, most recent last."""
+    found = {
+        file: None
+        for path in paths
+        for file in path.glob(GLOB_PATTERN)
+        if "parquet" not in file.name and ".tmp" not in file.name
+    }
+    return sorted(found, key=lambda p: p.stat().st_mtime)
 
 
 def main() -> None:
     assert sys.version_info >= (3, 14), "This script requires Python 3.14 or higher."
     import compression.zstd
 
-    parser = argparse.ArgumentParser(description="Filter packets files to keep only escaped rpkts")
-    parser.add_argument("--rm", action="store_true", help="Remove original files after processing")
-    parser.add_argument("-f", action="store_true", help="Confirm performing the filtering")
+    parser = argparse.ArgumentParser(
+        description="Filter packets files to keep only escaped rpkts.",
+        epilog="The script shows what the filter would remove. Add -f to do the filtering.",
+    )
+    parser.add_argument("paths", nargs="*", type=Path, default=[Path()], help="folders to search (default: .)")
+    parser.add_argument("-f", "--filter", action="store_true", dest="dofilter", help="do the filtering")
+    parser.add_argument("--rm", action="store_true", help="remove the original files instead of a backup")
     args = parser.parse_args()
-    TYPE_ESCAPE = str(packet_type_ids["TYPE_ESCAPE"])
-    TYPE_RPKT = str(packet_type_ids["TYPE_RPKT"])
-    glob_pattern = "**/packets/packets00_*.out*"
-    matching_files = sorted(Path().glob(glob_pattern), key=lambda p: p.stat().st_mtime)
+
+    matching_files = find_packets_files(args.paths)
     if not matching_files:
-        print(f"No matching files found for pattern {glob_pattern}")
+        print(f"No matching files found for pattern {GLOB_PATTERN}")
         return
 
+    files_to_filter = 0
+    total_packets = 0
+    total_removed = 0
+    total_size_in = 0
+    total_size_out = 0.0
+
     for filein in matching_files:
-        if "parquet" in filein.name or ".tmp" in filein.name:
-            continue
         print(f"\n{filein}")
         linesin = at.zopen(filein).readlines()
-        if linesin[0].startswith("#"):
-            header_cols = linesin[0].split()
-            type_id_index = header_cols.index("type_id")
-            escape_type_id_index = header_cols.index("escape_type_id")
-        else:
-            type_id_index, escape_type_id_index = 2, 15
+        type_id_index, escape_type_id_index = get_column_indices(linesin[0])
 
+        # one pass gives the statistics and the lines of the output file, in the order of the input
+        outlines: list[str] = []
         packets_in = 0
         kept_packets = 0
-        bytes_in = 0
-        bytes_kept = 0
+        chars_in = 0
+        chars_kept = 0
         for line in linesin:
             if line.startswith("#"):
+                outlines.append(line)
                 continue
             packets_in += 1
-            bytes_in += len(line)
-            if get_type_escapetype(line, type_id_index, escape_type_id_index) == (TYPE_ESCAPE, TYPE_RPKT):
+            chars_in += len(line)
+            if is_escaped_rpkt(line, type_id_index, escape_type_id_index):
+                outlines.append(line)
                 kept_packets += 1
-                bytes_kept += len(line)
+                chars_kept += len(line)
 
         if kept_packets == packets_in:
             print("  contains only escaped rpkts, skipping...")
             continue
 
+        size_in = filein.stat().st_size
         removed_packets = packets_in - kept_packets
-        data_reduction = (1 - bytes_kept / bytes_in) * 100
+        removed_fraction = 1 - chars_kept / chars_in
+        files_to_filter += 1
+        total_packets += packets_in
+        total_removed += removed_packets
+        total_size_in += size_in
         print(
             f"  the filter removes {removed_packets} of {packets_in} packets "
-            f"({removed_packets / packets_in * 100:.2f}%). Approximate data reduction: {data_reduction:.2f}%."
+            f"({removed_packets / packets_in * 100:.1f}%). It removes {removed_fraction * 100:.1f}% of the "
+            f"uncompressed text, or about {format_size(removed_fraction * size_in)} of {format_size(size_in)}."
         )
-        if not args.f:
-            print("  (not filtering. Use -f to confirm filtering and --rm to remove original files)")
+        if not args.dofilter:
+            total_size_out += (1 - removed_fraction) * size_in
             continue
 
         fileout_rpkt = Path(
@@ -80,21 +129,13 @@ def main() -> None:
         print("  filtering rpkts...", end="", flush=True)
 
         with compression.zstd.open(fileout_rpkt_temp, "wt", level=12) as foutrpkt:
-            for line in linesin:
-                type_id, escape_type_id = get_type_escapetype(line, type_id_index, escape_type_id_index)
-                if line.startswith("#"):
-                    assert type_id == "type_id"
-                    assert escape_type_id == "escape_type_id"
-
-                    foutrpkt.write(line)
-                    continue
-
-                if (type_id, escape_type_id) == (TYPE_ESCAPE, TYPE_RPKT):
-                    foutrpkt.write(line)
-        size_factor = fileout_rpkt_temp.stat().st_size / filein.stat().st_size
+            foutrpkt.writelines(outlines)
+        size_out = fileout_rpkt_temp.stat().st_size
+        total_size_out += size_out
         print(
-            f" kept {kept_packets} of {packets_in} packets ({kept_packets / packets_in * 100:.2f}%)"
-            f" new/old size {size_factor * 100:.2f}%"
+            f" kept {kept_packets} of {packets_in} packets ({kept_packets / packets_in * 100:.1f}%)."
+            f" The size changed from {format_size(size_in)} to {format_size(size_out)}"
+            f" ({size_out / size_in * 100:.1f}%)."
         )
         if args.rm:
             filein.unlink()
@@ -107,6 +148,26 @@ def main() -> None:
 
         fileout_rpkt_temp.rename(fileout_rpkt)
         print(f"  wrote {fileout_rpkt}")
+
+    print()
+    if files_to_filter == 0:
+        print(f"Checked {len(matching_files)} files. Every file contains only escaped rpkts.")
+        return
+
+    removed_percent = total_removed / total_packets * 100
+    if args.dofilter:
+        print(
+            f"Filtered {files_to_filter} of {len(matching_files)} files. The filter removed "
+            f"{total_removed} of {total_packets} packets ({removed_percent:.1f}%). "
+            f"The size changed from {format_size(total_size_in)} to {format_size(total_size_out)}."
+        )
+    else:
+        print(
+            f"{files_to_filter} of {len(matching_files)} files need the filter. It removes "
+            f"{total_removed} of {total_packets} packets ({removed_percent:.1f}%). "
+            f"The size changes from {format_size(total_size_in)} to about {format_size(total_size_out)}."
+        )
+        print("Use -f to do the filtering. Add --rm to remove the original files.")
 
 
 if __name__ == "__main__":

--- a/scripts/filterpacketsescapedrpkt.py
+++ b/scripts/filterpacketsescapedrpkt.py
@@ -42,15 +42,29 @@ def main() -> None:
         else:
             type_id_index, escape_type_id_index = 2, 15
 
-        if all(
-            get_type_escapetype(line, type_id_index, escape_type_id_index) == (TYPE_ESCAPE, TYPE_RPKT)
-            for line in linesin
-            if not line.startswith("#")
-        ):
+        packets_in = 0
+        kept_packets = 0
+        bytes_in = 0
+        bytes_kept = 0
+        for line in linesin:
+            if line.startswith("#"):
+                continue
+            packets_in += 1
+            bytes_in += len(line)
+            if get_type_escapetype(line, type_id_index, escape_type_id_index) == (TYPE_ESCAPE, TYPE_RPKT):
+                kept_packets += 1
+                bytes_kept += len(line)
+
+        if kept_packets == packets_in:
             print("  contains only escaped rpkts, skipping...")
             continue
 
-        print("  contains gamma or non-escaped packets, should filter this file.")
+        removed_packets = packets_in - kept_packets
+        data_reduction = (1 - bytes_kept / bytes_in) * 100
+        print(
+            f"  the filter removes {removed_packets} of {packets_in} packets "
+            f"({removed_packets / packets_in * 100:.2f}%). Approximate data reduction: {data_reduction:.2f}%."
+        )
         if not args.f:
             print("  (not filtering. Use -f to confirm filtering and --rm to remove original files)")
             continue
@@ -64,8 +78,6 @@ def main() -> None:
             f"{fileout_rpkt.parts[-1]}.partial.tmp.nosync",
         )
         print("  filtering rpkts...", end="", flush=True)
-        commentrows = 0
-        kept_packets = 0
 
         with compression.zstd.open(fileout_rpkt_temp, "wt", level=12) as foutrpkt:
             for line in linesin:
@@ -75,18 +87,14 @@ def main() -> None:
                     assert escape_type_id == "escape_type_id"
 
                     foutrpkt.write(line)
-                    commentrows += 1
                     continue
 
-                if type_id == str(packet_type_ids["TYPE_ESCAPE"]) and escape_type_id == str(
-                    packet_type_ids["TYPE_RPKT"]
-                ):
+                if (type_id, escape_type_id) == (TYPE_ESCAPE, TYPE_RPKT):
                     foutrpkt.write(line)
-                    kept_packets += 1
         size_factor = fileout_rpkt_temp.stat().st_size / filein.stat().st_size
-        packets_in = len(linesin) - commentrows
         print(
-            f" kept {kept_packets} of {packets_in} packets ({kept_packets / packets_in * 100:.2f}%) new/old size {size_factor * 100:.2f}%"
+            f" kept {kept_packets} of {packets_in} packets ({kept_packets / packets_in * 100:.2f}%)"
+            f" new/old size {size_factor * 100:.2f}%"
         )
         if args.rm:
             filein.unlink()


### PR DESCRIPTION
## What changed

`scripts/filterpacketsescapedrpkt.py` scans the packets files of a run and keeps only the
escaped r-packets. The dry run printed one message for each file that needs the filter:

```
  contains gamma or non-escaped packets, should filter this file.
```

The dry run now reports what the filter removes, and the script ends with the totals:

```
runA/packets/packets00_0000.out
  the filter removes 400 of 1000 packets (40.0%). It removes 40.0% of the uncompressed text, or about 151.3 kB of 378.1 kB.

2 of 4 files need the filter. It removes 800 of 1500 packets (53.3%). The size changes from 567.2 kB to about 264.6 kB.
Use -f to do the filtering. Add --rm to remove the original files.
```

## Why

The old message gave no measure of the gain. A user could not decide if the filter is worth
the time before the filter started.

## The statistics

- The script counts the packets and the characters in one pass.
- The percentage of the removed data is the fraction of the uncompressed text. The output
  file is zstd compressed, so the message says "uncompressed text" and "about". The real run
  prints the true size of the new file.
- A file that has a header and no packet gives no division by zero, because the test for a
  file that needs no filter compares the counts.

## Usability

- The script accepts the folders to search as arguments. The default is the current folder,
  as before. A user can now filter a run folder from a different directory.
- `-f` has the long name `--filter`, and the help text says what the script does without it.
- The sizes have a unit (kB, MB, GB), so a user sees the gain in bytes and not only as a
  percentage.
- The totals of all of the files come at the end. The hint about `-f` also moved there, so
  it prints one time and not for each file.

## Simplification

- `is_escaped_rpkt()` is the only definition of the rule for a kept packet. The counting
  pass and the write loop each contained that rule before this change.
- One pass gives the statistics and the lines of the output file, in the order of the input.
  The script therefore parses each line one time, and the write loop became one call to
  `writelines()`.
- `get_type_escapetype()` stops the split after the `escape_type_id` column. A packet line
  has more than 30 columns, and the function reads two of them.

## Tests

- `prek run --files scripts/filterpacketsescapedrpkt.py` passes, with ruff check and ruff
  format.
- I ran the script on synthetic packets files: two mixed files, a file of escaped r-packets
  only, a file with a header and no packet, and a file in the old format that has no header.
  - The dry-run counts agree with the counts of the `-f` run.
  - The output file holds the header and exactly the kept packets, in the order of the input.
  - A second run reports that every file contains only escaped r-packets, so the script is
    idempotent.
  - The script does not read the backup folder, and it does not count a folder two times
    when the command line names it two times.

The change is in a helper script. It changes no simulation result and no checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)