### PR TITLE
Run one zstd process for each file in exspec-after.sh

### DIFF
--- a/scripts/exspec-after.sh
+++ b/scripts/exspec-after.sh
@@ -30,19 +30,33 @@ if [[ -f emission.out || -f emission.out.zst || -f emissionpol.out ]]; then
   # remove empty directories, but keep the artis folder
   find . -maxdepth 1 -type d -empty ! -name artis -delete
 
+  # One zstd process compresses its files one after the other. At level 13, -T0 divides a file
+  # into jobs of 16 MiB, so a packet file of 44 MiB uses a maximum of three cores. xargs therefore
+  # starts one zstd for each file, and runs one zstd on each CPU of the job. Without -n1, xargs
+  # gives all the file names to one zstd. -T1 keeps the memory of each zstd small and gives the
+  # same output as -T0.
+  ncpus=$(nproc)
+
   # 3D kilonova model.txt and abundances.txt can be huge, so compress txt files
   # do maxdepth 1 first in case job gets killed during run folder compression
-  find . -maxdepth 1 -name '*.txt' ! -name "output_0-0.txt" -size +200k -print0 | sort -z | xargs -r0 -P8 zstd -T0 -13 -v --rm -f
-  find . -maxdepth 1 -name '*.out' ! -name "slurm-*.out" -size +200k -print0 | sort -z | xargs -r0 -P8 zstd -T0 -13 -v --rm -f
+  echo "$(date): zstd compresses the .txt files of the run folder"
+  find . -maxdepth 1 -name '*.txt' ! -name "output_0-0.txt" -size +200k -print0 | sort -z | xargs -r0 -n1 -P"$ncpus" zstd -T1 -13 -v --rm -f
+  echo "$(date): zstd compresses the .out files of the run folder"
+  find . -maxdepth 1 -name '*.out' ! -name "slurm-*.out" -size +200k -print0 | sort -z | xargs -r0 -n1 -P"$ncpus" zstd -T1 -13 -v --rm -f
 
-  find packets/ -name 'packets*.out' -size +200k -print0 | sort -z | xargs -r0 -P8 zstd -T0 -13 -v --rm -f
+  echo "$(date): zstd compresses the packet files"
+  find packets/ -name 'packets*.out' -size +200k -print0 | sort -z | xargs -r0 -n1 -P"$ncpus" zstd -T1 -13 -v --rm -f
 
   # the artis folder holds the code and the data files of the code, so do not change them
-  find . -path ./artis -prune -o -name '*.txt' ! -name "output_0-0.txt" -size +200k -print0 | sort -z | xargs -r0 -P8 zstd -T0 -13 -v --rm -f
-  find . -path ./artis -prune -o -name '*.out' ! -name "slurm-*.out" -size +200k -print0 | sort -z | xargs -r0 -P8 zstd -T0 -13 -v --rm -f
+  echo "$(date): zstd compresses the .txt files of the subfolders"
+  find . -path ./artis -prune -o -name '*.txt' ! -name "output_0-0.txt" -size +200k -print0 | sort -z | xargs -r0 -n1 -P"$ncpus" zstd -T1 -13 -v --rm -f
+  echo "$(date): zstd compresses the .out files of the subfolders"
+  find . -path ./artis -prune -o -name '*.out' ! -name "slurm-*.out" -size +200k -print0 | sort -z | xargs -r0 -n1 -P"$ncpus" zstd -T1 -13 -v --rm -f
 
+  echo "$(date): tar_rm_logs.sh archives the log files"
   ./artis/scripts/tar_rm_logs.sh
 
+  echo "$(date): artistools converts the output files to parquet"
   export PATH="$(pwd)/../uv/bin:$PATH"
   export PATH="$HOME/.local/bin/:$PATH"
   if ! command -v uv >/dev/null 2>&1


### PR DESCRIPTION
## Summary

`exspec-after.sh` compressed each group of files with one zstd process. The `xargs` command had `-P8`, but without `-n` it put all the file names into one zstd command. That zstd compressed its files one after the other. At level 13, `zstd -T0` divides a file into jobs of 16 MiB. A packet file of 44 MiB therefore used a maximum of three cores, and a rank log of 1.4 MiB used one core.

This PR gives each file to a separate zstd process with `xargs -n1`, and runs one process on each CPU of the job (`nproc`). Each zstd uses `-T1`.

The script also writes the date before each stage, so that the log of the next job shows the time of each stage.

## Evidence from a production run

The log of an exspec job for a 3D kilonova run with 960 ranks on Virgo (64 CPUs) shows:

- Each `find` line started one zstd process. For example, one process compressed all 960 packet files.
- zstd `-T0` detected 192 physical cores, but the job had 64 CPUs.
- Compression took about 7 h 03 min of the 7 h 21 min of the job. The change times of the folders divide this into two parts:
  - about 5 h 06 min for the run folder, the packet files (41.6 GiB), and the rank logs (4.0 GiB);
  - about 1 h 58 min for the estimator files (155 GiB).

## Measurements

These ran on a 14-core M4 Pro (10 performance and 4 efficiency cores) with zstd 1.5.7. The input was 28 copies of one packet file of 44.4 MiB from that run. "Busy cores" is the CPU time divided by the wall time.

| Command | Wall time | Busy cores |
|---|---|---|
| Before: `xargs -P8 zstd -T0` | 84.2 s | 2.7 |
| After: `xargs -n1 -P14 zstd -T1` | 30.7 s | 11.8 |
| `xargs -n1 -P14 zstd -T0` | 30.0 s | 12.2 |

The gain is smaller than the number of cores. Level 13 uses 32 MiB of hash tables for each file, and the parallel processes share the memory bandwidth. The CPU time for each file increased from 6.0 s with one process to 12.7 s with 14 processes. A Virgo job has more CPUs, so I expect a larger gain there. The date lines of the next job will show the real gain.

## Why `-T1`

- `-T0` in each process gave no gain (30.0 s against 30.7 s).
- `-T0` multiplies the memory. For one file of 1.1 GB, one zstd used 819 MB with `-T0` and 109 MB with `-T1`.
- `-T1` gives the same output. The md5 of the `-T1` output of the test file is equal to the md5 of the file that Virgo wrote with `-T0`.
- The cost is that the largest file compresses on one core. On the Mac, `-T1` compressed `model.txt` at 54 MB/s, so a `model.txt` of 2.1 GiB takes about 40 s.

## Changes in the log

- zstd `-v` now prints its title line once for each file. The summary line for each stage (`960 files compressed`) is gone.
- `nproc` obeys `OMP_NUM_THREADS`. The exspec job scripts do not set it. If a job sets `OMP_NUM_THREADS=1`, the compression uses one CPU.

## Test

- A run of the script on a fake run folder with 64 large files. Stubs replaced `uv`, `mergeangleres.py`, and `tar_rm_logs.sh`. 64 zstd processes compressed the 64 files. The files in `artis/`, `output_0-0.txt`, `slurm-*.out`, and the small files stayed uncompressed.
- `bash -n` and `prek run --files scripts/exspec-after.sh` pass.

This change affects only a job script. The output of sn3d and exspec does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
