### PR TITLE
Stop on invalid phixs targets, check tmin/tmax on resume, batch the grid broadcasts, and remove direct aborts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ sentences. It does not control the spelling variant here.
 ARTIS is a 3D Monte Carlo radiative transfer code for supernovae and kilonovae.
 The code uses modern C++ and the Message Passing Interface (MPI). You can also
 add OpenMP threads or C++ standard parallelism. gcc and clang compile the code
-as C++26. nvc++ and hipcc compile it as C++23, so the code must stay compatible
-with C++23. The Makefile builds three programs from the same sources:
+as C++26, and so does nvc++. hipcc compiles it as C++23, so the code must stay
+compatible with C++23. The Makefile builds three programs from the same sources:
 
 - `sn3d`: the main simulation. It does the radiative transfer over a sequence
   of timesteps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,11 +350,13 @@ are the only defence.
 - Many `assert_always()` calls hold a call with a side effect, e.g. a read
   from a file. Do not change such an assertion to `assert_testmodeonly()` and
   do not delete it.
-- A fatal error is an `assert_always()` on the condition. Write an optional
-  `printlnlog("[error] ...")` with the values before it. Do not call
-  `std::abort()` directly. A direct abort is very hard to debug. The assertion
-  reporter adds the file, the line, the expression, and the function. It does
-  this on the host and on the device.
+- A fatal error is an `assert_always()` on the condition, or a
+  `fatal_crash("...", values)` when the message must show the values. Both
+  come from `mpi_logging.h`. `fatal_crash()` takes a `std::format` string and
+  writes the message with the rank, the file, the line, and the function to
+  the rank log and to stderr. Do not call `std::abort()` directly. A direct
+  abort is very hard to debug. Both reporters work on the host and on the
+  device.
 - An invalid input stops the run. Do not give a warning for it.
 - Two numeric helpers are an exception: `toms748.h` and `gausskronrod.h` throw
   `std::domain_error` on the host, inside a guard that returns a NaN for a GPU

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,8 +356,8 @@ are the only defence.
   writes the message with the rank, the file, the line, and the function to
   the rank log and to stderr. Do not call `std::abort()` directly. A direct
   abort is very hard to debug. Both reporters work on the host and on the
-  device. On a device, `fatal_crash()` shows the format string without the
-  values.
+  device. On a device, `fatal_crash()` prints the values with `printf` and
+  ignores the spec inside a `{}` placeholder.
 - An invalid input stops the run. Do not give a warning for it.
 - Two numeric helpers are an exception: `toms748.h` and `gausskronrod.h` throw
   `std::domain_error` on the host, inside a guard that returns a NaN for a GPU

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,7 +356,8 @@ are the only defence.
   writes the message with the rank, the file, the line, and the function to
   the rank log and to stderr. Do not call `std::abort()` directly. A direct
   abort is very hard to debug. Both reporters work on the host and on the
-  device.
+  device. On a device, `fatal_crash()` shows the format string without the
+  values.
 - An invalid input stops the run. Do not give a warning for it.
 - Two numeric helpers are an exception: `toms748.h` and `gausskronrod.h` throw
   `std::domain_error` on the host, inside a guard that returns a NaN for a GPU

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ COMPILER_NAME := unknown
 CPU_ARCH := unknown
 ifneq '' '$(findstring HIP version,$(COMPILER_VERSION))'
 	COMPILER_NAME := hipcc
+	# the C++26 operator delete declarations of libstdc++ conflict with the HIP device overloads in cuda_wrappers/new
+	CXX_STD := c++23
 	CXXFLAGS += -Wno-macro-redefined -Wno-unused-command-line-argument
 else ifneq '' '$(findstring clang,$(COMPILER_VERSION))'
 	COMPILER_NAME := clang
@@ -106,7 +108,7 @@ $(info detected CPU is $(CPU_ARCH))
 # Use a custom build directory for each combination of compiler, CPU architecture, and options to avoid conflicts and ensure that the correct binaries are used
 BUILD_DIR = build/$(COMPILER_NAME)-$(COMPILER_VERSION_NUMBER)_$(CPU_ARCH)
 
-CXXFLAGS += -std=c++26 $(ARCH_FLAGS) -Wall -Wextra -Wpedantic -Wredundant-decls -Wno-unused-parameter -Wsign-compare -Wshadow -isystem third_party
+CXXFLAGS += -std=$(CXX_STD) $(ARCH_FLAGS) -Wall -Wextra -Wpedantic -Wredundant-decls -Wno-unused-parameter -Wsign-compare -Wshadow -isystem third_party
 
 # generate and use .d header dependency files, so that header edits trigger recompilation of the
 # objects that include them (every compiler, including nvc++, supports these GCC-style options)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ COMPILER_NAME := unknown
 CPU_ARCH := unknown
 ifneq '' '$(findstring HIP version,$(COMPILER_VERSION))'
 	COMPILER_NAME := hipcc
-	CXX_STD := c++23
 	CXXFLAGS += -Wno-macro-redefined -Wno-unused-command-line-argument
 else ifneq '' '$(findstring clang,$(COMPILER_VERSION))'
 	COMPILER_NAME := clang
@@ -74,7 +73,6 @@ $(warning WARNING: Detected GCC version $(COMPILER_VERSION_NUMBER) but minimum s
 
 else ifneq '' '$(findstring nvc++,$(COMPILER_VERSION))'
 	COMPILER_NAME := nvhpc
-	CXX_STD := c++23
 	# to use the pixi installed libstdc++
 	CXXFLAGS += -Minfo=accel
 # 	CXXFLAGS += --gcc-toolchain=$(PWD)/.pixi/envs/default -Wl,-rpath,$(PWD)/.pixi/envs/default/lib
@@ -108,7 +106,7 @@ $(info detected CPU is $(CPU_ARCH))
 # Use a custom build directory for each combination of compiler, CPU architecture, and options to avoid conflicts and ensure that the correct binaries are used
 BUILD_DIR = build/$(COMPILER_NAME)-$(COMPILER_VERSION_NUMBER)_$(CPU_ARCH)
 
-CXXFLAGS += -std=$(CXX_STD) $(ARCH_FLAGS) -Wall -Wextra -Wpedantic -Wredundant-decls -Wno-unused-parameter -Wsign-compare -Wshadow -isystem third_party
+CXXFLAGS += -std=c++26 $(ARCH_FLAGS) -Wall -Wextra -Wpedantic -Wredundant-decls -Wno-unused-parameter -Wsign-compare -Wshadow -isystem third_party
 
 # generate and use .d header dependency files, so that header edits trigger recompilation of the
 # objects that include them (every compiler, including nvc++, supports these GCC-style options)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ARTIS simulates ejecta in 1D spherical, 2D cylindrical, and 3D Cartesian coordin
 - **Full-phase coverage**: a single simulation framework spans both the photospheric and nebular phases of a transient, eliminating the need to switch between specialised codes.
 
 ### High-performance computing
-- **Modern C++**: the codebase uses current language standards, including `constexpr`, concepts, ranges, and structured bindings, resulting in expressive and maintainable code that benefits from the full optimisation pipeline of modern compilers. Builds use C++26 with gcc and clang, and C++23 with the nvc++ and hipcc GPU compilers.
+- **Modern C++**: the codebase uses current language standards, including `constexpr`, concepts, ranges, and structured bindings, resulting in expressive and maintainable code that benefits from the full optimisation pipeline of modern compilers. Builds use C++26 with gcc, clang, and nvc++, and C++23 with the hipcc GPU compiler.
 - **Distributed memory parallelism with MPI**: the simulation scales to thousands of CPU cores across multiple nodes. Intra-node communication uses MPI shared-memory windows to avoid redundant data copies between ranks on the same host.
 - **Cache-friendly data layout**: data structures are organised for spatial locality so that packet updates and cell lookups achieve high cache hit rates, reducing memory-bandwidth bottlenecks on modern CPU architectures.
 - **Cell-batched packet updates**: packets are processed in cell-ordered batches — analogous to ray-coherence methods used in production rendering engines — further improving instruction and data cache reuse.

--- a/decay.cc
+++ b/decay.cc
@@ -298,14 +298,13 @@ void abort_if_decaypath_has_duplicate_lambdas() {
     for (auto i = 0Z; i < std::ssize(lambdas); i++) {
       for (auto j = i + 1; j < std::ssize(lambdas); j++) {
         if (lambdas[i] > 0. && lambdas[i] == lambdas[j]) {
-          printlnlog(
-              "[error] decay path contains two nuclides with identical decay constants {:g} [1/s], which makes the "
+          printout_decaypath(decaypathindex);
+          fatal_crash(
+              "decay path contains two nuclides with identical decay constants {:g} [1/s], which makes the "
               "Bateman solution singular. Slightly perturb one of the mean lifetimes in the decay data to break the "
               "degeneracy.",
               lambdas[i]);
-          printout_decaypath(decaypathindex);
         }
-        assert_always(lambdas[i] <= 0. || lambdas[i] != lambdas[j]);
       }
     }
   }
@@ -331,13 +330,12 @@ void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
       // check for nuclide in existing path, which would indicate a loop
       for (const auto [z, a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
         if (z == daughter.z && a == daughter.a) {
-          printlog("[error] loop in nuclear decay chain: ");
+          std::string chain;
           for (const auto [chain_z, chain_a] : std::views::zip(initial_last_decaypath.z, initial_last_decaypath.a)) {
-            printlog("(Z={},A={}) -> ", chain_z, chain_a);
+            chain += std::format("(Z={},A={}) -> ", chain_z, chain_a);
           }
-          printlnlog("(Z={},A={}) already occurred. aborting", daughter.z, daughter.a);
+          fatal_crash("loop in nuclear decay chain: {}(Z={},A={}) already occurred", chain, daughter.z, daughter.a);
         }
-        assert_always(z != daughter.z || a != daughter.a);
       }
       const auto daughter_nucindex = get_nucindex(daughter.z, daughter.a);
       auto newdecaypath = initial_last_decaypath;

--- a/decay.cc
+++ b/decay.cc
@@ -304,8 +304,8 @@ void abort_if_decaypath_has_duplicate_lambdas() {
               "degeneracy.",
               lambdas[i]);
           printout_decaypath(decaypathindex);
-          std::abort();
         }
+        assert_always(lambdas[i] <= 0. || lambdas[i] != lambdas[j]);
       }
     }
   }
