### PR TITLE
Align the shared array pointer manually to 128 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ else ifneq '' '$(findstring clang,$(COMPILER_VERSION))'
 	LDFLAGS += -Wno-unused-command-line-argument
 
 	ifeq '' '$(findstring Apple,$(COMPILER_VERSION))'
-		ifeq ($(if $(shell command -v lld),'true','false'), 'true')
+		# Use lld only when it can link a trivial program. An older lld does not know every target that a
+		# new macOS SDK lists in its TAPI files, and the link then fails with "unknown target".
+		ifeq ($(shell echo 'int main(){}' | mpicxx -fuse-ld=lld -x c++ - -o /dev/null >/dev/null 2>&1 && echo true), true)
 			LDFLAGS += -fuse-ld=lld
 		endif
 	endif

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -283,7 +283,11 @@ template <typename T>
   // only rank_in_node 0 on each node allocates memory, but all ranks will get a pointer to it
   const auto num_thisnoderank = (globals::rank_in_node == 0) ? num_allranks : 0;
 
-  auto size = static_cast<MPI_Aint>(num_thisnoderank * sizeof(T));
+  // The MPI library does not always obey the alignment hint. Rank 0 asks for 128 more bytes, and every rank then
+  // rounds the shared base pointer up to the next 128-byte boundary. All ranks query the same base pointer from
+  // rank 0, so they all get the same aligned pointer.
+  constexpr std::size_t alignment_bytes = 128;
+  auto size = static_cast<MPI_Aint>((num_thisnoderank * sizeof(T)) + ((num_thisnoderank > 0) ? alignment_bytes : 0));
   int disp_unit = sizeof(T);
   MPI_Win mpiwin{MPI_WIN_NULL};
   T* ptr{};
@@ -297,6 +301,10 @@ template <typename T>
   assert_always(MPI_Info_free(&info) == MPI_SUCCESS);
   assert_always(MPI_Win_shared_query(mpiwin, 0, &size, &disp_unit, static_cast<void*>(&ptr)) == MPI_SUCCESS);
   assert_always(ptr != nullptr);
+  void* alignedptr = static_cast<void*>(ptr);
+  auto space = static_cast<std::size_t>(size);
+  assert_always(std::align(alignment_bytes, num_allranks * sizeof(T), alignedptr, space) != nullptr);
+  ptr = static_cast<T*>(alignedptr);
 #ifdef __cpp_lib_is_sufficiently_aligned
   assert_always(std::is_sufficiently_aligned<128>(ptr));
 #endif

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <bit>
 #include <cassert>
 #include <cstdarg>
 #include <cstddef>
@@ -283,9 +284,10 @@ template <typename T>
   // only rank_in_node 0 on each node allocates memory, but all ranks will get a pointer to it
   const auto num_thisnoderank = (globals::rank_in_node == 0) ? num_allranks : 0;
 
-  // The MPI library does not always obey the alignment hint. Rank 0 asks for 128 more bytes, and every rank then
-  // rounds the shared base pointer up to the next 128-byte boundary. All ranks query the same base pointer from
-  // rank 0, so they all get the same aligned pointer.
+  // The MPI library does not always obey the alignment hint. Rank 0 asks for 128 more bytes and computes the byte
+  // offset that rounds its base pointer up to the next 128-byte boundary. Every rank then applies that one offset.
+  // Each process maps the segment at its own virtual address, so the offset must come from a single rank, or the
+  // spans of the ranks would refer to different parts of the segment.
   constexpr std::size_t alignment_bytes = 128;
   auto size = static_cast<MPI_Aint>((num_thisnoderank * sizeof(T)) + ((num_thisnoderank > 0) ? alignment_bytes : 0));
   int disp_unit = sizeof(T);
@@ -295,16 +297,20 @@ template <typename T>
   assert_always(MPI_Info_create(&info) == MPI_SUCCESS);
   // Request alignment (AVX-512 requires 64b, and 128b is Apple Silicon cache line size).
   assert_always(MPI_Info_set(info, "mpi_minimum_memory_alignment", "128") == MPI_SUCCESS);
