### PR TITLE
Mark the detailed bf estimators of a thick cell as invalid

### DIFF
--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -219,6 +219,7 @@ template <typename... Args>
   MY_IF_HOST(report_fatal_error_and_abort(file, line, func, std::format(fmt, std::forward<Args>(args)...).c_str()););
   // the host reporter above does not return. The trap stops a device thread, and it also shows every compiler
   // that this function does not return, because the target split above hides that from nvc++.
+  // cppcheck-suppress unreachableCode
   __builtin_trap();
 }
 

--- a/radfield.cc
+++ b/radfield.cc
@@ -642,7 +642,8 @@ void init() {
     const auto bfestimcount = std::ssize(globals::bfestim_nu_edge);
     prev_bfrate_normed = MPI_shared_array<float>(nonempty_npts_model * bfestimcount);
     if (globals::rank_in_node == 0) {
-      std::ranges::fill(prev_bfrate_normed, 0.);
+      // -1 marks a cell without a valid estimator. get_corrphotoioncoeff() then uses the LUT or the integral.
+      std::ranges::fill(prev_bfrate_normed, -1.);
     }
     MPI_Barrier_node();
     printlnlog("[info] mem_usage: detailed bf estimators for non-empty cells occupy {:.3f} MB (node shared memory)",
@@ -917,6 +918,11 @@ void normalise_bf_estimators(const int nts, const int nts_prev, const int titer,
     const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
     for (auto nonemptymgi = 0Z; nonemptymgi < nonempty_npts_model; nonemptymgi++) {
       if (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {
+        // a thick cell collected no estimators in the last timestep. If the cell becomes thin in the coming grid
+        // update, the packets must not read the values of an older timestep, so mark them as invalid
+        for (int i = 0; i < bfestimcount; i++) {
+          prev_bfrate_normed[(nonemptymgi * bfestimcount) + i] = -1.;
+        }
         continue;
       }
       const auto mgi = grid::get_mgi_of_nonemptymgi(nonemptymgi);

--- a/radfield.cc
+++ b/radfield.cc
@@ -918,8 +918,8 @@ void normalise_bf_estimators(const int nts, const int nts_prev, const int titer,
     const ptrdiff_t nonempty_npts_model = grid::get_nonempty_npts_model();
     for (auto nonemptymgi = 0Z; nonemptymgi < nonempty_npts_model; nonemptymgi++) {
       if (grid::thick_allcells[nonemptymgi] == grid::CellThickness::THICK) {
-        // a thick cell collected no estimators in the last timestep. If the cell becomes thin in the coming grid
-        // update, the packets must not read the values of an older timestep, so mark them as invalid
+        // a thick cell collected no estimators in the last timestep. The cell can become thin in the coming grid
+        // update. The packets must then not read the values of an older timestep, so mark them as invalid.
         for (int i = 0; i < bfestimcount; i++) {
           prev_bfrate_normed[(nonemptymgi * bfestimcount) + i] = -1.;
         }


### PR DESCRIPTION
`prev_bfrate_normed` had no sentinel. `normalise_bf_estimators()` skipped a thick cell, so the array kept the init value 0 or the values of the last thin timestep. When the grid update then made the cell thin, the packets read those values as valid estimators. `get_corrphotoioncoeff()` falls back to the LUT or the integral only for a negative value, so a cell that was thick from the start had a photoionisation rate of zero in every bound-free continuum for that timestep, with no warning.

The array now starts at -1, and the normalisation writes -1 for a thick cell. The fallback then runs for a cell that has just become thin. The restart file already stores the array with `%a`, so a negative value goes through the resume path unchanged.

**When the results change.** A cell is thick only during the grey timesteps (`update_grid.cc`, `nts < num_grey_timesteps`), and the packets read the estimators only from `DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP` on. The stale values are therefore read only when `num_grey_timesteps >= DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP`. Every CI test has fewer grey timesteps than that (nebular: 4 grey, use from 7; photospheric: 2 grey, use from 4; kilonova NLTE: 1 grey, use from 2), so the checksums stay identical in CI. A production run with a longer grey phase gets different bound-free rates in the first thin timestep of each cell.

Found by the whole-codebase review of 2026-09-02 (the checksum-neutral fixes were in #569).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
