### PR TITLE
Add the submit scripts for Leonardo

### DIFF
--- a/scripts/artis-leonardo-submit.sh
+++ b/scripts/artis-leonardo-submit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+# Submit the ARTIS job on Leonardo. Use this script in place of a direct sbatch.
+
+# sbatch expands no variable in a #SBATCH line, and Slurm supplies no
+# SBATCH_MAIL_USER variable. The address must therefore come from the command
+# line. The job script artis-leonardo.sh keeps all of the resource options,
+# because a #SBATCH line works correctly on this system.
+
+# Leonardo mails <user>@leonardo.local when the address is absent, and that
+# address reaches nobody. So give no --mail-user when EMAIL is empty.
+mailargs=()
+if [ -n "$EMAIL" ]; then
+    mailargs=(--mail-user="$EMAIL")
+fi
+
+sbatch -J "$(basename "$(pwd)")" "${mailargs[@]}" -- artis/scripts/artis-leonardo.sh
+
+# Add a line like this to your .bashrc to get the notifications:
+# export EMAIL=your_email_address

--- a/scripts/artis-leonardo.sh
+++ b/scripts/artis-leonardo.sh
@@ -8,7 +8,7 @@
 #SBATCH --qos=normal
 #SBATCH --account=EUHPC_R07_209
 #SBATCH --mail-type=ALL
-##SBATCH --mail-user=luke.shingles@gmail.com
+# artis-leonardo-submit.sh gives --mail-user from the EMAIL variable
 
 export PATH="/leonardo_work/EUHPC_R07_209/bin:$PATH"
 export PIXI_HOME="/leonardo_work/EUHPC_R07_209/.pixi"
@@ -60,10 +60,11 @@ source ./artis/scripts/corehours-after.sh
 
 if grep -q "RESTART_NEEDED" "output_0-0.txt"
 then
-    sbatch --job-name="$SLURM_JOB_NAME" ./artis/scripts/artis-leonardo.sh
+    # the submit script sets the job name and the address of the next job
+    source ./artis/scripts/artis-leonardo-submit.sh
 else
     # post-processing can remove restart files, so only queue it when no continuation job was submitted
     if [ -f packets00_0000.out ]; then
-        sbatch --job-name="exspec_$SLURM_JOB_NAME" ./artis/scripts/exspec-zip-leonardo.sh
+        source ./artis/scripts/exspec-zip-leonardo-submit.sh
     fi
 fi

--- a/scripts/exspec-zip-leonardo-submit.sh
+++ b/scripts/exspec-zip-leonardo-submit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+# Submit the exspec job on Leonardo. Use this script in place of a direct sbatch.
+
+# sbatch expands no variable in a #SBATCH line, and Slurm supplies no
+# SBATCH_MAIL_USER variable. The address must therefore come from the command
+# line. The job script exspec-zip-leonardo.sh keeps all of the resource
+# options, because a #SBATCH line works correctly on this system.
+
+# Leonardo mails <user>@leonardo.local when the address is absent, and that
+# address reaches nobody. So give no --mail-user when EMAIL is empty.
+mailargs=()
+if [ -n "$EMAIL" ]; then
+    mailargs=(--mail-user="$EMAIL")
+fi
+
+sbatch -J "exspec_$(basename "$(pwd)")" "${mailargs[@]}" -- artis/scripts/exspec-zip-leonardo.sh
+
+# Add a line like this to your .bashrc to get the notifications:
+# export EMAIL=your_email_address

--- a/scripts/exspec-zip-leonardo.sh
+++ b/scripts/exspec-zip-leonardo.sh
@@ -8,7 +8,7 @@
 #SBATCH --qos=normal
 #SBATCH --account=EUHPC_R07_209
 #SBATCH --mail-type=ALL
-##SBATCH --mail-user=luke.shingles@gmail.com
+# exspec-zip-leonardo-submit.sh gives --mail-user from the EMAIL variable
 
 export PATH="/leonardo_work/EUHPC_R07_209/bin:$PATH"
 export PIXI_HOME="/leonardo_work/EUHPC_R07_209/.pixi"


### PR DESCRIPTION
Slurm supplies no `SBATCH_MAIL_USER` variable, and `sbatch` expands no variable in a `#SBATCH` line. The address of the notifications must therefore come from the command line of `sbatch`. Leonardo sets `MailDomain = leonardo.local`, so a job with no `--mail-user` mails an address that reaches nobody.

This pull request adds `artis-leonardo-submit.sh` and `exspec-zip-leonardo-submit.sh`. They give the job name and the address of the `EMAIL` variable, as `artis-virgo-submit.sh` does. Submit a run with:

```sh
./artis/scripts/artis-leonardo-submit.sh
```

Two points differ from the virgo submit script:

- The job scripts keep all of the resource options. The virgo scripts hold them on the command line because a `#SBATCH` line does not work in the container of that system. A `#SBATCH` line works correctly on Leonardo, so a copy of the options would give two places to edit.
- An array holds the argument, so an empty `EMAIL` gives no `--mail-user`. The virgo script gives an empty address in that case.

The job script now calls the submit script for a continuation job and for the exspec job. This removes the two hard-coded addresses.

## Tests

- A stub `sbatch` shows the command line for both scripts, with `EMAIL` set and with `EMAIL` absent. The flag is present or absent as expected, and the job name is the name of the run folder.
- `sbatch --test-only` on Leonardo accepts both job scripts: 1008 processors on 9 nodes, and 112 processors on 1 node, in the partition `dcgp_usr_prod`.

The scripts change no numerical result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)