-  assert_always(MPI_Info_set(info, "alloc_shared_noncontig", "true") == MPI_SUCCESS);
   assert_always(MPI_Win_allocate_shared(size, disp_unit, info, globals::mpi_comm_node, static_cast<void*>(&ptr),
                                         &mpiwin) == MPI_SUCCESS);
   assert_always(MPI_Info_free(&info) == MPI_SUCCESS);
   assert_always(MPI_Win_shared_query(mpiwin, 0, &size, &disp_unit, static_cast<void*>(&ptr)) == MPI_SUCCESS);
   assert_always(ptr != nullptr);
-  void* alignedptr = static_cast<void*>(ptr);
-  auto space = static_cast<std::size_t>(size);
-  assert_always(std::align(alignment_bytes, num_allranks * sizeof(T), alignedptr, space) != nullptr);
-  ptr = static_cast<T*>(alignedptr);
+  std::uint64_t alignment_offset_bytes = 0;
+  if (globals::rank_in_node == 0) {
+    const auto baseaddress = std::bit_cast<std::uintptr_t>(ptr);
+    alignment_offset_bytes = (alignment_bytes - (baseaddress % alignment_bytes)) % alignment_bytes;
+  }
+  assert_always(MPI_Bcast(&alignment_offset_bytes, 1, MPI_UINT64_T, 0, globals::mpi_comm_node) == MPI_SUCCESS);
+  assert_always(alignment_offset_bytes < alignment_bytes);
+  assert_always(static_cast<std::size_t>(size) >= alignment_offset_bytes + (num_allranks * sizeof(T)));
+  ptr = std::bit_cast<T*>(std::bit_cast<std::uintptr_t>(ptr) + alignment_offset_bytes);
 #ifdef __cpp_lib_is_sufficiently_aligned
   assert_always(std::is_sufficiently_aligned<128>(ptr));
 #endif

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -297,6 +297,9 @@ template <typename T>
   assert_always(MPI_Info_create(&info) == MPI_SUCCESS);
   // Request alignment (AVX-512 requires 64b, and 128b is Apple Silicon cache line size).
   assert_always(MPI_Info_set(info, "mpi_minimum_memory_alignment", "128") == MPI_SUCCESS);
+  // Only rank 0 has a non-zero segment, so the segments are contiguous in any case. The hint lets the library
+  // page-align the segment, which usually gives a zero alignment offset below.
+  assert_always(MPI_Info_set(info, "alloc_shared_noncontig", "true") == MPI_SUCCESS);
   assert_always(MPI_Win_allocate_shared(size, disp_unit, info, globals::mpi_comm_node, static_cast<void*>(&ptr),
                                         &mpiwin) == MPI_SUCCESS);
   assert_always(MPI_Info_free(&info) == MPI_SUCCESS);


### PR DESCRIPTION
## What changed

`MPI_shared_malloc_span_keepwin()` in `mpi_logging.h` now aligns the shared window pointer itself:

- Rank 0 requests 128 more bytes than the array needs.
- Rank 0 computes the byte offset that rounds its base pointer up to the next 128-byte boundary, and broadcasts that offset over the node communicator. Every rank applies the same offset.
- The `is_sufficiently_aligned<128>` assertion stays as a check of the result.

The Makefile adds `-fuse-ld=lld` only when a probe link with lld succeeds. The Homebrew lld 23.1.1 rejects the TAPI files of the macOS 27 SDK, so the build falls back to the system linker there.

## Why

The MPI library does not always obey the `mpi_minimum_memory_alignment` hint. The alignment assertion then stops the run at the first shared allocation.

Each process maps the segment at its own virtual address, so the residue modulo 128 can differ between the ranks. The offset must therefore come from one rank, or the spans of the ranks would refer to different parts of the segment.

The `alloc_shared_noncontig` hint stays. Only rank 0 has a non-zero segment, so the hint changes no layout. It lets the library page-align the segment, which usually makes the offset zero.

## Notes for the reviewer

- The numerical results do not change. The checksums must stay identical.
- The build links, all unit tests pass, clang-tidy gives no diagnostic, and the pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
