### PR TITLE
Stop the run when the level energies in adata.txt decrease with the level index

### DIFF
--- a/input.cc
+++ b/input.cc
@@ -473,8 +473,8 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
             "[error] adata.txt: Z={} ionstage {}: level {} has energy {:g} eV, below the previous level energy {:g} "
             "eV. The count of ionising levels needs energies that increase with the level index",
             get_atomicnumber(element), get_ionstage(element, ion), levelindex_in, levelenergy_ev, prev_levelenergy_ev);
-        std::abort();
       }
+      assert_always(levelenergy_ev >= prev_levelenergy_ev);
       prev_levelenergy_ev = levelenergy_ev;
     }
   }

--- a/input.cc
+++ b/input.cc
@@ -431,6 +431,10 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
                      std::vector<TempEnergyLevel>& temp_alllevels) {
   std::string line;
   static std::istringstream ssline;
+  // The count nlevels_ionising covers the first levels of the ion, so it is only correct when the level energies
+  // increase with the level index. A level that is out of order is reported once per ion.
+  double prev_levelenergy_ev = -std::numeric_limits<double>::infinity();
+  int nlevels_outoforder = 0;
   for (int level = 0; level < nlevels; level++) {
     int levelindex_in = 0;
     double levelenergy_ev{NAN};
@@ -465,7 +469,17 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
       if (levelenergy_ev < ionpot_ev && ion < nions - 1) {
         globals::elements[element].ions[ion].nlevels_ionising++;
       }
+      if (levelenergy_ev < prev_levelenergy_ev) {
+        nlevels_outoforder++;
+      }
+      prev_levelenergy_ev = levelenergy_ev;
     }
+  }
+  if (nlevels_outoforder > 0) {
+    printlnlog(
+        "[warning] adata.txt: Z={} ionstage {}: {} levels have a lower energy than the previous level. The count of "
+        "ionising levels assumes that the energies increase with the level index",
+        get_atomicnumber(element), get_ionstage(element, ion), nlevels_outoforder);
   }
 }
 

--- a/input.cc
+++ b/input.cc
@@ -432,9 +432,8 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
   std::string line;
   static std::istringstream ssline;
   // The count nlevels_ionising covers the first levels of the ion, so it is only correct when the level energies
-  // increase with the level index. A level that is out of order is reported once per ion.
+  // increase with the level index. A level with a lower energy than the previous level stops the run.
   double prev_levelenergy_ev = -std::numeric_limits<double>::infinity();
-  int nlevels_outoforder = 0;
   for (int level = 0; level < nlevels; level++) {
     int levelindex_in = 0;
     double levelenergy_ev{NAN};
@@ -470,16 +469,14 @@ void read_ion_levels(std::istream& adata, const int element, const int ion, cons
         globals::elements[element].ions[ion].nlevels_ionising++;
       }
       if (levelenergy_ev < prev_levelenergy_ev) {
-        nlevels_outoforder++;
+        printlnlog(
+            "[error] adata.txt: Z={} ionstage {}: level {} has energy {:g} eV, below the previous level energy {:g} "
+            "eV. The count of ionising levels needs energies that increase with the level index",
+            get_atomicnumber(element), get_ionstage(element, ion), levelindex_in, levelenergy_ev, prev_levelenergy_ev);
+        std::abort();
       }
       prev_levelenergy_ev = levelenergy_ev;
     }
-  }
-  if (nlevels_outoforder > 0) {
-    printlnlog(
-        "[warning] adata.txt: Z={} ionstage {}: {} levels have a lower energy than the previous level. The count of "
-        "ionising levels assumes that the energies increase with the level index",
-        get_atomicnumber(element), get_ionstage(element, ion), nlevels_outoforder);
   }
 }
 


### PR DESCRIPTION
## Summary

`read_ion_levels()` counts the ionising levels of an ion as the levels with an energy below the ionisation potential. The rest of the code uses that count as an index range over the first levels, so the count is only correct when the energies increase with the level index. A file that breaks this order can give a level above the ionisation potential a photoionisation table. The Seaton collisional ionisation term of that level is then negative, and `do_kpkt()` can find no cooling process (see #566).

This change stops the run at the first level whose energy is below the energy of the previous level. The error line names the element, the ion stage, the level, and both energies.

## Test plan

- `make OPTIMIZE=OFF sn3d` passes.
- clang-tidy on `input.cc` gives no diagnostic.
- The check adds an error path only, so the results and the checksums do not change. The CI test data sets must pass the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
