### PR TITLE
Mark the entry state variables of do_macroatom() as maybe unused

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ endif
 ifeq ($(REPRODUCIBLE),ON)
 	CXXFLAGS += -DREPRODUCIBLE=true -ffp-contract=off -DEIGEN_DONT_VECTORIZE
 	BUILD_DIR := $(BUILD_DIR)_reproducible
-	FASTMATH := OFF
+	override FASTMATH := OFF
 else ifeq ($(REPRODUCIBLE),OFF)
 else ifeq ($(REPRODUCIBLE),)
 else
@@ -251,6 +251,13 @@ ifeq ($(TESTMODE),ON)
 	CXXFLAGS += $(TESTMODE_CXXFLAGS)
 
 	BUILD_DIR := $(BUILD_DIR)_testmode
+endif
+
+ifneq ($(filter-out ON OFF,$(FASTMATH)),)
+  $(error bad value for FASTMATH option. Should be ON or OFF)
+endif
+ifneq ($(filter-out ON OFF,$(OPTIMIZE)),)
+  $(error bad value for OPTIMIZE option. Should be ON or OFF)
 endif
 
 ifeq ($(OPTIMIZE),OFF)
@@ -429,7 +436,7 @@ $(BUILD_DIR)/sn3d: $(sn3d_objects)
 sn3d: $(BUILD_DIR)/sn3d compile_commands.json
 	rm -f sn3d && ln -s $(BUILD_DIR)/sn3d sn3d
 
-$(BUILD_DIR)/sn3dwhole: $(sn3d_files) version.h artisoptions.h Makefile
+$(BUILD_DIR)/sn3dwhole: $(sn3d_files) $(wildcard *.h) Makefile
 	$(CXX) $(CXXFLAGS) $(sn3d_files) $(LDFLAGS) -o $(BUILD_DIR)/sn3dwhole
 -include $(sn3d_dep)
 

