### PR TITLE
Add the option WRITE_ION_HEATING_COOLING_RATES

### DIFF
--- a/artisoptions_classic.h
+++ b/artisoptions_classic.h
@@ -82,6 +82,8 @@ constexpr bool USE_LUT_PHOTOION = true;
 
 constexpr bool USE_ION_BFHEATING_ESTIMATORS = true;
 
+constexpr bool WRITE_ION_HEATING_COOLING_RATES = false;
+
 constexpr bool STRICT_POPULATION_CHECKING = false;
 
 constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = false;

--- a/artisoptions_doc.md
+++ b/artisoptions_doc.md
@@ -133,6 +133,12 @@ constexpr bool USE_LUT_PHOTOION;
 // enable per-ion bound-free heating estimators and associated renormalisation
 constexpr bool USE_ION_BFHEATING_ESTIMATORS;
 
+// write the heating and the cooling rate of each ion to the estimators file, in addition to the totals.
+// A bound-free term belongs to the lower ion of the continuum, and a collisional term belongs to the ion
+// that holds the level. The free-free heating estimator holds no per-ion information, so each ion gets
+// the share that it has in the free-free opacity.
+constexpr bool WRITE_ION_HEATING_COOLING_RATES;
+
 // Previously the NLTE solver only checked if level populations were negative and replaced these populations
 // with the LTE population. However this can cause numerical problems (e.g. when the ground populations is very
 // small and and the negative population is replaced with a significantly larger population ratios taken e.g.

--- a/artisoptions_kilonova_lte.h
+++ b/artisoptions_kilonova_lte.h
@@ -82,6 +82,8 @@ constexpr bool USE_LUT_PHOTOION = true;
 
 constexpr bool USE_ION_BFHEATING_ESTIMATORS = true;
 
+constexpr bool WRITE_ION_HEATING_COOLING_RATES = false;
+
 constexpr bool STRICT_POPULATION_CHECKING = true;
 
 constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = true;

--- a/artisoptions_kilonova_timedepnlte.h
+++ b/artisoptions_kilonova_timedepnlte.h
@@ -93,6 +93,8 @@ constexpr bool USE_LUT_PHOTOION = false;
 
 constexpr bool USE_ION_BFHEATING_ESTIMATORS = false;
 
+constexpr bool WRITE_ION_HEATING_COOLING_RATES = false;
+
 constexpr bool STRICT_POPULATION_CHECKING = true;
 
 constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = true;

--- a/artisoptions_nltenebular.h
+++ b/artisoptions_nltenebular.h
@@ -89,6 +89,8 @@ constexpr bool USE_LUT_PHOTOION = false;
 
 constexpr bool USE_ION_BFHEATING_ESTIMATORS = false;
 
+constexpr bool WRITE_ION_HEATING_COOLING_RATES = false;
+
 constexpr bool STRICT_POPULATION_CHECKING = true;
 
 constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = true;

--- a/artisoptions_nltephotospheric_dynamic_ion_range.h
+++ b/artisoptions_nltephotospheric_dynamic_ion_range.h
@@ -90,6 +90,8 @@ constexpr bool USE_LUT_PHOTOION = false;
 
 constexpr bool USE_ION_BFHEATING_ESTIMATORS = false;
 
+constexpr bool WRITE_ION_HEATING_COOLING_RATES = false;
+
 constexpr bool STRICT_POPULATION_CHECKING = true;
 
 constexpr bool NLTE_LIMIT_ION_STAGES_AFTER_FAILURE = true;

--- a/kpkt.cc
+++ b/kpkt.cc
@@ -276,6 +276,19 @@ auto sample_planck_montecarlo(const double T, rngstate_type& rngstate) -> double
 }
 }  // anonymous namespace
 