@@ -336,8 +336,8 @@ void extend_lastdecaypath(std::vector<DecayPath>& localdecaypaths) {
             printlog("(Z={},A={}) -> ", chain_z, chain_a);
           }
           printlnlog("(Z={},A={}) already occurred. aborting", daughter.z, daughter.a);
-          std::abort();
         }
+        assert_always(z != daughter.z || a != daughter.a);
       }
       const auto daughter_nucindex = get_nucindex(daughter.z, daughter.a);
       auto newdecaypath = initial_last_decaypath;

--- a/grid.cc
+++ b/grid.cc
@@ -193,10 +193,9 @@ void read_possible_yefile() {
       if (mgi < 0 || mgi >= get_npts_model()) {
         // An out-of-range id is a sign of a cell id mismatch with model.txt. A silently shifted
         // electron fraction would give wrong grey opacities in every cell.
-        printlnlog("[error] Ye.txt: cell id {} is outside the model.txt id range [{}..{}]", cellnumberin,
-                   first_input_cellid, last_input_cellid);
+        fatal_crash("Ye.txt: cell id {} is outside the model.txt id range [{}..{}]", cellnumberin, first_input_cellid,
+                    last_input_cellid);
       }
-      assert_always(mgi >= 0 && mgi < get_npts_model());
       minid = std::min(minid, cellnumberin);
       maxid = std::max(maxid, cellnumberin);
       set_initelectronfrac(mgi, initelecfrac);
@@ -825,9 +824,8 @@ void read_elem_abundances() {
       // later element. Only whitespace may remain here.
       remainder.remove_prefix(std::min(remainder.find_first_not_of(" \t\r"), remainder.size()));
       if (!remainder.empty()) {
-        printlnlog("[error] read_elem_abundances: cell {} has an unreadable token at '{}'", cellnumberinput, remainder);
+        fatal_crash("read_elem_abundances: cell {} has an unreadable token at '{}'", cellnumberinput, remainder);
       }
-      assert_always(remainder.empty());
 
       if (get_numpropcells(mgi) > 0) {
         if (threedimensional || normfactor <= 0.) {
@@ -1122,11 +1120,9 @@ void read_grid_restart_data(const int timestep) {
   double tmax_in = -1.;
   assert_always(fscanf(gridsave_file, "%la %la ", &tmin_in, &tmax_in) == 2);
   if (tmin_in != globals::tmin || tmax_in != globals::tmax) {
-    printlnlog("[error] {} was written with tmin {:g} tmax {:g} but input.txt gives tmin {:g} tmax {:g}", filename,
-               tmin_in, tmax_in, globals::tmin, globals::tmax);
+    fatal_crash("{} was written with tmin {:g} tmax {:g} but input.txt gives tmin {:g} tmax {:g}", filename, tmin_in,
+                tmax_in, globals::tmin, globals::tmax);
   }
-  assert_always(tmin_in == globals::tmin);
-  assert_always(tmax_in == globals::tmax);
 
   for (int nts = 0; nts < globals::ntimesteps; nts++) {
     assert_always(
@@ -1394,11 +1390,10 @@ void setup_nstart_ndo() {
 void require_subluminal_corners(const double vmax_corner) {
   printlnlog("corner vmax {:g} [cm/s] ({:.2f}c)", vmax_corner, vmax_corner / CLIGHT);
   if (!FORCE_SPHERICAL_ESCAPE_SURFACE && vmax_corner >= CLIGHT) {
-    printlnlog(
-        "[error] the grid corners expand faster than light. Enable FORCE_SPHERICAL_ESCAPE_SURFACE in "
+    fatal_crash(
+        "the grid corners expand faster than light. Enable FORCE_SPHERICAL_ESCAPE_SURFACE in "
         "artisoptions.h to remove the superluminal corners, or reduce vmax.");
   }
-  assert_always(FORCE_SPHERICAL_ESCAPE_SURFACE || vmax_corner < CLIGHT);
 }
 
 void setup_grid_cartesian_3d() {
@@ -2112,9 +2107,8 @@ void read_ejecta_model() {
   auto ssline = std::istringstream{line};
   ssline >> npts_0;
   if (npts_0 <= 0) {
-    printlnlog("[error] model.txt: could not read a positive cell count from the first line '{}'", line);
+    fatal_crash("model.txt: could not read a positive cell count from the first line '{}'", line);
   }
-  assert_always(npts_0 > 0);
   if (ssline >> npts_1) {
     // second number on the line for 2D means the line was n_r n_z
     detected_dim = GridType::CYLINDRICAL2D;
@@ -2130,9 +2124,8 @@ void read_ejecta_model() {
   std::istringstream{line} >> t_model_days;
   // a failed extraction stores zero, which would zero all densities via the (t_model / tmin)^3 scaling
   if (!std::isfinite(t_model_days) || t_model_days <= 0.) {
-    printlnlog("[error] model.txt: could not read a positive snapshot time in days from line '{}'", line);
+    fatal_crash("model.txt: could not read a positive snapshot time in days from line '{}'", line);
   }
-  assert_always(std::isfinite(t_model_days) && t_model_days > 0.);
   t_model = t_model_days * DAY;
   assert_always(globals::tmin >= t_model);
 
@@ -2282,10 +2275,9 @@ void read_ejecta_model() {
       assert_always(cellnumberin == mgi + first_input_cellid);
 
       if (rho_tmodel < 0) {
-        printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model. aborting",
-                   mgi, cellnumberin, rho_tmodel);
+        fatal_crash("model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model", mgi,
+                    cellnumberin, rho_tmodel);
       }
-      assert_always(rho_tmodel >= 0);
 
       const bool keepcell = (rho_tmodel > 0);
       set_rho_tmin(mgi, static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin)));
@@ -2296,9 +2288,8 @@ void read_ejecta_model() {
     }
 
     if (mgi != get_npts_model()) {
-      printlnlog("[error] model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
+      fatal_crash("model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
     }
-    assert_always(mgi == get_npts_model());
 
     if (get_modelgridtype() == GridType::SPHERICAL1D) {
       // for 1D models, vmax is the outer velocity of the last cell

--- a/grid.cc
+++ b/grid.cc
@@ -195,8 +195,8 @@ void read_possible_yefile() {
         // electron fraction would give wrong grey opacities in every cell.
         printlnlog("[error] Ye.txt: cell id {} is outside the model.txt id range [{}..{}]", cellnumberin,
                    first_input_cellid, last_input_cellid);
-        std::abort();
       }
+      assert_always(mgi >= 0 && mgi < get_npts_model());
       minid = std::min(minid, cellnumberin);
       maxid = std::max(maxid, cellnumberin);
       set_initelectronfrac(mgi, initelecfrac);
@@ -826,8 +826,8 @@ void read_elem_abundances() {
       remainder.remove_prefix(std::min(remainder.find_first_not_of(" \t\r"), remainder.size()));
       if (!remainder.empty()) {
         printlnlog("[error] read_elem_abundances: cell {} has an unreadable token at '{}'", cellnumberinput, remainder);
-        std::abort();
       }
+      assert_always(remainder.empty());
 
       if (get_numpropcells(mgi) > 0) {
         if (threedimensional || normfactor <= 0.) {
@@ -1117,6 +1117,17 @@ void read_grid_restart_data(const int timestep) {
   assert_always(fscanf(gridsave_file, "%d ", &nprocs_in) == 1);
   assert_always(nprocs_in == globals::nprocs);
 
+  // the saved per-timestep energies belong to the time grid of the run that wrote the file
+  double tmin_in = -1.;
+  double tmax_in = -1.;
+  assert_always(fscanf(gridsave_file, "%la %la ", &tmin_in, &tmax_in) == 2);
+  if (tmin_in != globals::tmin || tmax_in != globals::tmax) {
+    printlnlog("[error] {} was written with tmin {:g} tmax {:g} but input.txt gives tmin {:g} tmax {:g}", filename,
+               tmin_in, tmax_in, globals::tmin, globals::tmax);
+  }
+  assert_always(tmin_in == globals::tmin);
+  assert_always(tmax_in == globals::tmax);
+
   for (int nts = 0; nts < globals::ntimesteps; nts++) {
     assert_always(
         fscanf(gridsave_file, "%la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %d ",
@@ -1386,8 +1397,8 @@ void require_subluminal_corners(const double vmax_corner) {
     printlnlog(
         "[error] the grid corners expand faster than light. Enable FORCE_SPHERICAL_ESCAPE_SURFACE in "
         "artisoptions.h to remove the superluminal corners, or reduce vmax.");
-    std::abort();
   }
+  assert_always(FORCE_SPHERICAL_ESCAPE_SURFACE || vmax_corner < CLIGHT);
 }
 
 void setup_grid_cartesian_3d() {
@@ -2102,8 +2113,8 @@ void read_ejecta_model() {
   ssline >> npts_0;
   if (npts_0 <= 0) {
     printlnlog("[error] model.txt: could not read a positive cell count from the first line '{}'", line);
-    std::abort();
   }
+  assert_always(npts_0 > 0);
   if (ssline >> npts_1) {
     // second number on the line for 2D means the line was n_r n_z
     detected_dim = GridType::CYLINDRICAL2D;
@@ -2120,8 +2131,8 @@ void read_ejecta_model() {
   // a failed extraction stores zero, which would zero all densities via the (t_model / tmin)^3 scaling
   if (!std::isfinite(t_model_days) || t_model_days <= 0.) {
     printlnlog("[error] model.txt: could not read a positive snapshot time in days from line '{}'", line);
-    std::abort();
   }
+  assert_always(std::isfinite(t_model_days) && t_model_days > 0.);
   t_model = t_model_days * DAY;
   assert_always(globals::tmin >= t_model);
 
@@ -2273,8 +2284,8 @@ void read_ejecta_model() {
       if (rho_tmodel < 0) {
         printlnlog("[error] model.txt cell {} (inputcellid {}) has negative density {:g} [g/cm3] at t_model. aborting",
                    mgi, cellnumberin, rho_tmodel);
-        std::abort();
       }
+      assert_always(rho_tmodel >= 0);
 
       const bool keepcell = (rho_tmodel > 0);
       set_rho_tmin(mgi, static_cast<float>(rho_tmodel * pow3(t_model / globals::tmin)));
@@ -2286,8 +2297,8 @@ void read_ejecta_model() {
 
     if (mgi != get_npts_model()) {
       printlnlog("[error] model.txt: found only {} cells instead of {} expected.", mgi, get_npts_model());
-      std::abort();
     }
+    assert_always(mgi == get_npts_model());
 
     if (get_modelgridtype() == GridType::SPHERICAL1D) {
       // for 1D models, vmax is the outer velocity of the last cell
@@ -2367,6 +2378,7 @@ void write_grid_restart_data(const int timestep) {
 
   fprintf(gridsave_file, "%d ", globals::ntimesteps);
   fprintf(gridsave_file, "%d ", globals::nprocs);
+  fprintf(gridsave_file, "%la %la ", globals::tmin, globals::tmax);
 
   for (int nts = 0; nts < globals::ntimesteps; nts++) {
     fprintf(gridsave_file, "%la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %la %d ",

--- a/input.cc
+++ b/input.cc
@@ -679,12 +679,10 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
         // combine it into the existing line. The duplicate immediately follows the first occurrence
         // (the table is sorted), so the transition entries filled most recently are the ones to update.
 
-        const bool prev_line_matches = (temp_linelist[prev_lineindex].elementindex == element) &&
-                                       (temp_linelist[prev_lineindex].ionindex == ion) &&
-                                       (temp_linelist[prev_lineindex].upperlevelindex == level) &&
-                                       (temp_linelist[prev_lineindex].lowerlevelindex == lowerlevel);
-        if (!prev_line_matches) {
-          printlnlog("[error] Failure to identify level pair for duplicate bb-transition ... going to abort now");
+        if ((temp_linelist[prev_lineindex].elementindex != element) ||
+            (temp_linelist[prev_lineindex].ionindex != ion) ||
+            (temp_linelist[prev_lineindex].upperlevelindex != level) ||
+            (temp_linelist[prev_lineindex].lowerlevelindex != lowerlevel)) {
           printlnlog("   element {} ion {} targetlevel {} level {}", element, ion, lowerlevel, level);
           printlnlog("   duplicate of lineindex {}", prev_lineindex);
           printlnlog("   A_ul {:g}, coll_str {:g}", transition.A, transition.coll_str);
@@ -693,8 +691,8 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
               "globals::linelist[lineindex].upperlevelindex {}, globals::linelist[lineindex].lowerlevelindex {}",
               temp_linelist[prev_lineindex].elementindex, temp_linelist[prev_lineindex].ionindex,
               temp_linelist[prev_lineindex].upperlevelindex, temp_linelist[prev_lineindex].lowerlevelindex);
+          fatal_crash("Failure to identify level pair for duplicate bb-transition");
         }
-        assert_always(prev_line_matches);
 
         const auto g_ratio = static_cast<double>(ion_levels[level].stat_weight) / ion_levels[lowerlevel].stat_weight;
         const auto f_lu =
@@ -884,15 +882,14 @@ void setup_phixs_list() {
               // groundcontindex slot, and the writes below use the same slot. The nearest-edge search
               // gives another ion's slot only when two ions have an identical ground threshold. That
               // case would silently mix the estimators of the two ions.
-              const int foundslot = alllevels_closestgroundlevelcont[uniquelevelindex];
-              if (foundslot != groundcontindex) {
-                printlnlog(
-                    "[error] element {} ion {} has the ground continuum slot {}, but the nearest-edge search "
+              if (const int foundslot = alllevels_closestgroundlevelcont[uniquelevelindex];
+                  foundslot != groundcontindex) {
+                fatal_crash(
+                    "element {} ion {} has the ground continuum slot {}, but the nearest-edge search "
                     "found the slot {} of element {} ion {}. Two ions have an identical ground threshold {:g}.",
                     element, ion, groundcontindex, foundslot, globals::groundcont_element[foundslot],
                     globals::groundcont_ion[foundslot], nu_edge_target0);
               }
-              assert_always(foundslot == groundcontindex);
             }
           }
 
@@ -1926,9 +1923,8 @@ void read_parameterfile(std::span<Packet> packets) {
     std::error_code ec;
     std::filesystem::copy_file("input-newrun.txt", "input.txt", ec);
     if (ec) {
-      printlnlog("[error] failed to copy input-newrun.txt to input.txt: {}", ec.message());
+      fatal_crash("failed to copy input-newrun.txt to input.txt: {}", ec.message());
     }
-    assert_always(!ec);
     printlnlog("done");
   }
   // rank 0 creates input.txt before the other ranks open it
@@ -1946,11 +1942,10 @@ void read_parameterfile(std::span<Packet> packets) {
     printlnlog("input.txt specified random number seed is {}", pre_zseed);
   } else {
 #if defined REPRODUCIBLE && REPRODUCIBLE
-    printlnlog(
-        "[error] REPRODUCIBLE mode requires a positive random number seed on the first non-comment line of input.txt "
+    fatal_crash(
+        "REPRODUCIBLE mode requires a positive random number seed on the first non-comment line of input.txt "
         "(found {})",
         pre_zseed);
-    assert_always(pre_zseed > 0);
 #endif
     pre_zseed = get_rng_random_seed();
     // broadcast randomly-generated seed from rank 0 to all ranks

--- a/input.cc
+++ b/input.cc
@@ -164,6 +164,8 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
       // top ion has only one level, so send it to that level
       upperlevel = 0;
     }
+    // a target level above the levels kept from compositiondata.txt would index the level block of the next ion
+    assert_always(upperlevel < get_nlevels(element, upperion));
 
     tmpallphixstargets.push_back({.probability = 1., .levelindex = upperlevel});
   } else {  // upperlevel < 0, indicating that a table of upper levels and their probabilities will follow
@@ -184,7 +186,7 @@ void read_phixs_data_table(std::istream& phixsfile, const int nphixspoints_input
         assert_always(get_noncommentline(phixsfile, phixsline));
         assert_always(std::stringstream(phixsline) >> upperlevel_in >> phixstargetprobability);
         const int upperlevel = upperlevel_in - groundstate_index_in;
-        assert_always(upperlevel >= 0);
+        assert_always(upperlevel >= 0 && upperlevel < get_nlevels(element, upperion));
         assert_always(phixstargetprobability > 0);
         tmpallphixstargets.push_back({.probability = phixstargetprobability, .levelindex = upperlevel});
 
@@ -677,10 +679,11 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
         // combine it into the existing line. The duplicate immediately follows the first occurrence
         // (the table is sorted), so the transition entries filled most recently are the ones to update.
 
-        if ((temp_linelist[prev_lineindex].elementindex != element) ||
-            (temp_linelist[prev_lineindex].ionindex != ion) ||
-            (temp_linelist[prev_lineindex].upperlevelindex != level) ||
-            (temp_linelist[prev_lineindex].lowerlevelindex != lowerlevel)) {
+        const bool prev_line_matches = (temp_linelist[prev_lineindex].elementindex == element) &&
+                                       (temp_linelist[prev_lineindex].ionindex == ion) &&
+                                       (temp_linelist[prev_lineindex].upperlevelindex == level) &&
+                                       (temp_linelist[prev_lineindex].lowerlevelindex == lowerlevel);
+        if (!prev_line_matches) {
           printlnlog("[error] Failure to identify level pair for duplicate bb-transition ... going to abort now");
           printlnlog("   element {} ion {} targetlevel {} level {}", element, ion, lowerlevel, level);
           printlnlog("   duplicate of lineindex {}", prev_lineindex);
@@ -690,8 +693,8 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
               "globals::linelist[lineindex].upperlevelindex {}, globals::linelist[lineindex].lowerlevelindex {}",
               temp_linelist[prev_lineindex].elementindex, temp_linelist[prev_lineindex].ionindex,
               temp_linelist[prev_lineindex].upperlevelindex, temp_linelist[prev_lineindex].lowerlevelindex);
-          std::abort();
         }
+        assert_always(prev_line_matches);
 
         const auto g_ratio = static_cast<double>(ion_levels[level].stat_weight) / ion_levels[lowerlevel].stat_weight;
         const auto f_lu =
@@ -881,15 +884,15 @@ void setup_phixs_list() {
               // groundcontindex slot, and the writes below use the same slot. The nearest-edge search
               // gives another ion's slot only when two ions have an identical ground threshold. That
               // case would silently mix the estimators of the two ions.
-              if (const int foundslot = alllevels_closestgroundlevelcont[uniquelevelindex];
-                  foundslot != groundcontindex) {
+              const int foundslot = alllevels_closestgroundlevelcont[uniquelevelindex];
+              if (foundslot != groundcontindex) {
                 printlnlog(
                     "[error] element {} ion {} has the ground continuum slot {}, but the nearest-edge search "
                     "found the slot {} of element {} ion {}. Two ions have an identical ground threshold {:g}.",
                     element, ion, groundcontindex, foundslot, globals::groundcont_element[foundslot],
                     globals::groundcont_ion[foundslot], nu_edge_target0);
-                std::abort();
               }
+              assert_always(foundslot == groundcontindex);
             }
           }
 
@@ -1924,8 +1927,8 @@ void read_parameterfile(std::span<Packet> packets) {
     std::filesystem::copy_file("input-newrun.txt", "input.txt", ec);
     if (ec) {
       printlnlog("[error] failed to copy input-newrun.txt to input.txt: {}", ec.message());
-      std::abort();
     }
+    assert_always(!ec);
     printlnlog("done");
   }
   // rank 0 creates input.txt before the other ranks open it
@@ -1947,7 +1950,7 @@ void read_parameterfile(std::span<Packet> packets) {
         "[error] REPRODUCIBLE mode requires a positive random number seed on the first non-comment line of input.txt "
         "(found {})",
         pre_zseed);
-    std::abort();
+    assert_always(pre_zseed > 0);
 #endif
     pre_zseed = get_rng_random_seed();
     // broadcast randomly-generated seed from rank 0 to all ranks

--- a/mpi_logging.cc
+++ b/mpi_logging.cc
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstdarg>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -59,4 +60,15 @@ DEVICE_FUNC void report_assert_failure(const char* file, const int line, const c
     output_file.flush();
   } std::println(std::cerr, "\n[rank {}] {}:{}: failed assertion `{}` in function {}", globals::my_rank, file, line,
                  expr, func););
+}
+
+DEVICE_FUNC void report_fatal_error_and_abort(const char* file, const int line, const char* func,
+                                              const char* message) noexcept {
+  MY_IF_DEVICE(printf("\n[rank %d] [error] %s:%d in %s: %s\n", globals::my_rank, file, line, func, message);
+               assert(false); __builtin_trap(););
+  MY_IF_HOST(if (output_file) {
+    std::println(output_file, "\n[rank {}] [error] {}:{} in {}: {}", globals::my_rank, file, line, func, message);
+    output_file.flush();
+  } std::println(std::cerr, "\n[rank {}] [error] {}:{} in {}: {}", globals::my_rank, file, line, func, message);
+             std::abort(););
 }

--- a/mpi_logging.cc
+++ b/mpi_logging.cc
@@ -62,13 +62,11 @@ DEVICE_FUNC void report_assert_failure(const char* file, const int line, const c
                  expr, func););
 }
 
-DEVICE_FUNC void report_fatal_error_and_abort(const char* file, const int line, const char* func,
-                                              const char* message) noexcept {
-  MY_IF_DEVICE(printf("\n[rank %d] [error] %s:%d in %s: %s\n", globals::my_rank, file, line, func, message);
-               assert(false); __builtin_trap(););
-  MY_IF_HOST(if (output_file) {
+void report_fatal_error_and_abort(const char* file, const int line, const char* func, const char* message) noexcept {
+  if (output_file) {
     std::println(output_file, "\n[rank {}] [error] {}:{} in {}: {}", globals::my_rank, file, line, func, message);
     output_file.flush();
-  } std::println(std::cerr, "\n[rank {}] [error] {}:{} in {}: {}", globals::my_rank, file, line, func, message);
-             std::abort(););
+  }
+  std::println(std::cerr, "\n[rank {}] [error] {}:{} in {}: {}", globals::my_rank, file, line, func, message);
+  std::abort();
 }

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -543,24 +543,25 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
 }
 
 [[nodiscard]] inline auto fopen_required(const std::string& filename, std::span<const char> mode) -> FILE* {
+  FILE* file = nullptr;
   if (mode[0] == 'r') {
     // search data folders in order to find file to read
     for (const auto& datadir : datafolders) {
       const auto datafolderfilename = std::format("{}{}", datadir, filename);
-      auto* file = std::fopen(datafolderfilename.c_str(), mode.data());
+      file = std::fopen(datafolderfilename.c_str(), mode.data());
       if (file != nullptr) {
-        return file;
+        break;
       }
     }
   } else {
-    auto* file = std::fopen(filename.c_str(), mode.data());
-    if (file != nullptr) {
-      return file;
-    }
+    file = std::fopen(filename.c_str(), mode.data());
   }
 
-  printlnlog("[error] Could not open file '{}' for mode '{}'.", filename, mode.data());
-  std::abort();
+  if (file == nullptr) {
+    printlnlog("[error] Could not open file '{}' for mode '{}'.", filename, mode.data());
+  }
+  assert_always(file != nullptr);
+  return file;
 }
 
 [[nodiscard]] inline auto fopen_required_uniqueptr(const std::string& filename, std::span<const char> mode) {
@@ -571,28 +572,29 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
 [[nodiscard]] inline auto fstream_required(const std::string_view filename, std::ios::openmode mode) -> std::fstream {
   if (filename.empty()) {
     printlnlog("[error] Cannot open file with empty filename.");
-    std::abort();
   }
+  assert_always(!filename.empty());
 
+  auto file = std::fstream{};
   if ((mode & std::ios::in) != 0U) {
     // search data folders in order to find file to read
     for (const auto& datadir : datafolders) {
       const auto datafolderfilename = std::format("{}{}", datadir, filename);
-      auto file = std::fstream(datafolderfilename, mode);
+      file.open(datafolderfilename, mode);
       if (file.is_open()) {
-        return file;
+        break;
       }
     }
   } else {
     // don't prepend data folders when writing
-    auto file = std::fstream(std::string(filename), mode);
-    if (file.is_open()) {
-      return file;
-    }
+    file.open(std::string(filename), mode);
   }
 
-  printlnlog("[error] Could not open file '{}'", filename);
-  std::abort();
+  if (!file.is_open()) {
+    printlnlog("[error] Could not open file '{}'", filename);
+  }
+  assert_always(file.is_open());
+  return file;
 }
 
 // open a per-rank output file such as estimators_0000.out for writing

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -120,10 +120,10 @@ void log_write(std::string_view message, bool add_newline) noexcept;
 [[gnu::cold]] DEVICE_FUNC void report_assert_failure(const char* file, int line, const char* expr,
                                                      const char* func) noexcept;
 
-// Write the message with the rank, the file, the line, and the function to the rank log (or to stdout on a
-// device) and to stderr, then stop the run. Call it through the macro fatal_crash(fmt, args...).
-[[noreturn]] [[gnu::cold]] DEVICE_FUNC void report_fatal_error_and_abort(const char* file, int line, const char* func,
-                                                                         const char* message) noexcept;
+// Write the message with the rank, the file, the line, and the function to the rank log and to stderr, then stop
+// the run. Host only. Call it through the macro fatal_crash(fmt, args...), which also has a device path.
+[[noreturn]] [[gnu::cold]] void report_fatal_error_and_abort(const char* file, int line, const char* func,
+                                                             const char* message) noexcept;
 
 #define __artis_assert(e)                                                 \
   {                                                                       \
@@ -146,13 +146,76 @@ inline auto printlnlog(const std::format_string<Args...> fmt, Args&&... args) no
   MY_IF_HOST(log_write(std::format(fmt, std::forward<Args>(args)...), true););
 }
 
-// Stop the run with a message. The host formats the message. Device code has no std::format, so the device path
-// reports the format string without the values, together with the same rank, file, line, and function.
+// Device code has no std::format, so these helpers print a std::format string with the device printf. Each {...}
+// takes the next argument and the spec inside the braces is ignored. {{ and }} print one brace.
+template <typename T>
+DEVICE_FUNC inline auto device_printf_arg(const T& value) -> void {
+  if constexpr (std::is_same_v<T, bool>) {
+    printf("%s", value ? "true" : "false");
+  } else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>) {
+    printf("%lld", static_cast<long long>(value));
+  } else if constexpr (std::is_integral_v<T>) {
+    printf("%llu", static_cast<unsigned long long>(value));
+  } else if constexpr (std::is_floating_point_v<T>) {
+    printf("%g", static_cast<double>(value));
+  } else if constexpr (std::is_convertible_v<T, const char*>) {
+    printf("%s", static_cast<const char*>(value));
+  } else if constexpr (requires { value.c_str(); }) {
+    printf("%s", value.c_str());
+  } else if constexpr (requires {
+                         value.data();
+                         value.size();
+                       }) {
+    printf("%.*s", static_cast<int>(value.size()), value.data());
+  } else {
+    static_assert(false, "device_printf_arg: no printf conversion for this argument type");
+  }
+}
+
+// Print the part [start, end) of the format string
+DEVICE_FUNC inline auto device_printf_literal(const std::string_view fmt, const size_t start, const size_t end)
+    -> void {
+  const auto part = fmt.substr(start, end - start);
+  printf("%.*s", static_cast<int>(part.size()), part.data());
+}
+
+// Print the literal text up to and including the next {...} placeholder. Give back the position after it.
+DEVICE_FUNC inline auto device_printf_until_placeholder(const std::string_view fmt, size_t pos) -> size_t {
+  size_t literal_start = pos;
+  while (pos < fmt.size()) {
+    const char c = fmt[pos];
+    const char next = (pos + 1 < fmt.size()) ? fmt[pos + 1] : '\0';
+    if ((c == '{' && next == '{') || (c == '}' && next == '}')) {
+      device_printf_literal(fmt, literal_start, pos + 1);
+      pos += 2;
+      literal_start = pos;
+    } else if (c == '{') {
+      device_printf_literal(fmt, literal_start, pos);
+      const auto close = fmt.find('}', pos);
+      return (close == std::string_view::npos) ? fmt.size() : close + 1;
+    } else {
+      pos++;
+    }
+  }
+  device_printf_literal(fmt, literal_start, fmt.size());
+  return pos;
+}
+
+template <typename... Args>
+DEVICE_FUNC inline auto device_printf_format(const std::string_view fmt, const Args&... args) -> void {
+  size_t pos = 0;
+  ((pos = device_printf_until_placeholder(fmt, pos), device_printf_arg(args)), ...);
+  device_printf_until_placeholder(fmt, pos);
+}
+
+// Stop the run with a message. The host formats the message with std::format and writes it with the rank, the
+// file, the line, and the function to the rank log and to stderr. A device prints the same line with printf.
 template <typename... Args>
 [[noreturn]] DEVICE_FUNC inline auto fatal_crash_at(const char* file, const int line, const char* func,
-                                                    const std::format_string<Args...> fmt,
-                                                    [[maybe_unused]] Args&&... args) noexcept -> void {
-  MY_IF_DEVICE(report_fatal_error_and_abort(file, line, func, fmt.get().data()););
+                                                    const std::format_string<Args...> fmt, Args&&... args) noexcept
+    -> void {
+  MY_IF_DEVICE(printf("\n[rank %d] [error] %s:%d in %s: ", globals::my_rank, file, line, func);
+               device_printf_format(fmt.get(), args...); printf("\n"); assert(false); __builtin_trap(););
   MY_IF_HOST(report_fatal_error_and_abort(file, line, func, std::format(fmt, std::forward<Args>(args)...).c_str()););
 }
 

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -215,8 +215,11 @@ template <typename... Args>
                                                     const std::format_string<Args...> fmt, Args&&... args) noexcept
     -> void {
   MY_IF_DEVICE(printf("\n[rank %d] [error] %s:%d in %s: ", globals::my_rank, file, line, func);
-               device_printf_format(fmt.get(), args...); printf("\n"); assert(false); __builtin_trap(););
+               device_printf_format(fmt.get(), args...); printf("\n"););
   MY_IF_HOST(report_fatal_error_and_abort(file, line, func, std::format(fmt, std::forward<Args>(args)...).c_str()););
+  // the host reporter above does not return. The trap stops a device thread, and it also shows every compiler
+  // that this function does not return, because the target split above hides that from nvc++.
+  __builtin_trap();
 }
 
 #define fatal_crash(...) fatal_crash_at(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__)

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -120,6 +120,11 @@ void log_write(std::string_view message, bool add_newline) noexcept;
 [[gnu::cold]] DEVICE_FUNC void report_assert_failure(const char* file, int line, const char* expr,
                                                      const char* func) noexcept;
 
+// Write the message with the rank, the file, the line, and the function to the rank log (or to stdout on a
+// device) and to stderr, then stop the run. Call it through the macro fatal_crash(fmt, args...).
+[[noreturn]] [[gnu::cold]] DEVICE_FUNC void report_fatal_error_and_abort(const char* file, int line, const char* func,
+                                                                         const char* message) noexcept;
+
 #define __artis_assert(e)                                                 \
   {                                                                       \
     const bool assertpass = static_cast<bool>(e);                         \
@@ -140,6 +145,17 @@ inline auto printlnlog(const std::format_string<Args...> fmt, Args&&... args) no
   MY_IF_DEVICE(const auto str = std::vformat(fmt.get(), std::make_format_args(args...)); printf("%s\n", str.c_str()););
   MY_IF_HOST(log_write(std::format(fmt, std::forward<Args>(args)...), true););
 }
+
+template <typename... Args>
+[[noreturn]] DEVICE_FUNC inline auto fatal_crash_at(const char* file, const int line, const char* func,
+                                                    const std::format_string<Args...> fmt, Args&&... args) noexcept
+    -> void {
+  MY_IF_DEVICE(const auto str = std::vformat(fmt.get(), std::make_format_args(args...));
+               report_fatal_error_and_abort(file, line, func, str.c_str()););
+  MY_IF_HOST(report_fatal_error_and_abort(file, line, func, std::format(fmt, std::forward<Args>(args)...).c_str()););
+}
+
+#define fatal_crash(...) fatal_crash_at(__FILE__, __LINE__, __PRETTY_FUNCTION__, __VA_ARGS__)
 
 #define assert_always(e) __artis_assert(e)
 
@@ -543,25 +559,23 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
 }
 
 [[nodiscard]] inline auto fopen_required(const std::string& filename, std::span<const char> mode) -> FILE* {
-  FILE* file = nullptr;
   if (mode[0] == 'r') {
     // search data folders in order to find file to read
     for (const auto& datadir : datafolders) {
       const auto datafolderfilename = std::format("{}{}", datadir, filename);
-      file = std::fopen(datafolderfilename.c_str(), mode.data());
+      auto* file = std::fopen(datafolderfilename.c_str(), mode.data());
       if (file != nullptr) {
-        break;
+        return file;
       }
     }
   } else {
-    file = std::fopen(filename.c_str(), mode.data());
+    auto* file = std::fopen(filename.c_str(), mode.data());
+    if (file != nullptr) {
+      return file;
+    }
   }
 
-  if (file == nullptr) {
-    printlnlog("[error] Could not open file '{}' for mode '{}'.", filename, mode.data());
-  }
-  assert_always(file != nullptr);
-  return file;
+  fatal_crash("Could not open file '{}' for mode '{}'.", filename, mode.data());
 }
 
 [[nodiscard]] inline auto fopen_required_uniqueptr(const std::string& filename, std::span<const char> mode) {
@@ -571,30 +585,27 @@ inline void MPI_Reduce_safe(R&& data, MPI_Op op, const int root, MPI_Comm comm) 
 
 [[nodiscard]] inline auto fstream_required(const std::string_view filename, std::ios::openmode mode) -> std::fstream {
   if (filename.empty()) {
-    printlnlog("[error] Cannot open file with empty filename.");
+    fatal_crash("Cannot open file with empty filename.");
   }
-  assert_always(!filename.empty());
 
-  auto file = std::fstream{};
   if ((mode & std::ios::in) != 0U) {
     // search data folders in order to find file to read
     for (const auto& datadir : datafolders) {
       const auto datafolderfilename = std::format("{}{}", datadir, filename);
-      file.open(datafolderfilename, mode);
+      auto file = std::fstream(datafolderfilename, mode);
       if (file.is_open()) {
-        break;
+        return file;
       }
     }
   } else {
     // don't prepend data folders when writing
-    file.open(std::string(filename), mode);
+    auto file = std::fstream(std::string(filename), mode);
+    if (file.is_open()) {
+      return file;
+    }
   }
 
-  if (!file.is_open()) {
-    printlnlog("[error] Could not open file '{}'", filename);
-  }
-  assert_always(file.is_open());
-  return file;
+  fatal_crash("Could not open file '{}'", filename);
 }
 
 // open a per-rank output file such as estimators_0000.out for writing

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -146,12 +146,13 @@ inline auto printlnlog(const std::format_string<Args...> fmt, Args&&... args) no
   MY_IF_HOST(log_write(std::format(fmt, std::forward<Args>(args)...), true););
 }
 
+// Stop the run with a message. The host formats the message. Device code has no std::format, so the device path
+// reports the format string without the values, together with the same rank, file, line, and function.
 template <typename... Args>
 [[noreturn]] DEVICE_FUNC inline auto fatal_crash_at(const char* file, const int line, const char* func,
-                                                    const std::format_string<Args...> fmt, Args&&... args) noexcept
-    -> void {
-  MY_IF_DEVICE(const auto str = std::vformat(fmt.get(), std::make_format_args(args...));
-               report_fatal_error_and_abort(file, line, func, str.c_str()););
+                                                    const std::format_string<Args...> fmt,
+                                                    [[maybe_unused]] Args&&... args) noexcept -> void {
+  MY_IF_DEVICE(report_fatal_error_and_abort(file, line, func, fmt.get().data()););
   MY_IF_HOST(report_fatal_error_and_abort(file, line, func, std::format(fmt, std::forward<Args>(args)...).c_str()););
 }
 

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -2156,8 +2156,8 @@ void nltepop_read_restart_data(FILE* restart_file) {
   if (total_nlte_levels_in != globals::total_nlte_levels) {
     printlnlog("[error] Expected {} NLTE levels but found {} in restart file", globals::total_nlte_levels,
                total_nlte_levels_in);
-    std::abort();
   }
+  assert_always(total_nlte_levels_in == globals::total_nlte_levels);
   const auto nincludedions = get_includedions();
 
   for (auto nonemptymgi = 0Z; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -2154,10 +2154,9 @@ void nltepop_read_restart_data(FILE* restart_file) {
   int total_nlte_levels_in = 0;
   assert_always(fscanf(restart_file, "%d\n", &total_nlte_levels_in) == 1);
   if (total_nlte_levels_in != globals::total_nlte_levels) {
-    printlnlog("[error] Expected {} NLTE levels but found {} in restart file", globals::total_nlte_levels,
-               total_nlte_levels_in);
+    fatal_crash("Expected {} NLTE levels but found {} in restart file", globals::total_nlte_levels,
+                total_nlte_levels_in);
   }
-  assert_always(total_nlte_levels_in == globals::total_nlte_levels);
   const auto nincludedions = get_includedions();
 
   for (auto nonemptymgi = 0Z; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2768,13 +2768,14 @@ void read_restart_data(FILE* gridsave_file) {
   double SF_EMAX_in{NAN};
   assert_always(fscanf(gridsave_file, "%d %la %la\n", &sfpts_in, &SF_EMIN_in, &SF_EMAX_in) == 3);
 
-  if (sfpts_in != SFPTS || SF_EMIN_in != SF_EMIN || SF_EMAX_in != SF_EMAX) {
+  const bool sf_grid_matches = sfpts_in == SFPTS && SF_EMIN_in == SF_EMIN && SF_EMAX_in == SF_EMAX;
+  if (!sf_grid_matches) {
     printlnlog("[error] gridsave file specifies {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", sfpts_in,
                SF_EMIN_in, SF_EMAX_in);
     printlnlog("[error] This simulation has {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", SFPTS, SF_EMIN,
                SF_EMAX);
-    std::abort();
   }
+  assert_always(sf_grid_matches);
 
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     int nonemptymgi_in = 0;
@@ -2818,31 +2819,35 @@ void read_restart_data(FILE* gridsave_file) {
   }
 }
 
-void nt_MPI_Bcast(const ptrdiff_t nonemptymgi, const int root_node_id) {
+// broadcast the non-thermal solution of the cells that belong to the root rank to all ranks
+void nt_MPI_Bcast(const ptrdiff_t nstart_nonempty, const ptrdiff_t ndo_nonempty, const int root_node_id) {
   if (globals::rank_in_node == 0) {
     // node-shared memory, so only node leaders participate in the internode broadcast
     // (root_node_id is only a valid root rank within the rank_in_node == 0 communicator)
-    MPI_Bcast_safe(ntlepton_deposition_rate_density_all_cells[nonemptymgi], root_node_id, globals::mpi_comm_internode);
+    MPI_Bcast_safe(ntlepton_deposition_rate_density_all_cells.subspan(nstart_nonempty, ndo_nonempty), root_node_id,
+                   globals::mpi_comm_internode);
   }
 
   if (NT_SCHEME == NonThermalScheme::NT_SPENCERFANO) {
     if (globals::rank_in_node == 0) {
-      MPI_Bcast_safe(nt_solution[nonemptymgi].nneperion_when_solved, root_node_id, globals::mpi_comm_internode);
-      MPI_Bcast_safe(nt_solution[nonemptymgi].timestep_last_solved, root_node_id, globals::mpi_comm_internode);
-      MPI_Bcast_safe(nt_solution[nonemptymgi].frac_heating, root_node_id, globals::mpi_comm_internode);
-      MPI_Bcast_safe(nt_solution[nonemptymgi].frac_ionisation, root_node_id, globals::mpi_comm_internode);
-      MPI_Bcast_safe(nt_solution[nonemptymgi].frac_excitation, root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast_safe(nt_solution.subspan(nstart_nonempty, ndo_nonempty), root_node_id, globals::mpi_comm_internode);
 
-      MPI_Bcast_safe(nt_solution[nonemptymgi].frac_excitations_list_size, root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast_safe(
+          ion_data_all_cells.subspan(nstart_nonempty * get_includedions(), ndo_nonempty * get_includedions()),
+          root_node_id, globals::mpi_comm_internode);
 
-      MPI_Bcast_safe(get_cell_ntexcitations(nonemptymgi), root_node_id, globals::mpi_comm_internode);
-
-      MPI_Bcast_safe(get_cell_allions_data(nonemptymgi), root_node_id, globals::mpi_comm_internode);
+      // the excitation list of a cell has its own length, which the broadcast of nt_solution above has set
+      for (auto nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+        MPI_Bcast_safe(get_cell_ntexcitations(nonemptymgi), root_node_id, globals::mpi_comm_internode);
+      }
     }
 
+    // the other ranks on a node read the shared arrays only after the node leader has received them
     MPI_Barrier_allranks();
 
-    check_auger_probabilities(nonemptymgi);
+    for (auto nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+      check_auger_probabilities(nonemptymgi);
+    }
   }
 }
 

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -2768,14 +2768,11 @@ void read_restart_data(FILE* gridsave_file) {
   double SF_EMAX_in{NAN};
   assert_always(fscanf(gridsave_file, "%d %la %la\n", &sfpts_in, &SF_EMIN_in, &SF_EMAX_in) == 3);
 
-  const bool sf_grid_matches = sfpts_in == SFPTS && SF_EMIN_in == SF_EMIN && SF_EMAX_in == SF_EMAX;
-  if (!sf_grid_matches) {
+  if (sfpts_in != SFPTS || SF_EMIN_in != SF_EMIN || SF_EMAX_in != SF_EMAX) {
     printlnlog("[error] gridsave file specifies {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", sfpts_in,
                SF_EMIN_in, SF_EMAX_in);
-    printlnlog("[error] This simulation has {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", SFPTS, SF_EMIN,
-               SF_EMAX);
+    fatal_crash("This simulation has {} Spencer-Fano samples, SF_EMIN {:g} SF_EMAX {:g}", SFPTS, SF_EMIN, SF_EMAX);
   }
-  assert_always(sf_grid_matches);
 
   for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
     int nonemptymgi_in = 0;

--- a/nonthermal.h
+++ b/nonthermal.h
@@ -55,7 +55,7 @@ DEVICE_FUNC void do_ntalpha_fisprod_deposit(Packet& pkt);
 DEVICE_FUNC void do_ntlepton_deposit(Packet& pkt);
 void write_restart_data(FILE* gridsave_file);
 void read_restart_data(FILE* gridsave_file);
-void nt_MPI_Bcast(ptrdiff_t nonemptymgi, int root_node_id);
+void nt_MPI_Bcast(ptrdiff_t nstart_nonempty, ptrdiff_t ndo_nonempty, int root_node_id);
 void reset_stats();
 void print_stats(double modelvolume, double deltat);
 }  // namespace nonthermal

--- a/packet.cc
+++ b/packet.cc
@@ -194,9 +194,8 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
       ntokens++;
     }
     if (ntokens != ncolumns) {
-      printlnlog("[error] read_text_packets: the row has {} of {} columns: '{}'", ntokens, ncolumns, line);
+      fatal_crash("read_text_packets: the row has {} of {} columns: '{}'", ntokens, ncolumns, line);
     }
-    assert_always(ntokens == ncolumns);
 
     ssline.clear();
     ssline.str(line);
@@ -223,9 +222,8 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
     // row, e.g. from a partial write on a full file system. A silently accepted truncated row would
     // drop the packet from the spectra (escape_type stays 0) with no diagnostic.
     if (ssline.fail()) {
-      printlnlog("[error] read_text_packets: could not parse the packet row '{}'", line);
+      fatal_crash("read_text_packets: could not parse the packet row '{}'", line);
     }
-    assert_always(!ssline.fail());
 
     ssline >> pkt.em_pos[0] >> pkt.em_pos[1] >> pkt.em_pos[2];
     ssline >> pkt.absorptiontype >> pkt.absorptionfreq >> pkt.nscatterings;
@@ -308,9 +306,8 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
   bool write_success = false;
   while (!write_success) {
     if (tries > 10) {
-      printlnlog("[error] Failed to write {} after {} tries. Aborting.", filename, tries);
+      fatal_crash("Failed to write {} after {} tries. Aborting.", filename, tries);
     }
-    assert_always(tries <= 10);
     if (tries > 0) {
       // give transient filesystem problems (e.g. contention on a cluster parallel filesystem) a
       // chance to clear instead of burning through all of the retries within milliseconds

--- a/packet.cc
+++ b/packet.cc
@@ -195,8 +195,8 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
     }
     if (ntokens != ncolumns) {
       printlnlog("[error] read_text_packets: the row has {} of {} columns: '{}'", ntokens, ncolumns, line);
-      std::abort();
     }
+    assert_always(ntokens == ncolumns);
 
     ssline.clear();
     ssline.str(line);
@@ -224,8 +224,8 @@ auto read_text_packets(const std::string& filename) -> std::vector<Packet> {
     // drop the packet from the spectra (escape_type stays 0) with no diagnostic.
     if (ssline.fail()) {
       printlnlog("[error] read_text_packets: could not parse the packet row '{}'", line);
-      std::abort();
     }
+    assert_always(!ssline.fail());
 
     ssline >> pkt.em_pos[0] >> pkt.em_pos[1] >> pkt.em_pos[2];
     ssline >> pkt.absorptiontype >> pkt.absorptionfreq >> pkt.nscatterings;
@@ -309,8 +309,8 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
   while (!write_success) {
     if (tries > 10) {
       printlnlog("[error] Failed to write {} after {} tries. Aborting.", filename, tries);
-      std::abort();
     }
+    assert_always(tries <= 10);
     if (tries > 0) {
       // give transient filesystem problems (e.g. contention on a cluster parallel filesystem) a
       // chance to clear instead of burning through all of the retries within milliseconds

--- a/radfield.cc
+++ b/radfield.cc
@@ -1146,15 +1146,13 @@ void read_restart_data(FILE* gridsave_file) {
       nu_upper_last_ratio = 1 / nu_upper_last_ratio;
     }
 
-    const bool bins_match = bincount_in == RADFIELDBINCOUNT && T_R_min_in == bins_T_R_min &&
-                            T_R_max_in == bins_T_R_max && nu_lower_first_ratio >= 0.999 && nu_upper_last_ratio >= 0.999;
-    if (!bins_match) {
+    if (bincount_in != RADFIELDBINCOUNT || T_R_min_in != bins_T_R_min || T_R_max_in != bins_T_R_max ||
+        nu_lower_first_ratio < 0.999 || nu_upper_last_ratio < 0.999) {
       printlnlog("[error] gridsave file specifies {} bins, nu_min {} nu_max {} T_R_min {} T_R_max {}", bincount_in,
                  nu_min_in, nu_max_in, T_R_min_in, T_R_max_in);
-      printlnlog("require {} bins, RADFIELDBINS_NU_MIN {:g} RADFIELDBINS_NU_MAX {:g} T_R_min {:g} T_R_max {:g}",
-                 RADFIELDBINCOUNT, RADFIELDBINS_NU_MIN, RADFIELDBINS_NU_MAX, bins_T_R_min, bins_T_R_max);
+      fatal_crash("require {} bins, RADFIELDBINS_NU_MIN {:g} RADFIELDBINS_NU_MAX {:g} T_R_min {:g} T_R_max {:g}",
+                  RADFIELDBINCOUNT, RADFIELDBINS_NU_MIN, RADFIELDBINS_NU_MAX, bins_T_R_min, bins_T_R_max);
     }
-    assert_always(bins_match);
 
     for (int binindex = 0; binindex < RADFIELDBINCOUNT; binindex++) {
       int binindex_in = 0;
@@ -1195,10 +1193,9 @@ void read_restart_data(FILE* gridsave_file) {
     assert_always(fscanf(gridsave_file, "%d\n", &detailed_linecount_in) == 1);
 
     if (detailed_linecount_in != detailed_linecount) {
-      printlnlog("[error] gridsave file specifies {} detailed lines but this simulation has {}.", detailed_linecount_in,
-                 detailed_linecount);
+      fatal_crash("gridsave file specifies {} detailed lines but this simulation has {}.", detailed_linecount_in,
+                  detailed_linecount);
     }
-    assert_always(detailed_linecount_in == detailed_linecount);
 
     for (int jblueindex = 0; jblueindex < detailed_linecount; jblueindex++) {
       assert_always(fscanf(gridsave_file, "%d ", &detailed_lineindices[jblueindex]) == 1);

--- a/radfield.cc
+++ b/radfield.cc
@@ -1034,27 +1034,31 @@ void reduce_estimators() {
   MPI_Barrier_allranks();
 }
 
-// broadcast computed radfield results including parameters from the cells belonging to root process to all processes
-void do_MPI_Bcast(const ptrdiff_t nonemptymgi, const int root, const int root_node_id) {
-  MPI_Bcast_safe(J_normfactor[nonemptymgi], root, MPI_COMM_WORLD);
+// broadcast the radiation field parameters of the cells that belong to the root rank to all ranks. The caller
+// puts a barrier after this call, so that the other ranks on a node read the shared arrays after the broadcast.
+void do_MPI_Bcast(const ptrdiff_t nstart_nonempty, const ptrdiff_t ndo_nonempty, const int root,
+                  const int root_node_id) {
+  MPI_Bcast_safe(std::span{J_normfactor}.subspan(nstart_nonempty, ndo_nonempty), root, MPI_COMM_WORLD);
 
   if constexpr (MULTIBIN_RADFIELD_MODEL_ON) {
     if (globals::rank_in_node == 0) {
-      MPI_Bcast_safe(radfieldbin_solutions_W.subspan(nonemptymgi * RADFIELDBINCOUNT, RADFIELDBINCOUNT), root_node_id,
-                     globals::mpi_comm_internode);
-      MPI_Bcast_safe(radfieldbin_solutions_T_R.subspan(nonemptymgi * RADFIELDBINCOUNT, RADFIELDBINCOUNT), root_node_id,
-                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(
+          radfieldbin_solutions_W.subspan(nstart_nonempty * RADFIELDBINCOUNT, ndo_nonempty * RADFIELDBINCOUNT),
+          root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast_safe(
+          radfieldbin_solutions_T_R.subspan(nstart_nonempty * RADFIELDBINCOUNT, ndo_nonempty * RADFIELDBINCOUNT),
+          root_node_id, globals::mpi_comm_internode);
     }
   }
 
   if constexpr (DETAILED_LINE_ESTIMATORS_ON) {
-    for (int jblueindex = 0; jblueindex < detailed_linecount; jblueindex++) {
-      MPI_Bcast_safe(prev_Jb_lu_normed[nonemptymgi][jblueindex].value, root, MPI_COMM_WORLD);
-      MPI_Bcast_safe(prev_Jb_lu_normed[nonemptymgi][jblueindex].contribcount, root, MPI_COMM_WORLD);
+    for (auto nonemptymgi = nstart_nonempty; nonemptymgi < (nstart_nonempty + ndo_nonempty); nonemptymgi++) {
+      for (int jblueindex = 0; jblueindex < detailed_linecount; jblueindex++) {
+        MPI_Bcast_safe(prev_Jb_lu_normed[nonemptymgi][jblueindex].value, root, MPI_COMM_WORLD);
+        MPI_Bcast_safe(prev_Jb_lu_normed[nonemptymgi][jblueindex].contribcount, root, MPI_COMM_WORLD);
+      }
     }
   }
-
-  MPI_Barrier_allranks();
 }
 
 void write_restart_data(FILE* gridsave_file) {
@@ -1142,14 +1146,15 @@ void read_restart_data(FILE* gridsave_file) {
       nu_upper_last_ratio = 1 / nu_upper_last_ratio;
     }
 
-    if (bincount_in != RADFIELDBINCOUNT || T_R_min_in != bins_T_R_min || T_R_max_in != bins_T_R_max ||
-        nu_lower_first_ratio < 0.999 || nu_upper_last_ratio < 0.999) {
+    const bool bins_match = bincount_in == RADFIELDBINCOUNT && T_R_min_in == bins_T_R_min &&
+                            T_R_max_in == bins_T_R_max && nu_lower_first_ratio >= 0.999 && nu_upper_last_ratio >= 0.999;
+    if (!bins_match) {
       printlnlog("[error] gridsave file specifies {} bins, nu_min {} nu_max {} T_R_min {} T_R_max {}", bincount_in,
                  nu_min_in, nu_max_in, T_R_min_in, T_R_max_in);
       printlnlog("require {} bins, RADFIELDBINS_NU_MIN {:g} RADFIELDBINS_NU_MAX {:g} T_R_min {:g} T_R_max {:g}",
                  RADFIELDBINCOUNT, RADFIELDBINS_NU_MIN, RADFIELDBINS_NU_MAX, bins_T_R_min, bins_T_R_max);
-      std::abort();
     }
+    assert_always(bins_match);
 
     for (int binindex = 0; binindex < RADFIELDBINCOUNT; binindex++) {
       int binindex_in = 0;
@@ -1192,8 +1197,8 @@ void read_restart_data(FILE* gridsave_file) {
     if (detailed_linecount_in != detailed_linecount) {
       printlnlog("[error] gridsave file specifies {} detailed lines but this simulation has {}.", detailed_linecount_in,
                  detailed_linecount);
-      std::abort();
     }
+    assert_always(detailed_linecount_in == detailed_linecount);
 
     for (int jblueindex = 0; jblueindex < detailed_linecount; jblueindex++) {
       assert_always(fscanf(gridsave_file, "%d ", &detailed_lineindices[jblueindex]) == 1);

--- a/radfield.h
+++ b/radfield.h
@@ -32,7 +32,7 @@ void normalise_nuJ(int nonemptymgi, double estimator_normfactor_over4pi);
 void titer_J(int nonemptymgi);
 void titer_nuJ(int nonemptymgi);
 void reduce_estimators();
-void do_MPI_Bcast(ptrdiff_t nonemptymgi, int root, int root_node_id);
+void do_MPI_Bcast(ptrdiff_t nstart_nonempty, ptrdiff_t ndo_nonempty, int root, int root_node_id);
 void write_restart_data(FILE* gridsave_file);
 void read_restart_data(FILE* gridsave_file);
 void normalise_bf_estimators(int nts, int nts_prev, int titer, double deltat);

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -1064,17 +1064,19 @@ template void calculate_chi_rpkt_cont<true>(const double nu_cmf, ContinuumOpacit
 template void calculate_chi_rpkt_cont<false>(const double nu_cmf, ContinuumOpacity& chi_rpkt_cont,
                                              const int nonemptymgi);
 
-void MPI_Bcast_binned_opacities(const ptrdiff_t nonemptymgi, const int root_node_id) {
+// broadcast the binned expansion opacities of the cells that belong to the root rank to all node leaders
+void MPI_Bcast_binned_opacities(const ptrdiff_t nstart_nonempty, const ptrdiff_t ndo_nonempty, const int root_node_id) {
   if (globals::rank_in_node == 0) {
-    assert_always(nonemptymgi >= 0);
+    assert_always(nstart_nonempty >= 0);
     if constexpr (RPKT_USE_EXPANSION_OPACITIES || VPKT_USE_EXPANSION_OPACITIES) {
-      MPI_Bcast_safe(expansionopacities.subspan(nonemptymgi * expopac_nbins, expopac_nbins), root_node_id,
-                     globals::mpi_comm_internode);
+      MPI_Bcast_safe(expansionopacities.subspan(nstart_nonempty * expopac_nbins, ndo_nonempty * expopac_nbins),
+                     root_node_id, globals::mpi_comm_internode);
     }
 
     if constexpr (RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY.has_value()) {
-      MPI_Bcast_safe(expansionopacity_planck_cumulative.subspan(nonemptymgi * expopac_nbins, expopac_nbins),
-                     root_node_id, globals::mpi_comm_internode);
+      MPI_Bcast_safe(
+          expansionopacity_planck_cumulative.subspan(nstart_nonempty * expopac_nbins, ndo_nonempty * expopac_nbins),
+          root_node_id, globals::mpi_comm_internode);
     }
   }
 }

--- a/rpkt.h
+++ b/rpkt.h
@@ -111,7 +111,7 @@ void allocate_expansionopacities();
 // construct the Planck-weighted cumulative distribution used to sample thermal re-emission frequencies.
 // Eastman & Pinto (1993), doi:10.1086/172957; Karp et al. (1977), doi:10.1086/155241.
 void calculate_expansion_opacities(int nonemptymgi);
-void MPI_Bcast_binned_opacities(ptrdiff_t nonemptymgi, int root_node_id);
+void MPI_Bcast_binned_opacities(ptrdiff_t nstart_nonempty, ptrdiff_t ndo_nonempty, int root_node_id);
 auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
 
 [[nodiscard]] constexpr auto get_linedistance(const double prop_time, const double nu_cmf, const double nu_trans,

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -392,8 +392,8 @@ void write_deposition_file() {
     std::filesystem::rename("deposition.out.tmp", "deposition.out", ec);
     if (ec) {
       printlnlog("[error] The rename of deposition.out.tmp to deposition.out failed: {}", ec.message());
-      std::abort();
     }
+    assert_always(!ec);
 
     // energy-conservation consistency check (log only): the cumulative deposition should not exceed the
     // cumulative decay emission by more than the Monte Carlo noise of the trajectory estimators allows
@@ -453,14 +453,11 @@ void mpi_communicate_grid_properties() {
                      root, MPI_COMM_WORLD);
     }
 
-    for (auto nonemptymgi = root_nstart_nonempty; nonemptymgi < (root_nstart_nonempty + root_ndo_nonempty);
-         nonemptymgi++) {
-      radfield::do_MPI_Bcast(nonemptymgi, root, root_node_id);
+    radfield::do_MPI_Bcast(root_nstart_nonempty, root_ndo_nonempty, root, root_node_id);
 
-      nonthermal::nt_MPI_Bcast(nonemptymgi, root_node_id);
+    nonthermal::nt_MPI_Bcast(root_nstart_nonempty, root_ndo_nonempty, root_node_id);
 
-      MPI_Bcast_binned_opacities(nonemptymgi, root_node_id);
-    }
+    MPI_Bcast_binned_opacities(root_nstart_nonempty, root_ndo_nonempty, root_node_id);
 
     MPI_Barrier_allranks();
     if (globals::rank_in_node == 0) {
@@ -870,8 +867,8 @@ void setup_runoutputfolder() {
     std::filesystem::create_directories(globals::runoutputfolder, ec);
     if (ec) {
       std::println(stderr, "[error] could not create output folder '{}': {}", globals::runoutputfolder, ec.message());
-      std::abort();
     }
+    assert_always(!ec);
 
     // clear out per-rank output files (and any leftover log symlink) from a previous run of this folder, so
     // that e.g. a rerun with fewer ranks does not leave a mixture of new estimator files and stale ones from
@@ -937,11 +934,13 @@ auto main(int argc, char* argv[]) -> int {
     if (opt == 'w') {
       char* parse_end = nullptr;
       const float walltimehours = strtof(optarg, &parse_end);  // NOLINT(misc-include-cleaner)
-      if (parse_end == optarg || *parse_end != '\0' || !std::isfinite(walltimehours) || walltimehours <= 0.) {
+      const bool walltimehours_valid =
+          parse_end != optarg && *parse_end == '\0' && std::isfinite(walltimehours) && walltimehours > 0.;
+      if (!walltimehours_valid) {
         // silently accepting a bad value would disable the wall time limit instead of applying it
         std::println(stderr, "[error] invalid wall time hours '{}' given with -w option", optarg);
-        std::abort();
       }
+      assert_always(walltimehours_valid);
       walltimelimitseconds = static_cast<int>(walltimehours * HOUR);
       walltimehours_str = optarg;
     } else if (opt == 'o') {
@@ -951,11 +950,11 @@ auto main(int argc, char* argv[]) -> int {
       }
       if (globals::runoutputfolder.empty()) {
         std::println(stderr, "[error] empty output folder given with -o option");
-        std::abort();
       }
+      assert_always(!globals::runoutputfolder.empty());
     } else {
       print_options_help(stderr, argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      std::abort();
+      assert_always(opt == 'w' || opt == 'o');
     }
   }
 

--- a/sn3d.cc
+++ b/sn3d.cc
@@ -391,9 +391,8 @@ void write_deposition_file() {
     std::error_code ec;
     std::filesystem::rename("deposition.out.tmp", "deposition.out", ec);
     if (ec) {
-      printlnlog("[error] The rename of deposition.out.tmp to deposition.out failed: {}", ec.message());
+      fatal_crash("The rename of deposition.out.tmp to deposition.out failed: {}", ec.message());
     }
-    assert_always(!ec);
 
     // energy-conservation consistency check (log only): the cumulative deposition should not exceed the
     // cumulative decay emission by more than the Monte Carlo noise of the trajectory estimators allows
@@ -866,9 +865,8 @@ void setup_runoutputfolder() {
     std::error_code ec;
     std::filesystem::create_directories(globals::runoutputfolder, ec);
     if (ec) {
-      std::println(stderr, "[error] could not create output folder '{}': {}", globals::runoutputfolder, ec.message());
+      fatal_crash("could not create output folder '{}': {}", globals::runoutputfolder, ec.message());
     }
-    assert_always(!ec);
 
     // clear out per-rank output files (and any leftover log symlink) from a previous run of this folder, so
     // that e.g. a rerun with fewer ranks does not leave a mixture of new estimator files and stale ones from
@@ -934,13 +932,10 @@ auto main(int argc, char* argv[]) -> int {
     if (opt == 'w') {
       char* parse_end = nullptr;
       const float walltimehours = strtof(optarg, &parse_end);  // NOLINT(misc-include-cleaner)
-      const bool walltimehours_valid =
-          parse_end != optarg && *parse_end == '\0' && std::isfinite(walltimehours) && walltimehours > 0.;
-      if (!walltimehours_valid) {
+      if (parse_end == optarg || *parse_end != '\0' || !std::isfinite(walltimehours) || walltimehours <= 0.) {
         // silently accepting a bad value would disable the wall time limit instead of applying it
-        std::println(stderr, "[error] invalid wall time hours '{}' given with -w option", optarg);
+        fatal_crash("invalid wall time hours '{}' given with -w option", optarg);
       }
-      assert_always(walltimehours_valid);
       walltimelimitseconds = static_cast<int>(walltimehours * HOUR);
       walltimehours_str = optarg;
     } else if (opt == 'o') {
@@ -949,12 +944,11 @@ auto main(int argc, char* argv[]) -> int {
         globals::runoutputfolder.pop_back();
       }
       if (globals::runoutputfolder.empty()) {
-        std::println(stderr, "[error] empty output folder given with -o option");
+        fatal_crash("empty output folder given with -o option");
       }
-      assert_always(!globals::runoutputfolder.empty());
     } else {
       print_options_help(stderr, argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      assert_always(opt == 'w' || opt == 'o');
+      fatal_crash("unknown command line option");
     }
   }
 

--- a/sn3d.h
+++ b/sn3d.h
@@ -48,13 +48,15 @@ inline void check_already_running() {
       std::istringstream{line} >> artispid_in;
       std::getline(pidfile, line);
       pidfile.close();
-      if (is_pid_running(artispid_in) && std::filesystem::current_path().generic_string() == line) {
+      const bool other_run_active =
+          is_pid_running(artispid_in) && std::filesystem::current_path().generic_string() == line;
+      if (other_run_active) {
         std::println(stderr,
                      "\n[error] artis or exspec is already running in this folder with existing pid {}. Refusing to "
                      "start. (delete artis.pid if you are sure this is incorrect)",
                      artispid_in);
-        std::abort();
       }
+      assert_always(!other_run_active);
     }
 
     auto pidfile = std::fstream("artis.pid", std::ofstream::out | std::ofstream::trunc);

--- a/sn3d.h
+++ b/sn3d.h
@@ -48,15 +48,12 @@ inline void check_already_running() {
       std::istringstream{line} >> artispid_in;
       std::getline(pidfile, line);
       pidfile.close();
-      const bool other_run_active =
-          is_pid_running(artispid_in) && std::filesystem::current_path().generic_string() == line;
-      if (other_run_active) {
-        std::println(stderr,
-                     "\n[error] artis or exspec is already running in this folder with existing pid {}. Refusing to "
-                     "start. (delete artis.pid if you are sure this is incorrect)",
-                     artispid_in);
+      if (is_pid_running(artispid_in) && std::filesystem::current_path().generic_string() == line) {
+        fatal_crash(
+            "artis or exspec is already running in this folder with existing pid {}. Refusing to "
+            "start. (delete artis.pid if you are sure this is incorrect)",
+            artispid_in);
       }
-      assert_always(!other_run_active);
     }
 
     auto pidfile = std::fstream("artis.pid", std::ofstream::out | std::ofstream::trunc);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -221,7 +221,7 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
         printlnlog(
             "[error] pellet marked as particle emission is for decaytype {} != any of (alpha, beta+, beta-, spfission)",
             pkt.pellet_decaytype);
-        std::abort();
+        assert_always(false);
       } else {
         __builtin_unreachable();
       }

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -218,10 +218,8 @@ void update_pellet(Packet& pkt, const int nts, const double t2) {
         atomicadd(globals::timesteps[nts].spfission_dep_discrete, pkt.e_cmf);
         pkt.type = TYPE_NTALPHA_FISPROD_DEPOSITED;
       } else if constexpr (TESTMODE) {
-        printlnlog(
-            "[error] pellet marked as particle emission is for decaytype {} != any of (alpha, beta+, beta-, spfission)",
-            pkt.pellet_decaytype);
-        assert_always(false);
+        fatal_crash("pellet marked as particle emission is for decaytype {} != any of (alpha, beta+, beta-, spfission)",
+                    pkt.pellet_decaytype);
       } else {
         __builtin_unreachable();
       }

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -724,8 +724,8 @@ void read_vpktparameterfile() {
     if (fabs(obsdirs_costheta[i]) > 1) {
       printlnlog("[error] vpkt.txt observer direction {} has costheta {:g}, which is outside [-1, 1]. aborting", i,
                  obsdirs_costheta[i]);
-      std::abort();
     }
+    assert_always(fabs(obsdirs_costheta[i]) <= 1);
     if (obsdirs_costheta[i] == 1) {
       obsdirs_costheta[i] = 0.9999;
     } else if (obsdirs_costheta[i] == -1) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -722,10 +722,8 @@ void read_vpktparameterfile() {
     assert_always(fscanf(input_file, "%lg", &obsdirs_costheta[i]) == 1);
 
     if (fabs(obsdirs_costheta[i]) > 1) {
-      printlnlog("[error] vpkt.txt observer direction {} has costheta {:g}, which is outside [-1, 1]. aborting", i,
-                 obsdirs_costheta[i]);
+      fatal_crash("vpkt.txt observer direction {} has costheta {:g}, which is outside [-1, 1]", i, obsdirs_costheta[i]);
     }
-    assert_always(fabs(obsdirs_costheta[i]) <= 1);
     if (obsdirs_costheta[i] == 1) {
       obsdirs_costheta[i] = 0.9999;
     } else if (obsdirs_costheta[i] == -1) {


### PR DESCRIPTION
Four fixes from a review of the whole code. None of them changes the results of a valid run, so the checksums must stay identical.

- `read_phixs_data_table()` now stops the run when a photoionisation target level is not below the level count of the upper ion. Before this change, a target above the `nlevelsmax` cut of `compositiondata.txt` read the level block of the next ion, and only a `TESTMODE` build found it.
- The gridsave file now holds `tmin` and `tmax` after `nprocs`, and `read_grid_restart_data()` compares them with `input.txt`. A resume after a change of `tmin_days` or `tmax_days` rescaled the saved per-timestep energies with the new timestep widths and gave no error.
- `mpi_communicate_grid_properties()` broadcasts the radiation field parameters, the non-thermal solution, and the binned opacities of each root rank as one message per array over the range of cells, in place of one message per cell. The per-cell barriers are gone. With the default options, this removes about three world collectives per non-empty cell per timestep.
- A new `fatal_crash(fmt, args...)` in `mpi_logging.h` formats the message and writes it with the rank, the file, the line, and the function to the rank log (or stdout on a device) and to stderr, then stops the run. Every direct `std::abort()` now goes through it. AGENTS.md names the helper in the "Logs and assertions" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
