### PR TITLE
Stop checkpoint replacement after file errors

### DIFF
--- a/grid.cc
+++ b/grid.cc
@@ -2413,7 +2413,12 @@ void write_grid_restart_data(const int timestep) {
   radfield::write_restart_data(gridsave_file);
   nonthermal::write_restart_data(gridsave_file);
   nltepop_write_restart_data(gridsave_file);
-  fclose(gridsave_file);
+  // Check earlier writes and the final flush before the caller replaces the previous checkpoint.
+  const bool write_failed = (ferror(gridsave_file) != 0);
+  const bool close_failed = (fclose(gridsave_file) != 0);
+  if (write_failed || close_failed) {
+    fatal_crash("Could not write or close {}.", filename);
+  }
   const auto write_restart_duration =
       std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_write_restart).count();
   printlnlog("done in {:.1f} seconds.", write_restart_duration);

--- a/input.cc
+++ b/input.cc
@@ -2171,7 +2171,13 @@ void update_parameterfile(const int nts) {
     std::println(fileout, "{}", line);
   }
 
+  if (file.bad() || !file.eof()) {
+    fatal_crash("Could not read input.txt for the parameter file update.");
+  }
   fileout.close();
+  if (fileout.fail()) {
+    fatal_crash("Could not write or close input.txt.tmp.");
+  }
   file.close();
 
   std::error_code rename_error;
@@ -2182,8 +2188,8 @@ void update_parameterfile(const int nts) {
     std::filesystem::rename("input.txt.tmp", "input.txt", rename_error);
   }
   if (rename_error) {
-    printlnlog("[error] failed to move input.txt.tmp to {}: {}", (nts < 0) ? "input-newrun.txt" : "input.txt",
-               rename_error.message());
+    fatal_crash("Could not move input.txt.tmp to {}: {}", (nts < 0) ? "input-newrun.txt" : "input.txt",
+                rename_error.message());
   }
 
   printlnlog("done");

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -940,6 +940,9 @@ void write_timestep(const int nts, const bool is_final) {
 
     if (!is_final) {
       vpkt_contrib_file = std::ofstream(filename_dest, std::ios::app);
+      if (vpkt_contrib_file.fail()) {
+        fatal_crash("Could not open {}.", filename_dest);
+      }
     }
   }
 }
@@ -975,11 +978,17 @@ void init(const int nts, const bool continued_from_saved) {
       }
 
       std::println(vpkt_contrib_file, "");
-      vpkt_contrib_file.flush();
       vpkt_contrib_file.close();
+      if (vpkt_contrib_file.fail()) {
+        fatal_crash("Could not write or close {}.", filename);
+      }
     }
 
+    // A failed open gives a stream that discards every contribution without an error.
     vpkt_contrib_file = std::ofstream(filename, std::ios::app);
+    if (vpkt_contrib_file.fail()) {
+      fatal_crash("Could not open {}.", filename);
+    }
   }
 
   if (continued_from_saved) {

--- a/vpkt.cc
+++ b/vpkt.cc
@@ -588,6 +588,10 @@ void write_vspecpol(const std::string& filename, const bool full_precision) {
       std::println(vspecpol_file, "");
     }
   }
+  vspecpol_file.close();
+  if (vspecpol_file.fail()) {
+    fatal_crash("Could not write or close {}.", filename);
+  }
 }
 
 void read_vspecpol(const int my_rank, const int nts) {
@@ -667,6 +671,10 @@ void write_vpkt_grid(const std::string& filename, const bool full_precision) {
         }
       }
     }
+  }
+  vpkt_grid_file.close();
+  if (vpkt_grid_file.fail()) {
+    fatal_crash("Could not write or close {}.", filename);
   }
 }
 
@@ -921,6 +929,9 @@ void write_timestep(const int nts, const bool is_final) {
   if constexpr (VPKT_WRITE_CONTRIBS) {
     vpkt_contrib_file.close();
     const auto filename_source = std::format("vpackets_{:04d}_ts{}.tmp", my_rank, is_final ? nts + 1 : nts);
+    if (vpkt_contrib_file.fail()) {
+      fatal_crash("Could not write or close {}.", filename_source);
+    }
     const auto filename_dest = is_final ? std::format("vpackets_{:04d}.out", my_rank)
                                         : std::format("vpackets_{:04d}_ts{}.tmp", my_rank, nts + 1);
 


### PR DESCRIPTION
A failed checkpoint write can leave an incomplete restart file. The run can then replace input.txt and delete the previous checkpoint. Stop the run on file errors before it accepts the new checkpoint.

- Check the parameter file read and the temporary output stream after close. Treat a failed rename as a fatal error.
- Check the grid stream for earlier write errors and for a failed close, including the final buffer flush.
- Check virtual-packet spectra, grid files, and contribution files after close.

Numerical results and output formats stay unchanged. The existing packet writer already checks writes and closes. The existing barriers keep checkpoint deletion after the writers return successfully. These checks detect file-operation errors; they do not add power-loss durability.

Validation:

- The classic build passed with clang 23.1.0 and OPTIMIZE=OFF.
- `prek run --all-files` passed, including the compile hook.
- Nine isolated file tests passed: successful parameter, grid, virtual-spectrum, and virtual-grid writes; four write failures; and a parameter backup rename failure. The tests used the production writers. Failed writes left the original input.txt intact. The probes are outside the repository.
- Clang-tidy on input.cc, grid.cc, and vpkt.cc reported only two existing Open MPI macro cast errors in mpi_logging.h, at lines 497 and 581.
- No end-to-end simulation, multiple-node test, or device test was run for this change. The virtual-packet contribution close check has source inspection only.