--- a/gammapkt.cc
+++ b/gammapkt.cc
@@ -72,17 +72,17 @@ void read_gamma_spectrum(const int nucindex, const std::string& filename) {
   // read the gamma ray lines and store the average energy in gamma rays per nuclear decay
   auto gammafile = fstream_required(filename, std::ios::in);
   std::string line;
-  get_noncommentline(gammafile, line);
+  assert_always(get_noncommentline(gammafile, line));
   std::istringstream ssline(line);
   int nlines = 0;
-  ssline >> nlines;
+  assert_always(ssline >> nlines);
 
   gamma_spectra[nucindex].reserve(nlines);
   gamma_spectra[nucindex].clear();
 
   double E_gamma_avg = 0.;
   for (int n = 0; n < nlines; n++) {
-    get_noncommentline(gammafile, line);
+    assert_always(get_noncommentline(gammafile, line));
     double en_mev = 0.;
     double prob = 0.;
     ssline.clear();
@@ -992,7 +992,9 @@ DEVICE_FUNC void do_gamma(Packet& pkt, const int nts, const double t2) {
   }
 
   if (pkt.type != TYPE_GAMMA && pkt.type != TYPE_ESCAPE) {
-    if constexpr (PARTICLE_THERMALISATION_SCHEME != ParticleThermalisationScheme::TIMEDEPENDENTWITHGAMMAPRODUCTS) {
+    // with gamma products and the frequency-dependent scheme, do_nonthermal_predeposit() adds the deposition
+    if constexpr (PARTICLE_THERMALISATION_SCHEME != ParticleThermalisationScheme::TIMEDEPENDENTWITHGAMMAPRODUCTS ||
+                  GAMMA_THERMALISATION_SCHEME != GammaThermalisationScheme::FREQUENCYDEPENDENT) {
       atomicadd(globals::timesteps[nts].gamma_dep_discrete, pkt.e_cmf);
     }
 

--- a/globals.h
+++ b/globals.h
@@ -157,9 +157,6 @@ inline AllTransitions alltrans;
 
 struct LevelAutoion {
   float autoion_A;  // Autoionisation A-value
-  int elementindex;  // index (not atomic number) for the element involved
-  int lowerionindex;
-  int lowerlevelindex;  // this will be for a level index of the lower ion
   int upperionindex;
   int upperlevelindex;  // this will be for a level index of the upper ion.
                         // Note: level of the lower ion should also be at higher energy than of the higher ion
@@ -256,8 +253,8 @@ struct AllCont {
   // index into the ground-level continuum estimator arrays, or -1 for continua that do not feed them
   // (only a ground level's first photoionisation target does). This is the ion's own
   // get_groundcontindex() slot, the same slot where update_grid.cc normalises and applies the
-  // estimators. setup_phixs_list() checks that the nearest-edge search agrees for every ground
-  // level, so a dataset with two identical ground thresholds stops at startup.
+  // estimators. Two ions can have an identical ground threshold, so the ground level does not use
+  // the nearest-edge search.
   MPI_shared_array<const int> groundcontestimindex;
   MPI_shared_array<const int> bfestimindex;
 };

--- a/grid.cc
+++ b/grid.cc
@@ -119,7 +119,7 @@ struct ModelGridCellInput {
   // thermalisation scheme. A double, because the sum runs over up to millions of propagation cells
   // with radii of ~1e15 cm.
   double initial_radial_pos_squared_sum = 0.;
-  float initelectronfrac = 0.4;  // Ye: electrons (or protons) per nucleon
+  float initelectronfrac = -1.;  // Ye: electrons (or protons) per nucleon. Negative until the input sets it
   float initenergyq = 0.;  // q: energy in the model at tmin to use with INITIAL_PACKETS_ON [erg/g]
 };
 MPI_shared_array<ModelGridCellInput> modelgrid_input{};
@@ -168,7 +168,7 @@ void set_initelectronfrac(const int modelgridindex, const float electronfrac) {
 
 void read_possible_yefile() {
   if (!std::filesystem::exists("Ye.txt")) {
-    printlnlog("Ye.txt not present, so no initial electron fractions will be applied from it");
+    printlnlog("Ye.txt is not present, so the model keeps the electron fractions of model.txt");
     return;
   }
 
@@ -1449,7 +1449,7 @@ void setup_grid_cylindrical_2d() {
 
   ncoordgrid = ncoord_model;
 
-  ngrid = ncoordgrid[0] * ncoordgrid[1];
+  ngrid = static_cast<ptrdiff_t>(ncoordgrid[0]) * ncoordgrid[1];
   assert_always(ngrid == get_npts_model());
 
   reserve_resize(coord_pos_min_tmin[0], ncoordgrid[0]);
@@ -1988,19 +1988,19 @@ DEVICE_FUNC auto get_initenergyq(const int modelgridindex) -> double {
   return modelgrid_input[modelgridindex].initenergyq;
 }
 
-[[nodiscard]] auto get_elements_uppermost_ion(const int nonemptymgi, const int element) -> int {
+[[nodiscard]] auto get_elements_uppermost_ion(const std::ptrdiff_t nonemptymgi, const int element) -> int {
   const auto uppermost_ion = elements_uppermost_ion_allcells[(nonemptymgi * get_nelements()) + element];
   assert_testmodeonly(uppermost_ion >= -1);  // -1 before the first ion balance of the element in the cell
   assert_testmodeonly(uppermost_ion <= std::max(0, get_nions(element) - 1));
   return uppermost_ion;
 }
 
-void set_elements_uppermost_ion(const int nonemptymgi, const int element, const int uppermost_ion) {
+void set_elements_uppermost_ion(const std::ptrdiff_t nonemptymgi, const int element, const int uppermost_ion) {
   assert_testmodeonly(uppermost_ion <= std::max(0, get_nions(element) - 1));
   elements_uppermost_ion_allcells[(nonemptymgi * get_nelements()) + element] = uppermost_ion;
 }
 
-[[nodiscard]] auto get_elements_lowermost_ion(const int nonemptymgi, const int element) -> int {
+[[nodiscard]] auto get_elements_lowermost_ion(const std::ptrdiff_t nonemptymgi, const int element) -> int {
   if constexpr (!NLTE_TRACK_SOLUTION_RANGES) {
     return 0;  // the array is not allocated when no code reads the solution ranges
   }
@@ -2010,7 +2010,7 @@ void set_elements_uppermost_ion(const int nonemptymgi, const int element, const 
   return lowermost_ion;
 }
 
-void set_elements_lowermost_ion(const int nonemptymgi, const int element, const int lowermost_ion) {
+void set_elements_lowermost_ion(const std::ptrdiff_t nonemptymgi, const int element, const int lowermost_ion) {
   if constexpr (!NLTE_TRACK_SOLUTION_RANGES) {
     return;  // the array is not allocated when no code reads the solution ranges
   }
@@ -2045,7 +2045,12 @@ void do_MPI_Bcast_nlte_solution_ranges(const ptrdiff_t nstart_nonempty, const pt
     case RpktGreyType::TANAKA2020_ELECTRONFRAC: {
       // electron-fraction-dependent opacities from Tanaka et al. (2020) table 1.
       const auto Ye = modelgrid_input[mgi].initelectronfrac;
-      assert_always(Ye > 0.);
+      if (Ye <= 0.) {
+        fatal_crash(
+            "model cell {} has no electron fraction. TANAKA2020_ELECTRONFRAC needs a Ye column in model.txt or "
+            "a Ye.txt",
+            mgi);
+      }
 
       // pairs of (upper Ye limit, kappa [cm^2/g])
       constexpr auto kappa_table = std::to_array<std::pair<double, double>>(
@@ -2707,33 +2712,29 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
         }
 
         if (isoutside_error) {
-#ifndef GPU_ON
-          printlnlog(
-              "[error] timestep {}: packet outside coord {} {}{} boundary of cell {} by delta {:g}. vel {:g} initpos "
-              "{:g} cellcoordmin {:g} cellcoordmax {:g} dir [{:g}, {:g}, {:g}] tmin {:g} s tstart {:g} s",
-              globals::timestep, d, pos_component_vel_relative_to_flow ? '+' : '-', get_coordlabel(prop_gridtype, d),
-              cellindex, delta, pktvelgridcoord[d], pktposgridcoord[d], cellcoordmin[d] / globals::tmin * tstart,
-              cellcoordmax[d] / globals::tmin * tstart, dir[0], dir[1], dir[2], globals::tmin, tstart);
-#endif
+          MY_IF_HOST(
+              printlnlog("[error] timestep {}: packet outside coord {} {}{} boundary of cell {} by delta {:g}. vel "
+                         "{:g} initpos "
+                         "{:g} cellcoordmin {:g} cellcoordmax {:g} dir [{:g}, {:g}, {:g}] tmin {:g} s tstart {:g} s",
+                         globals::timestep, d, pos_component_vel_relative_to_flow ? '+' : '-',
+                         get_coordlabel(prop_gridtype, d), cellindex, delta, pktvelgridcoord[d], pktposgridcoord[d],
+                         cellcoordmin[d] / globals::tmin * tstart, cellcoordmax[d] / globals::tmin * tstart, dir[0],
+                         dir[1], dir[2], globals::tmin, tstart););
 
-          // this should not happen! Leave the check until late 2026 and if it never triggers on any runs, we can remove
-          // the check and correction code
           assert_always(!isoutside_error);
 
           const auto next_cellindex = get_cellindex_from_pos(pos, tstart);
           if ((cellcoordidx[d] == (ncoordgrid[d] - 1) && pos_component_vel_relative_to_flow) ||
               (cellcoordidx[d] == 0 && !pos_component_vel_relative_to_flow) || (next_cellindex < 0)) {
-#ifndef GPU_ON
-            printlnlog("[warning] treating out-of-boundary packet in cell {} as escaping the grid", cellindex);
-#endif
+            MY_IF_HOST(
+                printlnlog("[warning] treating out-of-boundary packet in cell {} as escaping the grid", cellindex););
             return {0., -99};
           }
-#ifndef GPU_ON
-          printlnlog(
-              "[warning] swapping packet cellindex from {} to {}, which has cellcoordmin {:g}, cellcoordmax {:g}",
-              cellindex, next_cellindex, get_cellcoordmin(next_cellindex, d) / globals::tmin * tstart,
-              get_cellcoordmax(next_cellindex, d) / globals::tmin * tstart);
-#endif
+          MY_IF_HOST(
+              printlnlog(
+                  "[warning] swapping packet cellindex from {} to {}, which has cellcoordmin {:g}, cellcoordmax {:g}",
+                  cellindex, next_cellindex, get_cellcoordmin(next_cellindex, d) / globals::tmin * tstart,
+                  get_cellcoordmax(next_cellindex, d) / globals::tmin * tstart););
           return {0., next_cellindex};
         }
       }
@@ -2917,8 +2918,7 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
       // No receding cell boundary lies ahead of the packet, so it escapes through the slower
       // spherical escape surface. The comoving coordinates of a packet converge to a point with
       // speed CLIGHT. Only a cell whose fastest corner is above CLIGHT can hold this state. A
-      // slower cell here is a sign of a defective boundary intersection, and the run then stops
-      // as it did before this escape path existed.
+      // slower cell here is a sign of a defective boundary intersection, and the run then stops.
       double cornerspeed_squared = 0.;
       for (int d = 0; d < get_ndim(prop_gridtype); d++) {
         cornerspeed_squared += pow2(std::max(std::abs(cellcoordmin[d]), std::abs(cellcoordmax[d])) / globals::tmin);
@@ -2931,11 +2931,12 @@ DEVICE_FUNC void snap_pos_to_cell(Vec3d& pos, const double time, const int celli
       // packets only when the cell diagonal spans from below vmax to above CLIGHT, so a finer
       // grid removes this stop.
       if (get_propcell_modelgridindex(cellindex) >= 0) {
-        printlnlog(
-            "[error] a packet cannot reach any boundary of matter cell {}, because every boundary recedes faster "
-            "than light. The cell reaches from inside the escape surface to beyond the light speed, so the grid is "
-            "too coarse. Use more grid cells per axis.",
-            cellindex);
+        MY_IF_HOST(
+            printlnlog(
+                "[error] a packet cannot reach any boundary of matter cell {}, because every boundary recedes faster "
+                "than light. The cell reaches from inside the escape surface to beyond the light speed, so the grid is "
+                "too coarse. Use more grid cells per axis.",
+                cellindex););
         assert_always(false);
       }
 

--- a/grid.h
+++ b/grid.h
@@ -48,13 +48,13 @@ inline MPI_shared_array<float> elem_massfracs_allcells;
 inline MPI_shared_array<float> ion_groundlevelpops_allcells;
 inline MPI_shared_array<float> ion_partfuncts_allcells;
 
-[[nodiscard]] auto get_elements_uppermost_ion(int nonemptymgi, int element) -> int;
-void set_elements_uppermost_ion(int nonemptymgi, int element, int uppermost_ion);
+[[nodiscard]] auto get_elements_uppermost_ion(std::ptrdiff_t nonemptymgi, int element) -> int;
+void set_elements_uppermost_ion(std::ptrdiff_t nonemptymgi, int element, int uppermost_ion);
 // The charge transfer reactions and the Anderson acceleration read the NLTE solution ranges, so the
 // lowermost ion of the range then needs storage.
 constexpr bool NLTE_TRACK_SOLUTION_RANGES = ENABLE_CHARGE_TRANSFER_REACTIONS || NLTE_TE_NNE_USE_ANDERSON_ACCEL;
-[[nodiscard]] auto get_elements_lowermost_ion(int nonemptymgi, int element) -> int;
-void set_elements_lowermost_ion(int nonemptymgi, int element, int lowermost_ion);
+[[nodiscard]] auto get_elements_lowermost_ion(std::ptrdiff_t nonemptymgi, int element) -> int;
+void set_elements_lowermost_ion(std::ptrdiff_t nonemptymgi, int element, int lowermost_ion);
 // Exchange the NLTE solution ranges between the node leaders.
 void do_MPI_Bcast_nlte_solution_ranges(ptrdiff_t nstart_nonempty, ptrdiff_t ndo_nonempty, int root_node_id);
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto propcell_width_tmin(int cellindex, int axis) -> double;
@@ -102,10 +102,11 @@ void set_element_meanweight(std::ptrdiff_t nonemptymgi, int element, float meanw
 [[gnu::pure]] [[nodiscard]] DEVICE_FUNC auto get_cellindex_from_pos(const Vec3d& pos, double time) -> int;
 void read_ejecta_model();
 void write_grid_restart_data(int timestep);
-[[gnu::pure]] [[nodiscard]] auto get_nstart(int rank) -> int;
-[[gnu::pure]] [[nodiscard]] auto get_nstart_nonempty(int rank) -> int;
-[[gnu::pure]] [[nodiscard]] auto get_ndo(int rank) -> int;
-[[gnu::pure]] [[nodiscard]] auto get_ndo_nonempty(int rank) -> int;
+// the first call sets up the rank ranges, so these functions are not pure
+[[nodiscard]] auto get_nstart(int rank) -> int;
+[[nodiscard]] auto get_nstart_nonempty(int rank) -> int;
+[[nodiscard]] auto get_ndo(int rank) -> int;
+[[nodiscard]] auto get_ndo_nonempty(int rank) -> int;
 [[gnu::pure]] [[nodiscard]] auto get_totmassnuclide_tmodel(int z, int a) -> double;
 [[nodiscard]] auto get_propcell_random_xyz_position_tmin(int cellindex, rngstate_type& rngstate) -> Vec3d;
 [[nodiscard]] DEVICE_FUNC auto boundary_distance(const Vec3d& dir, const Vec3d& pos, double tstart, int cellindex)

--- a/input.cc
+++ b/input.cc
@@ -368,6 +368,8 @@ void read_phixs_file(const int phixs_file_version, std::vector<float>& tmpallphi
     assert_always(Z > 0);
     assert_always(upperionstage >= 2);
     assert_always(lowerionstage >= 1);
+    // the continuum is stored for the lower ion, and its upper ion is always the next ion
+    assert_always(upperionstage == lowerionstage + 1);
 
     const int element = get_elementindex(Z);
 
@@ -625,6 +627,11 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
       // Make sure that we don't allow duplicate. In that case take only the lines first occurrence
       const bool is_duplicate = (lowerlevel == prev_lower && level == prev_upper);
 
+      // absorption oscillator strength f_lu from A_ul via f_lu = (g_u/g_l) * m_e c^3 / (8 pi^2 e^2 nu^2) * A_ul
+      const auto g_ratio = static_cast<double>(ion_levels[level].stat_weight) / ion_levels[lowerlevel].stat_weight;
+      const auto f_lu = static_cast<float>(g_ratio * ME * pow3(CLIGHT) / (8 * pow2(QE * nu_trans * PI)) * transition.A);
+      assert_always(std::isfinite(f_lu));
+
       if (!is_duplicate) {
         prev_lower = lowerlevel;
         prev_upper = level;
@@ -639,12 +646,6 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
         ion_updowntranscount += 2;
 
         if (pass == 1) {
-          // absorption oscillator strength f_lu from A_ul via f_lu = (g_u/g_l) * m_e c^3 / (8 pi^2 e^2 nu^2) * A_ul
-          const auto g_ratio = static_cast<double>(ion_levels[level].stat_weight) / ion_levels[lowerlevel].stat_weight;
-          const auto f_lu =
-              static_cast<float>(g_ratio * ME * pow3(CLIGHT) / (8 * pow2(QE * nu_trans * PI)) * transition.A);
-          assert_always(std::isfinite(f_lu));
-
           temp_linelist.push_back({
               .nu = nu_trans,
               .einstein_A = transition.A,
@@ -692,10 +693,6 @@ void add_transitions_to_unsorted_linelist(const int element, const int ion,
               temp_linelist[prev_lineindex].upperlevelindex, temp_linelist[prev_lineindex].lowerlevelindex);
           fatal_crash("Failure to identify level pair for duplicate bb-transition");
         }
-
-        const auto g_ratio = static_cast<double>(ion_levels[level].stat_weight) / ion_levels[lowerlevel].stat_weight;
-        const auto f_lu =
-            static_cast<float>(g_ratio * ME * pow3(CLIGHT) / (8 * pow2(QE * nu_trans * PI)) * transition.A);
 
         auto& downtransition =
             temp_alltranslist[ion_levels[level].alltrans_startdown + ion_levels[level].ndowntrans - 1];
@@ -829,8 +826,8 @@ void setup_phixs_list() {
       }
     }
     assert_always(nextgroundcontindex == globals::nbfcontinua_ground);
-    std::ranges::sort(std::views::zip(groundcont_nu_edge, groundcont_element, groundcont_ion),
-                      [](const auto& lhs, const auto& rhs) { return std::get<0>(lhs) < std::get<0>(rhs); });
+    // the element and the ion make the key unique when two ions have an equal threshold
+    std::ranges::sort(std::views::zip(groundcont_nu_edge, groundcont_element, groundcont_ion));
   }
   MPI_Barrier_node();
   globals::groundcont_nu_edge = std::move(groundcont_nu_edge);
@@ -874,22 +871,9 @@ void setup_phixs_list() {
           if constexpr (USE_LUT_PHOTOION || USE_ION_BFHEATING_ESTIMATORS) {
             // depends only on the level, so it is found once here rather than once per target below
             const double nu_edge_target0 = get_phixs_threshold(element, ion, level, 0) / H;
+            // the ground level uses the ion's own slot, because two ions can have an identical ground threshold
             alllevels_closestgroundlevelcont[uniquelevelindex] =
-                search_groundphixslist(nu_edge_target0, element, ion, level);
-            if (level == 0) {
-              // update_grid.cc normalises and applies the ground continuum estimators at the
-              // groundcontindex slot, and the writes below use the same slot. The nearest-edge search
-              // gives another ion's slot only when two ions have an identical ground threshold. That
-              // case would silently mix the estimators of the two ions.
-              if (const int foundslot = alllevels_closestgroundlevelcont[uniquelevelindex];
-                  foundslot != groundcontindex) {
-                fatal_crash(
-                    "element {} ion {} has the ground continuum slot {}, but the nearest-edge search "
-                    "found the slot {} of element {} ion {}. Two ions have an identical ground threshold {:g}.",
-                    element, ion, groundcontindex, foundslot, globals::groundcont_element[foundslot],
-                    globals::groundcont_ion[foundslot], nu_edge_target0);
-              }
-            }
+                (level == 0) ? groundcontindex : search_groundphixslist(nu_edge_target0, element, ion, level);
           }
 
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
@@ -1096,9 +1080,6 @@ void read_autoion_data() {
 
           temp_allautoion.push_back({
               .autoion_A = static_cast<float>(autoion_A),
-              .elementindex = element,
-              .lowerionindex = lowerion,
-              .lowerlevelindex = lowerlevel,
               .upperionindex = upperion,
               .upperlevelindex = upperlevel,
           });
@@ -1888,6 +1869,12 @@ void setup_nlte_levels() {
           }
         }
         globals::elements[element].ions[ion].nlevels_excited_nlte = nlevels_excited_nlte;
+        if (nlevels_excited_nlte == 0 && nlevels > 1) {
+          fatal_crash(
+              "Z={} ionstage {} has {} levels but ION_NLEVELS_EXCITED_NLTE gives 0. An ion of an element with NLTE "
+              "levels needs at least one excited NLTE level.",
+              get_atomicnumber(element), get_ionstage(element, ion), nlevels);
+        }
 
         // use the same definition as ion_has_superlevel(): autoionising levels get their own
         // NLTE-solver slots, so they must not count towards needing a superlevel
@@ -1983,12 +1970,12 @@ void read_parameterfile(std::span<Packet> packets) {
   }
 
   assert_always(get_noncommentline(file, line));
-  std::istringstream{line} >> globals::ntimesteps;  // number of time steps
+  assert_always(std::istringstream{line} >> globals::ntimesteps);  // number of time steps
   assert_always(globals::ntimesteps > 0);
 
   assert_always(get_noncommentline(file, line));
-  std::istringstream{line} >> globals::timestep_initial >>
-      globals::timestep_finish;  // number of start and end time step
+  assert_always(std::istringstream{line} >> globals::timestep_initial >> globals::timestep_finish);
+  assert_always(globals::timestep_initial >= 0);
   printlnlog("input: timestep_start {} timestep_finish {}", globals::timestep_initial, globals::timestep_finish);
   if (globals::timestep_finish < globals::ntimesteps) {
     printlnlog(
@@ -2054,7 +2041,11 @@ void read_parameterfile(std::span<Packet> packets) {
 
   // Sets the number of initial LTE timesteps for NLTE runs
   assert_always(get_noncommentline(file, line));
-  std::istringstream{line} >> globals::num_lte_timesteps;
+  assert_always(std::istringstream{line} >> globals::num_lte_timesteps);
+  if constexpr (MULTIBIN_RADFIELD_MODEL_ON) {
+    // the bins are fitted only after the LTE timesteps, and radfield() reads them from this timestep
+    assert_always(globals::num_lte_timesteps <= FIRST_NLTE_RADFIELD_TIMESTEP);
+  }
   printlnlog("input: doing the first {} timesteps in LTE", globals::num_lte_timesteps);
 
   if constexpr (NT_SCHEME == NonThermalScheme::NT_SPENCERFANO) {
@@ -2081,7 +2072,7 @@ void read_parameterfile(std::span<Packet> packets) {
 
   // Set up initial grey approximation?
   assert_always(get_noncommentline(file, line));
-  std::istringstream{line} >> globals::optical_depth_is_thick >> globals::num_grey_timesteps;
+  assert_always(std::istringstream{line} >> globals::optical_depth_is_thick >> globals::num_grey_timesteps);
   printlnlog(
       "input: cells with Thomson optical depth > {:g} are treated in grey approximation for the first {} timesteps",
       globals::optical_depth_is_thick, globals::num_grey_timesteps);
@@ -2090,7 +2081,7 @@ void read_parameterfile(std::span<Packet> packets) {
 
   // for exspec: read number of MPI tasks
   assert_always(get_noncommentline(file, line));
-  std::istringstream{line} >> globals::nprocs_exspec;
+  assert_always(std::istringstream{line} >> globals::nprocs_exspec);
 
   // UNUSED: Extract line-of-sight dependent information of last emission for spectrum_res
   assert_always(get_noncommentline(file, line));

--- a/ltepop.cc
+++ b/ltepop.cc
@@ -383,7 +383,7 @@ void calculate_ionfractions(const int element, const int nonemptymgi, const doub
   for (int ion = 0; ion <= uppermost_ion; ion++) {
     ionfractions[ion] = ionfractions[ion] / normfactor;
 
-    if (normfactor == 0. || !std::isfinite(ionfractions[ion])) {
+    if (!std::isfinite(normfactor) || !std::isfinite(ionfractions[ion])) {
       if (ionfract_zeroed_warned.is_first_occurrence(nonemptymgi)) {
         printlnlog(
             "[warning] calculate_ionfractions: cell {} timestep {}: non-finite ionfract set to zero for Z={} "

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -40,6 +40,7 @@ namespace {
 constexpr bool LOG_MACROATOM = false;
 
 std::fstream macroatom_file;
+PaddedMutex macroatom_file_mutex;
 
 [[nodiscard]] auto get_sum_internal_down_same_exceptlast(const std::span<double> allmacroatomictransitions,
                                                          const int uniquelevelindex) -> std::span<const double> {
@@ -443,10 +444,12 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
                                      levelrates[MA_ACTION_RADDEEXC], nonemptymgi);
 
         if constexpr (LOG_MACROATOM) {
-          std::println(macroatom_file, "{:d} {:d} {:d} {:d} {:d} {:d} {:d} {:d} {:.5e} {:.5e} {:.5e} {:.5e}",
-                       globals::timestep, grid::get_mgi_of_nonemptymgi(nonemptymgi), get_atomicnumber(element),
-                       get_ionstage(element, ion_in), get_ionstage(element, ion), level_in, level, activatingline,
-                       nu_cmf_in, pkt.nu_cmf, nu_rf_in, pkt.nu_rf);
+          // the lock and the stream exist on the host only
+          MY_IF_HOST([[maybe_unused]] const ScopedMutex lock{macroatom_file_mutex};
+                     std::println(macroatom_file, "{:d} {:d} {:d} {:d} {:d} {:d} {:d} {:d} {:.5e} {:.5e} {:.5e} {:.5e}",
+                                  globals::timestep, grid::get_mgi_of_nonemptymgi(nonemptymgi),
+                                  get_atomicnumber(element), get_ionstage(element, ion_in), get_ionstage(element, ion),
+                                  level_in, level, activatingline, nu_cmf_in, pkt.nu_cmf, nu_rf_in, pkt.nu_rf););
         }
 
         end_packet = true;

--- a/macroatom.cc
+++ b/macroatom.cc
@@ -377,10 +377,11 @@ DEVICE_FUNC void do_macroatom(Packet& pkt, const MacroAtomState& pktmastate) {
   const int activatingline = pktmastate.activatingline;
   assert_testmodeonly(pkt.absorptiontype < 0 || activatingline < 0 || activatingline == pkt.absorptiontype);
 
-  const int ion_in = ion;
-  const int level_in = level;
-  const double nu_cmf_in = pkt.nu_cmf;
-  const double nu_rf_in = pkt.nu_rf;
+  // the entry state of the packet, for the log of LOG_MACROATOM
+  [[maybe_unused]] const int ion_in = ion;
+  [[maybe_unused]] const int level_in = level;
+  [[maybe_unused]] const double nu_cmf_in = pkt.nu_cmf;
+  [[maybe_unused]] const double nu_rf_in = pkt.nu_rf;
 
   bool end_packet = false;
   while (!end_packet) {

--- a/mpi_logging.h
+++ b/mpi_logging.h
@@ -458,9 +458,6 @@ class MPI_shared_array {
   }
 
   auto reset() {
-    if constexpr (TESTMODE) {
-      printlnlog("freeing MPI_shared_array of size {}", _span.size());
-    }
     if (_win != MPI_WIN_NULL) {
       int finalized = 0;
       MPI_Finalized(&finalized);

--- a/nltepop.cc
+++ b/nltepop.cc
@@ -464,9 +464,11 @@ void print_level_rates(const int nonemptymgi, const int timestep, const int elem
 void nltepop_reset_element(const int nonemptymgi, const int element) {
   grid::set_elements_lowermost_ion(nonemptymgi, element, 0);
   for (int ion = 0; ion < get_nions(element); ion++) {
-    const int nlte_start = get_allnltelevelsindexstart(element, ion);
-    std::fill_n(&nltepops_allcells[(static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) + nlte_start],
-                get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0), -1.);
+    const auto nlte_start = get_allnltelevelsindexstart(element, ion);
+    const auto nlte_count = get_nlevels_excited_nlte(element, ion) + (ion_has_superlevel(element, ion) ? 1 : 0);
+    std::ranges::fill(nltepops_allcells.span().subspan(
+                          (static_cast<ptrdiff_t>(nonemptymgi) * globals::total_nlte_levels) + nlte_start, nlte_count),
+                      -1.);
   }
 }
 
@@ -1909,7 +1911,8 @@ void nltepop_write_to_file(const int nonemptymgi, const int timestep) {
   }
 
   for (int element = 0; element < get_nelements(); element++) {
-    if (!elem_has_nlte_levels(element)) {
+    // an element with no mass in the cell has no NLTE solution
+    if (!elem_has_nlte_levels(element) || grid::get_elem_massfrac(nonemptymgi, element) <= 0.) {
       continue;
     }
 
@@ -2129,8 +2132,8 @@ void nltepop_write_restart_data(FILE* restart_file) {
       // the solved ion range of each element, so that a resumed run starts with the same reactions
       fprintf(restart_file, "\n");
       for (int element = 0; element < get_nelements(); element++) {
-        const int lowermost_ion = grid::get_elements_lowermost_ion(static_cast<int>(nonemptymgi), element);
-        const int uppermost_ion = grid::get_elements_uppermost_ion(static_cast<int>(nonemptymgi), element);
+        const int lowermost_ion = grid::get_elements_lowermost_ion(nonemptymgi, element);
+        const int uppermost_ion = grid::get_elements_uppermost_ion(nonemptymgi, element);
         // A restart must contain the complete range for each stored NLTE solution.
         assert_always(!elem_has_nlte_solution(static_cast<int>(nonemptymgi), element) ||
                       (lowermost_ion >= 0 && lowermost_ion <= uppermost_ion && uppermost_ion < get_nions(element)));
@@ -2186,8 +2189,8 @@ void nltepop_read_restart_data(FILE* restart_file) {
         int lowermost_ion = 0;
         int uppermost_ion = 0;
         assert_always(fscanf(restart_file, "%d %d ", &lowermost_ion, &uppermost_ion) == 2);
-        grid::set_elements_lowermost_ion(static_cast<int>(nonemptymgi), element, lowermost_ion);
-        grid::set_elements_uppermost_ion(static_cast<int>(nonemptymgi), element, uppermost_ion);
+        grid::set_elements_lowermost_ion(nonemptymgi, element, lowermost_ion);
+        grid::set_elements_uppermost_ion(nonemptymgi, element, uppermost_ion);
       }
     }
     if constexpr (NLTE_TIME_DEPENDENT_FIRST_TIMESTEP.has_value()) {

--- a/nonthermal.cc
+++ b/nonthermal.cc
@@ -450,9 +450,13 @@ void read_auger_data() {
       float en_auger_ev_total_nocorrection = -1;
       int epsilon_e3 = -1;
 
-      assert_always(sscanf(strline.substr(linepos).c_str(), "%d %g %g %d%n", &shellnum, &ionpot_ev,
-                           &en_auger_ev_total_nocorrection, &epsilon_e3, &offset) == 4);
-      assert_always(offset == 20);
+      // fixed-width columns, because a five-digit ionisation potential touches the shell number
+      const auto fields = strline.substr(linepos, 20);
+      assert_always(fields.size() == 20);
+      assert_always(sscanf(fields.substr(0, 2).c_str(), "%d", &shellnum) == 1);
+      assert_always(sscanf(fields.substr(2, 7).c_str(), "%g", &ionpot_ev) == 1);
+      assert_always(sscanf(fields.substr(9, 7).c_str(), "%g", &en_auger_ev_total_nocorrection) == 1);
+      assert_always(sscanf(fields.substr(16, 4).c_str(), "%d", &epsilon_e3) == 1);
 
       float n_auger_elec_avg = 0;
       std::array<double, (NT_MAX_AUGER_ELECTRONS + 1)> prob_num_auger{};

--- a/packet.cc
+++ b/packet.cc
@@ -307,7 +307,7 @@ void write_temp_packetsfile(const int timestep, const int my_rank, const std::sp
   bool write_success = false;
   while (!write_success) {
     if (tries > 10) {
-      fatal_crash("Failed to write {} after {} tries. Aborting.", filename, tries);
+      fatal_crash("The write of {} failed after {} tries", filename, tries);
     }
     if (tries > 0) {
       // give transient filesystem problems (e.g. contention on a cluster parallel filesystem) a

--- a/radfield.cc
+++ b/radfield.cc
@@ -1088,8 +1088,8 @@ void write_restart_data(FILE* gridsave_file) {
     const int bfestimcount = static_cast<int>(globals::bfestim_nu_edge.size());
     fprintf(gridsave_file, "%d\n", bfestimcount);
 
-    for (int nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
-      fprintf(gridsave_file, "%d\n", nonemptymgi);
+    for (ptrdiff_t nonemptymgi = 0; nonemptymgi < grid::get_nonempty_npts_model(); nonemptymgi++) {
+      fprintf(gridsave_file, "%td\n", nonemptymgi);
       for (int i = 0; i < bfestimcount; i++) {
         fprintf(gridsave_file, "%a ", prev_bfrate_normed[(nonemptymgi * bfestimcount) + i]);
       }

--- a/rpkt.cc
+++ b/rpkt.cc
@@ -207,7 +207,8 @@ auto get_possible_event_expansion_opacity(const int nonemptymgi, Packet& pkt, co
       // optical depths scale in the same way with the packet time. A retrace at t_mid would instead give each
       // line distance a scale of t_mid / t.
       pkt_bin_start.prop_time = prop_time;
-      pkt_bin_start.next_trans = -1;
+      // at the start of the path the packet keeps its line position, so the line that emitted it is excluded
+      pkt_bin_start.next_trans = (dist == 0.) ? pkt.next_trans : -1;
       double edist_after_bin = 0.;
       bool event_is_boundbound = false;
       auto next_trans = -1;

--- a/tests/setup_classicmode_1d_3dgrid.sh
+++ b/tests/setup_classicmode_1d_3dgrid.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=classicmode_1d_3dgrid_testrun
 
-if [ ! -f atomicdata_classic.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_classic.tar.xz; fi
+if [ ! -f atomicdata_classic.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_classic.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_classicmode_3d.sh
+++ b/tests/setup_classicmode_3d.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=classicmode_3d_testrun
 
-if [ ! -f atomicdata_classic.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_classic.tar.xz; fi
+if [ ! -f atomicdata_classic.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_classic.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_kilonova_1d.sh
+++ b/tests/setup_kilonova_1d.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=kilonova_1d_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_kilonova_1d_timedepnlte.sh
+++ b/tests/setup_kilonova_1d_timedepnlte.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=kilonova_1d_timedepnlte_testrun
 
-if [ ! -f atomicdata_sryzrlace.tar.zst ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_sryzrlace.tar.zst; fi
+if [ ! -f atomicdata_sryzrlace.tar.zst ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_sryzrlace.tar.zst; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_kilonova_2d.sh
+++ b/tests/setup_kilonova_2d.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=kilonova_2d_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_kilonova_2d_barnesthermalisation.sh
+++ b/tests/setup_kilonova_2d_barnesthermalisation.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=kilonova_2d_barnesthermalisation_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_kilonova_2d_expansionopac.sh
+++ b/tests/setup_kilonova_2d_expansionopac.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=kilonova_2d_expansionopac_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_kilonova_2d_xcomgammaphotoion.sh
+++ b/tests/setup_kilonova_2d_xcomgammaphotoion.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=kilonova_2d_xcomgammaphotoion_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_nebular_1d_3dgrid.sh
+++ b/tests/setup_nebular_1d_3dgrid.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=nebular_1d_3dgrid_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_nebular_1d_3dgrid_limitbfest.sh
+++ b/tests/setup_nebular_1d_3dgrid_limitbfest.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=nebular_1d_3dgrid_limitbfest_testrun
 
-if [ ! -f atomicdata_feconi.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
+if [ ! -f atomicdata_feconi.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_feconi.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/tests/setup_nltephotospheric_dynamic_ion_range_1d_1dgrid.sh
+++ b/tests/setup_nltephotospheric_dynamic_ion_range_1d_1dgrid.sh
@@ -4,7 +4,7 @@ set -x
 
 runfolder=nltephotospheric_dynamic_ion_range_1d_1dgrid_testrun
 
-if [ ! -f atomicdata_hefeconi_fe_i_to_vii.tar.xz ]; then curl -O -L https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_hefeconi_fe_i_to_vii.tar.xz; fi
+if [ ! -f atomicdata_hefeconi_fe_i_to_vii.tar.xz ]; then curl -fL --retry 3 -O https://github.com/artis-mcrt/artis/releases/download/v2026.5.15/atomicdata_hefeconi_fe_i_to_vii.tar.xz; fi
 
 mkdir -p $runfolder
 

--- a/thermalbalance.cc
+++ b/thermalbalance.cc
@@ -292,19 +292,14 @@ void calculate_ion_heating_cooling_rates(const int nonemptymgi, HeatingCoolingRa
 // temperature solver tries.
 void calculate_bfheatingcoeffs(int nonemptymgi, std::span<double> bfheatingcoeffs) {
   assert_always(std::ssize(bfheatingcoeffs) == get_includedlevels());
-  const double minelfrac = 0.01;
   for (int element = 0; element < get_nelements(); element++) {
-    if (grid::get_elem_massfrac(nonemptymgi, element) <= minelfrac && !USE_ION_BFHEATING_ESTIMATORS) {
-      printlog("skipping Z={} X={:g}, ", get_atomicnumber(element), grid::get_elem_massfrac(nonemptymgi, element));
-    }
-
     const int nions = get_nions(element);
     for (int ion = 0; ion < nions; ion++) {
       const int nlevels = get_nlevels(element, ion);
       const auto levels = std::ranges::iota_view{0, nlevels};
       std::for_each(EXEC_PAR levels.begin(), levels.end(), [&](const int level) {
         double bfheatingcoeff = 0.;
-        if (grid::get_elem_massfrac(nonemptymgi, element) > minelfrac || USE_ION_BFHEATING_ESTIMATORS) {
+        {
           const auto nphixstargets = get_nphixstargets(element, ion, level);
           for (int phixstargetindex = 0; phixstargetindex < nphixstargets; phixstargetindex++) {
             bfheatingcoeff += calculate_bfheatingcoeff(element, ion, level, phixstargetindex, nonemptymgi);

--- a/update_packets.cc
+++ b/update_packets.cc
@@ -404,7 +404,10 @@ void cellcacheslot_populate(globals::CellCache& cacheslot, const int nonemptymgi
   for (int element = 0; element < nelements; element++) {
     const int nions = get_nions(element);
     for (int ion = 0; ion < nions; ion++) {
-      cacheslot.cooling_contrib[kpkt::get_coolinglistoffset(element, ion)] = -99.;
+      // an ion with no cooling term has the offset of the next ion, which can be one past the end
+      if (kpkt::get_ncoolingterms_ion(element, ion) > 0) {
+        cacheslot.cooling_contrib[kpkt::get_coolinglistoffset(element, ion)] = -99.;
+      }
     }
 
     for (int ion = 0; ion < nions; ion++) {


### PR DESCRIPTION
PR 588 put the LOG_MACROATOM log inside MY_IF_HOST(). That macro is empty for hipcc, so hipcc reports the four entry state variables as unused and the AMD ROCm job of main fails. The checksums stay identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)