### PR TITLE
Run the line-by-line retrace of an expansion-opacity bin at the packet time

### DIFF
--- a/rpkt.cc
+++ b/rpkt.cc
@@ -272,8 +272,12 @@ auto get_possible_event_expansion_opacity(const int nonemptymgi, Packet& pkt, co
       pkt_bin_start.nu_cmf = nu_cmf;
       pkt_bin_start.e_rf = e_rf;
       pkt_bin_start.e_cmf = e_cmf;
-      // expansion opacity was calculated at t_mid, so match it
-      pkt_bin_start.prop_time = globals::timesteps[globals::timestep].mid;
+      // The retrace runs at the time of the packet, the same as the bin walk above. The bin opacity holds the
+      // Sobolev optical depths at t_mid over a path length of c t_mid. The bin walk multiplies it by the path
+      // length at the packet time, so the bin optical depth scales with t / t_mid. The line-by-line Sobolev
+      // optical depths scale in the same way with the packet time. A retrace at t_mid would instead give each
+      // line distance and each move inside the bin a scale of t_mid / t.
+      pkt_bin_start.prop_time = prop_time;
       pkt_bin_start.next_trans = -1;
       double edist_after_bin = 0.;
       bool event_is_boundbound = false;


### PR DESCRIPTION
`get_possible_event_expansion_opacity()` gave the retrace copy of the packet the timestep midpoint as its time, to match the tabulation of the bin opacity. The returned distance is added to the real-time distance of the bin walk, so every line distance inside the bin had the scale `t_mid / t` (in the non-relativistic branch of `get_linedistance()`), and the moves inside the retrace derived the velocity from the real position over `t_mid`. The interaction site and the frequency after the move were therefore shifted by up to the fractional timestep spacing.

The bin walk already scales the bin optical depth with `t / t_mid`: the tabulated opacity holds the Sobolev optical depths at `t_mid` over a path length of `c t_mid`, and the walk multiplies it by the path length at the packet time. The line-by-line Sobolev optical depths scale in the same way with the packet time, so the retrace now runs at the packet time and is consistent with the bin walk.

**Checksums.** Only a build with `RPKT_USE_EXPANSION_OPACITIES = true` and without `RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY` reaches the retrace. The `kilonova_2d_expansionopac` test sets the thermalisation probability, so it returns before the retrace, and no other test uses the expansion opacities. The checksums must stay identical in CI.

Found by the whole-codebase review of 2026-09-02 (#569, #570 hold the earlier fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
