### PR TITLE
Calculate the bound-free heating of every element

### DIFF
--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -292,19 +292,14 @@ void calculate_ion_heating_cooling_rates(const int nonemptymgi, HeatingCoolingRa
 // temperature solver tries.
 void calculate_bfheatingcoeffs(int nonemptymgi, std::span<double> bfheatingcoeffs) {
   assert_always(std::ssize(bfheatingcoeffs) == get_includedlevels());
-  const double minelfrac = 0.01;
   for (int element = 0; element < get_nelements(); element++) {
-    if (grid::get_elem_massfrac(nonemptymgi, element) <= minelfrac && !USE_ION_BFHEATING_ESTIMATORS) {
-      printlog("skipping Z={} X={:g}, ", get_atomicnumber(element), grid::get_elem_massfrac(nonemptymgi, element));
-    }
-
     const int nions = get_nions(element);
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels = get_nlevels(element, ion);
       const auto levels = std::ranges::iota_view{0, nlevels};
       std::for_each(EXEC_PAR levels.begin(), levels.end(), [&](const int level) {
         double bfheatingcoeff = 0.;
-        if (grid::get_elem_massfrac(nonemptymgi, element) > minelfrac || USE_ION_BFHEATING_ESTIMATORS) {
+        {
           const auto nphixstargets = get_nphixstargets(element, ion, level);
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             bfheatingcoeff += calculate_bfheatingcoeff(element, ion, level, phixstargetindex, nonemptymgi);


### PR DESCRIPTION
Without USE_ION_BFHEATING_ESTIMATORS an element with a mass fraction of 1 percent or less got a zero bound-free heating coefficient, while its bound-free cooling and its photoionisation stayed in the balance. The skip came from a 2020 cost saving for the integration (c2fb445b), and be7d7e01 kept it by a rename. The integrals are already reused for the temperature solver tries, so the heating is now calculated for every element.

The results change: the nebular and the time-dependent NLTE tests. Found by the whole-codebase review of 2026-09-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)