+// Compute the cooling rate of a single ion, split into the free-free, the free-bound, and the collisional
+// contributions. calculate_cooling_rates() sums the same terms over all of the ions of the cell.
+auto calculate_ion_cooling_rates(const int nonemptymgi, const int element, const int ion) -> IonCoolingRates {
+  double C_ff = 0.;
+  double C_fb = 0.;
+  double C_exc = 0.;
+  double C_ionisation = 0.;
+  // the return value is the sum of the four terms below, so this function drops it
+  calculate_cooling_rates_ion<false>(nonemptymgi, element, ion, {}, &C_ff, &C_fb, &C_exc, &C_ionisation);
+
+  return IonCoolingRates{.ff = C_ff, .fb = C_fb, .collisional = C_exc + C_ionisation};
+}
+
 // Calculate the cooling rates for a given cell and store them for each ion
 // optionally store components (ff, bf, collisional) in heatingcoolingrates struct
 void calculate_cooling_rates(const int nonemptymgi, HeatingCoolingRates* heatingcoolingrates) {

--- a/kpkt.h
+++ b/kpkt.h
@@ -25,6 +25,16 @@ inline int ncoolingterms{0};
 
 void setup_coolinglist();
 void calculate_cooling_rates(int nonemptymgi, HeatingCoolingRates* heatingcoolingrates);
+
+// The cooling rate of one ion, split into the processes that the estimators file reports.
+struct IonCoolingRates {
+  double ff{0};  // free-free emission
+  double fb{0};  // free-bound emission
+  double collisional{0};  // collisional excitation and collisional ionisation
+};
+
+[[nodiscard]] auto calculate_ion_cooling_rates(int nonemptymgi, int element, int ion) -> IonCoolingRates;
+
 auto set_radiative_energy_factor(int nonemptymgi, const HeatingCoolingRates& heatingcoolingrates) -> double;
 void reset_radiative_energy_factor(int nonemptymgi);
 [[nodiscard]] DEVICE_FUNC auto get_radiative_energy_factor(int nonemptymgi) -> double;

--- a/tests/nebular_1d_3dgrid_inputfiles/results_md5_final.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/results_md5_final.txt
@@ -15,9 +15,9 @@ ccec6c397e9c000771367c278d28c9b6  packets00_0002.out
 d4fdb539e247bd7d24e670fa3d4b39e0  packets00_0003.out
 606ef1076e574a10b49f1e27aa8b02cb  spec.out
 8e7163982f1aa938dc1505478b8c60d1  timesteps.out
-c2a62cbe8a73c9cb9827a5d1067e8709  job1/estimators_0000.out
-ea0db0a7deeceda4e3a1e8e37a91cb0a  job1/estimators_0001.out
-b115ac53872b80f9a50d71be8f4ac2f5  job1/estimators_0002.out
+df21d2dedd8c0f633627198699e06501  job1/estimators_0000.out
+34b40c4b8ab5b79427ab7d069dbbe76a  job1/estimators_0001.out
+e05bfceca659bca6965accf2f1277d60  job1/estimators_0002.out
 c4baaa99d748259f1546845467ad7484  job1/nlte_0000.out
 f6d32fc8e64af2e99da4abbf5acd492b  job1/nlte_0001.out
 aef93790c835655ce44e334ce9efebcf  job1/nlte_0002.out

--- a/tests/nebular_1d_3dgrid_inputfiles/results_md5_job0.txt
+++ b/tests/nebular_1d_3dgrid_inputfiles/results_md5_job0.txt
@@ -15,9 +15,9 @@ f96bd2c0753003e105eaaa7c0a015a50  packets00_0002.out
 2bfbe9ea65f415b909bfbc77d0d5a5d2  packets00_0003.out
 b11110e42560a2482ff2405e96d863a4  spec.out
 8e7163982f1aa938dc1505478b8c60d1  timesteps.out
-cc52d609ecd628a96a05f3c574da126b  job0/estimators_0000.out
-bc161f52ac25088281e2c627327c68b9  job0/estimators_0001.out
-390d9ce34f2a73ce10377a32d64f0c50  job0/estimators_0002.out
+b66b3cc2a15847677797a8bbd8b71531  job0/estimators_0000.out
+45fafe99ded8bc9404d2928f953a0b48  job0/estimators_0001.out
+2c9dace369bcfbbc416994d199db3817  job0/estimators_0002.out
 fbd341a20f6bb5ed2f0b37be47f27e5a  job0/nlte_0000.out
 25fa0d4e9e1256d0a5a686082001122b  job0/nlte_0001.out
 4f01489b34f601b17185a1642e1f2573  job0/nlte_0002.out

--- a/tests/setup_nebular_1d_3dgrid.sh
+++ b/tests/setup_nebular_1d_3dgrid.sh
@@ -34,6 +34,8 @@ sed -i.bak -e 's/constexpr int FIRST_NLTE_RADFIELD_TIMESTEP.*/constexpr int FIRS
 
 sed -i.bak -e 's/constexpr int DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP.*/constexpr int DETAILED_BF_ESTIMATORS_USEFROMTIMESTEP = 7;/g' artisoptions.h
 
+sed -i.bak -e 's/constexpr bool WRITE_ION_HEATING_COOLING_RATES.*/constexpr bool WRITE_ION_HEATING_COOLING_RATES = true;/g' artisoptions.h
+
 rm -f artisoptions.h.bak
 
 cd -

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -219,6 +219,74 @@ auto calculate_bfheatingcoeff(const int element, const int ion, const int level,
   return bfheating;
 }
 
+// Split the heating and the cooling rate of a cell into the contribution of each ion. The thermal balance
+// solver needs only the totals, so this runs once for each cell after the solution, with the T_e and the
+// populations that the solver ended with. WRITE_ION_HEATING_COOLING_RATES writes the result to the
+// estimators file.
+void calculate_ion_heating_cooling_rates(const int nonemptymgi, HeatingCoolingRates& heatingcoolingrates,
+                                         const std::span<const double> bfheatingcoeffs) {
+  if constexpr (!WRITE_ION_HEATING_COOLING_RATES) {
+    return;
+  }
+
+  const auto nincludedions = get_includedions();
+  const auto T_e = grid::Te_allcells[nonemptymgi];
+  const auto clumpednne = grid::get_clumpfactor(nonemptymgi) * grid::get_nne(nonemptymgi);
+
+  heatingcoolingrates.heating_bf_ion.assign(nincludedions, 0.);
+  heatingcoolingrates.heating_ff_ion.assign(nincludedions, 0.);
+  heatingcoolingrates.cooling_ff_ion.assign(nincludedions, 0.);
+  heatingcoolingrates.cooling_fb_ion.assign(nincludedions, 0.);
+  heatingcoolingrates.cooling_coll_ion.assign(nincludedions, 0.);
+  if constexpr (COL_HEAT_FROM_LEVELPOPS) {
+    heatingcoolingrates.heating_coll_ion.assign(nincludedions, 0.);
+  }
+
+  // The free-free heating rate comes from a Monte Carlo estimator that holds no per-ion information.
+  // Each ion therefore gets the share that it has in the free-free opacity, which is proportional to
+  // nnion * ioncharge^2 at the T_e of the cell (see calculate_chi_ffheat_nnionpart() in rpkt.cc).
+  // heating_ff_ion holds these weights until the loop ends.
+  double ffweight_sum = 0.;
+
+  for (int uniqueionindex = 0; uniqueionindex < nincludedions; uniqueionindex++) {
+    const auto [element, ion] = get_ionfromuniqueionindex(uniqueionindex);
+
+    // Bound-free heating. The continuum belongs to the lower ion of the pair, as in
+    // calculate_heating_rates(), so the top ion of each element gets no contribution.
+    if (ion < (get_nions(element) - 1)) {
+      const int nbflevels = get_nlevels_ionising(element, ion);
+      const auto ionuniquelevelindexstart = get_ionuniquelevelindexstart(element, ion);
+      double bfheating_ion = 0.;
+      for (int level = 0; level < nbflevels; level++) {
+        bfheating_ion +=
+            calculate_levelpop(nonemptymgi, element, ion, level) * bfheatingcoeffs[ionuniquelevelindexstart + level];
+      }
+      heatingcoolingrates.heating_bf_ion[uniqueionindex] = bfheating_ion;
+    }
+
+    if constexpr (COL_HEAT_FROM_LEVELPOPS) {
+      heatingcoolingrates.heating_coll_ion[uniqueionindex] =
+          get_heating_ion_coll_deexc(nonemptymgi, element, ion, T_e, clumpednne);
+    }
+
+    const auto ioncooling = kpkt::calculate_ion_cooling_rates(nonemptymgi, element, ion);
+    heatingcoolingrates.cooling_ff_ion[uniqueionindex] = ioncooling.ff;
+    heatingcoolingrates.cooling_fb_ion[uniqueionindex] = ioncooling.fb;
+    heatingcoolingrates.cooling_coll_ion[uniqueionindex] = ioncooling.collisional;
+
+    const int ioncharge = get_ionstage(element, ion) - 1;
+    const double ffweight = (ioncharge > 0) ? pow2(ioncharge) * get_nnion(nonemptymgi, element, ion) : 0.;
+    heatingcoolingrates.heating_ff_ion[uniqueionindex] = ffweight;
+    ffweight_sum += ffweight;
+  }
+
+  // give each ion its share of the free-free heating rate
+  const double ffheating_per_weight = (ffweight_sum > 0.) ? (heatingcoolingrates.heating_ff / ffweight_sum) : 0.;
+  for (auto& ffheating_ion : heatingcoolingrates.heating_ff_ion) {
+    ffheating_ion *= ffheating_per_weight;
+  }
+}
+
 // Calculate the bound-free heating coefficient of every level in a cell. These depend only on the radiation
 // field, not on T_e or the populations, so they are computed once per cell and reused at every T_e that the
 // temperature solver tries.

--- a/thermalbalance.h
+++ b/thermalbalance.h
@@ -5,6 +5,7 @@
 #define THERMALBALANCE_H
 
 #include <span>
+#include <vector>
 
 // Per-cell energy budget of the free electrons. All members are erg/s/cm^3 except dep_frac_heating.
 // call_T_e_finder() solves heating_ff + heating_bf + heating_collisional + heating_dep
@@ -47,6 +48,18 @@ struct HeatingCoolingRates {
   double eps_alpha_ana{0};
   double eps_spfission_ana{0};
 
+  // The per-ion breakdown of the rates above, indexed by uniqueionindex. WRITE_ION_HEATING_COOLING_RATES
+  // fills them once for each cell after the thermal balance solution, and the estimators file reports them.
+  // They stay empty without that option and for a cell that gets no solution, e.g. a grey cell.
+  // heating_coll_ion also stays empty without COL_HEAT_FROM_LEVELPOPS, because the estimator that then gives
+  // heating_collisional holds no per-ion information.
+  std::vector<double> heating_bf_ion;
+  std::vector<double> heating_coll_ion;
+  std::vector<double> heating_ff_ion;
+  std::vector<double> cooling_ff_ion;
+  std::vector<double> cooling_fb_ion;
+  std::vector<double> cooling_coll_ion;  // collisional excitation and collisional ionisation
+
   // the two sides of the thermal balance. The order of the terms is fixed, because the results must not change.
   [[nodiscard]] auto get_total_heating() const -> double {
     return heating_ff + heating_bf + heating_collisional + heating_dep;
@@ -58,6 +71,8 @@ struct HeatingCoolingRates {
 
 void call_T_e_finder(int nonemptymgi, double t_current, HeatingCoolingRates& heatingcoolingrates,
                      std::span<const double> bfheatingcoeffs);
+void calculate_ion_heating_cooling_rates(int nonemptymgi, HeatingCoolingRates& heatingcoolingrates,
+                                         std::span<const double> bfheatingcoeffs);
 auto calculate_bfheatingcoeff(int element, int ion, int level, int phixstargetindex, int nonemptymgi) -> double;
 void calculate_bfheatingcoeffs(int nonemptymgi, std::span<double> bfheatingcoeffs);
 

--- a/update_grid.cc
+++ b/update_grid.cc
@@ -14,6 +14,7 @@
 #include <ostream>
 #include <print>
 #include <span>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -140,6 +141,24 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
     nltepop_write_to_file(nonemptymgi, timestep);
   }
 
+  // Write one line of per-ion values in the format of the gamma_R line, e.g.
+  // "cooling_ff         Z=26  1: 3.242e-03  2: 1.171e-01". values_allions holds one value for every ion of
+  // every element, and nions_towrite selects how many of this element's ions the line reports.
+  const auto print_perion_line = [&estimators_file](const std::string_view label, const int element,
+                                                    const int nions_towrite,
+                                                    const std::span<const double> values_allions) {
+    std::print(estimators_file, "{:<18} Z={:2d}", label, get_atomicnumber(element));
+    // add spaces for missing lowest ion stages to match other elements
+    for (int ionstage = 1; ionstage < get_ionstage(element, 0); ionstage++) {
+      std::print(estimators_file, "              ");
+    }
+    for (int ion = 0; ion < nions_towrite; ion++) {
+      std::print(estimators_file, "  {}: {:9.3e}", get_ionstage(element, ion),
+                 values_allions[get_uniqueionindex(element, ion)]);
+    }
+    std::println(estimators_file);
+  };
+
   // thread_local lets us reuse this allocation for every cell on each CPU thread
   THREADLOCALONHOST auto nuc_massfracs = std::vector<double>(decay::get_num_nuclides());
   decay::calc_cell_nuc_massfracs(nonemptymgi, nuc_massfrac_coeffs, nuc_massfracs);
@@ -208,6 +227,19 @@ void write_to_estimators_file(std::ostream& estimators_file, const int nonemptym
         std::print(estimators_file, "  {}: {:9.3e}", get_ionstage(element, ion), Y_nt);
       }
       std::println(estimators_file);
+    }
+
+    // a cell that gets no thermal balance solution, e.g. a grey cell, has no per-ion rates to report
+    if (WRITE_ION_HEATING_COOLING_RATES && !heatingcoolingrates.cooling_ff_ion.empty()) {
+      // the bound-free terms belong to the lower ion of each continuum, so the top ion has none
+      print_perion_line("heating_bf", element, nions - 1, heatingcoolingrates.heating_bf_ion);
+      if constexpr (COL_HEAT_FROM_LEVELPOPS) {
+        print_perion_line("heating_coll", element, nions, heatingcoolingrates.heating_coll_ion);
+      }
+      print_perion_line("heating_ff", element, nions, heatingcoolingrates.heating_ff_ion);
+      print_perion_line("cooling_ff", element, nions, heatingcoolingrates.cooling_ff_ion);
+      print_perion_line("cooling_fb", element, nions - 1, heatingcoolingrates.cooling_fb_ion);
+      print_perion_line("cooling_coll", element, nions, heatingcoolingrates.cooling_coll_ion);
     }
 
     if (USE_LUT_PHOTOION && globals::nbfcontinua_ground > 0) {
@@ -344,6 +376,12 @@ void solve_Te_nltepops(const int nonemptymgi, const int nts, const int nts_prev,
 
     const auto duration_solve_T_e =
         std::chrono::duration<double>(std::chrono::steady_clock::now() - sys_time_start_Te).count();
+
+    // The solver leaves the cell in the state of the T_e that it selected, so the totals above and the
+    // per-ion rates below belong to the same populations. The element solves that follow change the
+    // populations, so a later split would disagree with the totals. Each iteration overwrites the result
+    // of the previous one, and the estimators file reports the last.
+    calculate_ion_heating_cooling_rates(nonemptymgi, heatingcoolingrates, bfheatingcoeffs);
 
     if (globals::total_nlte_levels == 0) {
       const auto sys_time_start_pops = std::chrono::steady_clock::now();


### PR DESCRIPTION
## What this adds

The estimators file gives the heating rate and the cooling rate of each cell as one total for each
process. This pull request adds the compile-time option `WRITE_ION_HEATING_COOLING_RATES`. With that
option, each cell also gets one line for each process that names the contribution of each ion:

```
heating_bf         Z=26  1: 7.326e-14  2: 2.453e-14  3: 8.806e-24  4: 1.380e-34
heating_coll       Z=26  1: 1.770e-13  2: 1.112e-09  3: 1.060e-09  4: 1.801e-10  5: 6.331e-10
heating_ff         Z=26  1: 0.000e+00  2: 7.341e-18  3: 1.308e-16  4: 5.079e-16  5: 3.825e-16
cooling_ff         Z=26  1: 0.000e+00  2: 6.340e-15  3: 1.130e-13  4: 4.387e-13  5: 3.304e-13
cooling_fb         Z=26  1: 6.442e-14  2: 1.857e-12  3: 3.883e-12  4: 2.628e-12
cooling_coll       Z=26  1: 2.233e-12  2: 1.468e-09  3: 1.692e-09  4: 3.002e-10  5: 6.333e-10
```

The lines have the format of the `gamma_R` line, thus artistools reads them with no change. It gives
the columns `heating_bf_Fe_II`, `cooling_coll_Fe_III`, and so on, with the correct units.

## How the code computes the rates

`calculate_ion_heating_cooling_rates()` in `thermalbalance.cc` runs once for each cell, directly
after the thermal balance solver. The solver leaves the cell in the state of the T_e that it
selected, so the per-ion values agree with the totals. The element solves that follow change the
populations, thus a later split would disagree with the totals.

- A bound-free term belongs to the lower ion of the continuum, as `gamma_R` does.
- A collisional term belongs to the ion that holds the level.
- The free-free heating estimator holds no per-ion information. Each ion gets the share that it has
  in the free-free opacity, which is proportional to `nnion * ioncharge^2`.
- `heating_coll` needs `COL_HEAT_FROM_LEVELPOPS`. The estimator of the other branch holds no per-ion
  information, so the code then writes no such line.
- A cell that gets no thermal balance solution, e.g. a grey cell, gets no per-ion lines.

`kpkt::calculate_ion_cooling_rates()` is a new wrapper over the existing
`calculate_cooling_rates_ion()`, which already splits the cooling of one ion into the four
processes.

## Results

The option is false in every preset, and the code changes no existing line. The test
`nebular_1d_3dgrid` sets the option to true, thus **the results of that test change**. A maintainer
must make the reference checksums of that test again with the `updatechecksums.yml` workflow. The
other tests must give identical checksums.

## Tests

- `nebular_1d_3dgrid` with the option on: a local run of job0, of the resume job, and of `exspec`.
  The per-ion values sum to the totals of the `heating:` and `cooling:` lines, to the precision of
  the file format. artistools reads the folder and plots the new columns.
- The same test with the option off: all 26 output files are identical to a build of `main` on the
  same machine.
- `prek run --all-files` and clang-tidy give no message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)