### PR TITLE
Add the option FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST

### DIFF
--- a/artisoptions_classic.h
+++ b/artisoptions_classic.h
@@ -131,6 +131,8 @@ constexpr bool RPKT_USE_EXPANSION_OPACITIES = false;
 
 constexpr bool VPKT_USE_EXPANSION_OPACITIES = false;
 
+constexpr bool FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST = false;
+
 constexpr std::optional<float> RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY;
 
 constexpr RpktGreyType RPKT_GREY_TYPE = RpktGreyType::FEGROUP_APPROX;

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -289,6 +289,12 @@ constexpr bool RPKT_USE_EXPANSION_OPACITIES;
 // set true to calculate and use expansion opacities instead of line-by-line for virtual packets
 constexpr bool VPKT_USE_EXPANSION_OPACITIES;
 
+// correct the path that sweeps a bin of the expansion opacity. calculate_expansion_opacities()
+// normalises the opacity with the path c * t * dnu / nu, but USE_RELATIVISTIC_DOPPLER_SHIFT gives a
+// different path. The bin optical depth is then wrong by the Doppler factor times the Lorentz factor.
+// The option has no effect with the first-order Doppler shift. This option changes the results.
+constexpr bool FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST;
+
 // Optionally replace macroatom with a thermalisation probability P (where 1 - P is probability of scattering).
 constexpr std::optional<float> RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY;
 

--- a/artisoptions_kilonova_lte.h
+++ b/artisoptions_kilonova_lte.h
@@ -131,6 +131,8 @@ constexpr bool RPKT_USE_EXPANSION_OPACITIES = false;
 
 constexpr bool VPKT_USE_EXPANSION_OPACITIES = false;
 
+constexpr bool FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST = false;
+
 constexpr std::optional<float> RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY;
 
 constexpr RpktGreyType RPKT_GREY_TYPE = RpktGreyType::TANAKA2020_ELECTRONFRAC;

--- a/artisoptions_kilonova_timedepnlte.h
+++ b/artisoptions_kilonova_timedepnlte.h
@@ -142,6 +142,8 @@ constexpr bool RPKT_USE_EXPANSION_OPACITIES = false;
 
 constexpr bool VPKT_USE_EXPANSION_OPACITIES = false;
 
+constexpr bool FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST = false;
+
 constexpr std::optional<float> RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY;
 
 constexpr RpktGreyType RPKT_GREY_TYPE = RpktGreyType::TANAKA2020_ELECTRONFRAC;

--- a/artisoptions_nltenebular.h
+++ b/artisoptions_nltenebular.h
@@ -138,6 +138,8 @@ constexpr bool RPKT_USE_EXPANSION_OPACITIES = false;
 
 constexpr bool VPKT_USE_EXPANSION_OPACITIES = false;
 
+constexpr bool FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST = false;
+
 constexpr std::optional<float> RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY;
 
 constexpr RpktGreyType RPKT_GREY_TYPE = RpktGreyType::FEGROUP_APPROX;

--- a/artisoptions_nltephotospheric_dynamic_ion_range.h
+++ b/artisoptions_nltephotospheric_dynamic_ion_range.h
@@ -139,6 +139,8 @@ constexpr bool RPKT_USE_EXPANSION_OPACITIES = false;
 
 constexpr bool VPKT_USE_EXPANSION_OPACITIES = false;
 
+constexpr bool FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST = false;
+
 constexpr std::optional<float> RPKT_BOUNDBOUND_THERMALISATION_PROBABILITY;
 
 constexpr RpktGreyType RPKT_GREY_TYPE = RpktGreyType::FEGROUP_APPROX;

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -248,7 +248,8 @@ auto get_possible_event_expansion_opacity(const int nonemptymgi, Packet& pkt, co
       // opacity in units of [cm^2/g]
       const auto kappa = expansionopacities[(nonemptymgi * expopac_nbins) + binindex];
       // absorption coefficient in units of [1/cm]
-      chi_bb_expansionopac = kappa * grid::get_rho(nonemptymgi);
+      chi_bb_expansionopac =
+          kappa * grid::get_rho(nonemptymgi) * get_expopac_pathfactor(prop_time, next_bin_edge_nu, dnu_on_dl);
     }
 
     const double chi_tot = chi_cont + chi_bb_expansionopac;

--- a/rpkt.h
+++ b/rpkt.h
@@ -134,9 +134,28 @@ auto calculate_chi_ffheat_nnionpart(int nonemptymgi) -> double;
   return CLIGHT * prop_time * delta_nu / nu_trans;
 }
 
+// Get the correction of a binned expansion opacity for the path that sweeps the bin. The packet crosses
+// each line of the bin once, so the bin optical depth must equal the sum of (1 - exp(-tau_sobolev)).
+// calculate_expansion_opacities() assumes the path c * t * dnu / nu, which is the path that
+// get_linedistance() gives with the first-order Doppler shift. The factor is the ratio of that path to the
+// relativistic one, which is the Doppler factor times the Lorentz factor. Give the same time that the
+// caller gives to get_linedistance() for the same bin.
+[[nodiscard]] constexpr auto get_expopac_pathfactor(const double prop_time, const double bin_edge_nu,
+                                                    const double dnu_on_dl) -> double {
+  if constexpr (FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST && USE_RELATIVISTIC_DOPPLER_SHIFT) {
+    return -CLIGHT * prop_time * dnu_on_dl / bin_edge_nu;
+  }
+
+  return 1.;
+}
+
 static_assert(get_linedistance(100., 1., 2., -0.5) == 0.);  // overshot the line resonance
 static_assert(USE_RELATIVISTIC_DOPPLER_SHIFT || get_linedistance(2., 4., 2., -1.) == (CLIGHT * 2. * 2. / 2.));
 static_assert(!USE_RELATIVISTIC_DOPPLER_SHIFT || get_linedistance(2., 4., 2., -1.) == 2.);
+
+// the corrected path of a bin is the path that calculate_expansion_opacities() assumes
+static_assert(!FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST ||
+              (get_linedistance(2., 4., 2., -1.) * get_expopac_pathfactor(2., 2., -1.)) == (CLIGHT * 2. * 2. / 2.));
 
 // find the next transition lineindex redder than nu_cmf
 // for the propagation through non empty cells

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -309,6 +309,14 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
           nu_cmf);
 
       const double dnu_on_dl = (nu_cmf_boundary - nu_cmf) / boundarydist;
+
+      // The comoving frequency decreases strictly along the path. A gradient that is not negative and finite
+      // comes from rounding, when boundarydist is too short to change the frequency. The packet then reaches
+      // no line resonance in this cell, and it takes only the continuum opacity above. Without this test
+      // get_linedistance() gives an infinite distance, and the loops below add every remaining line.
+      // do_rpkt_step() has the same test.
+      const bool nu_cmf_decreases = std::isfinite(dnu_on_dl) && (dnu_on_dl < 0.);
+
       // Trace individual lines from nu_cmf until dist_limit. Returns false when all vpkt opacity setups exceed tau_max.
       const auto trace_lines_to_dist = [&](const double dist_limit) -> bool {
         while (true) {
@@ -373,7 +381,7 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
         const auto binindex_start =
             std::max(get_linearbinindex(1e8 * CLIGHT / nu_cmf, expopac_lambdamin, expopac_deltalambda), -1Z);
 
-        if (binindex_start < expopac_nbins) {
+        if (nu_cmf_decreases && binindex_start < expopac_nbins) {
           // trace line-by-line from nu_cmf to the next bin edge, because the expansion opacity bin at nu_cmf includes
           // lines with nu > nu_cmf
           const auto first_bin_edge_nu =
@@ -428,7 +436,7 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
           }
         }  // if (binindex_start < expopac_nbins)
       } else {
-        if (!trace_lines_to_dist(boundarydist)) {
+        if (nu_cmf_decreases && !trace_lines_to_dist(boundarydist)) {
           return false;
         }
       }

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -401,7 +401,8 @@ auto trace_vpkt_direction(const Packet& rpkt, const double t_arrive, const doubl
               // terms above. Saturated lines keep (1 - exp(-tau_sobolev)) ~ 1 and so fall off only as 1/t, but
               // their individual tau_sobolev cannot be recovered from the binned kappa, so the thin limit is
               // used for all bins.
-              const double chi_bb_expansionopac = kappa * grid::get_rho(nonemptymgi) * densityscalefactor;
+              const double chi_bb_expansionopac = kappa * grid::get_rho(nonemptymgi) * densityscalefactor *
+                                                  get_expopac_pathfactor(t_future, next_bin_edge_nu, dnu_on_dl);
 
               const double tau_bin = chi_bb_expansionopac * (std::min(binedgedist, boundarydist) - dist);
               dist = std::min(binedgedist, boundarydist);


### PR DESCRIPTION
## Summary

`calculate_expansion_opacities()` normalises the binned opacity with the path `c * t * dnu / nu`. The transport multiplies that opacity by the rest-frame path that sweeps the bin, which `get_linedistance()` gives. The optical depth over a bin must equal the sum of `1 - exp(-tau_sobolev)` over the lines of the bin, because the packet crosses each line resonance once.

With `USE_RELATIVISTIC_DOPPLER_SHIFT` the packet needs a different rest-frame path to sweep the same bin, so the bound-bound optical depth is wrong by the Doppler factor times the Lorentz factor. That is 1.30 for a radial outward path at 0.3c, and it depends on the direction of the packet. Both kilonova presets select the relativistic Doppler shift, and `tests/setup_kilonova_2d_expansionopac.sh` builds on one of them. With the first-order Doppler shift the factor is one, and the previous code was already correct.

`get_expopac_pathfactor()` removes the difference for an r-packet and for a virtual packet. `FRAME_TRANSFORM_EXPANSION_OPACITIES_BINEDGEDIST` controls it, and every preset sets it false, so the results and the reference checksums do not change.

## The second commit changes the results

`trace_vpkt_direction()` has no test for a degenerate gradient of the comoving frequency, which `do_rpkt_step()` gained in 263b6241. A gradient that is not negative and finite comes from rounding, when the distance to the cell boundary is too short to change the frequency. `get_linedistance()` then gives an infinite distance, and the loops for the lines and for the expansion opacity bins add every remaining line of the list. The new path factor makes the bin optical depth a NaN in the same case.

A virtual packet now takes only the continuum opacity over such a segment. It keeps its position in the line list, so the next cell reaches the same lines. This test is not behind an option, so the checksums of `classicmode_3d` change if a virtual packet meets such a segment.

## Verification

- Both option states compile clean with clang and `-Werror`, with the relativistic and with the first-order Doppler shift, and with the expansion opacities of an r-packet and of a virtual packet.
- `./unittests`: 176 of 176 checks passed.
- `prek run --all-files` and `run-clang-tidy` on the changed sources: clean.
- The disabled path keeps the same operands in the same order, so it is bit-identical.

## Not in this pull request

The frame transformation of the estimator path lengths, of the Sobolev length, and of the rates that a cell integrates over time is on the branch `frame-transform-times`, for a later pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)