### PR TITLE
Mark macroatom_file_mutex as maybe unused

### DIFF
--- a/macroatom.cc
+++ b/macroatom.cc
@@ -40,7 +40,7 @@ namespace {
 constexpr bool LOG_MACROATOM = false;
 
 std::fstream macroatom_file;
-PaddedMutex macroatom_file_mutex;
+[[maybe_unused]] PaddedMutex macroatom_file_mutex;  // used on the host only
 
 [[nodiscard]] auto get_sum_internal_down_same_exceptlast(const std::span<double> allmacroatomictransitions,
                                                          const int uniquelevelindex) -> std::span<const double> {


### PR DESCRIPTION
The lock of the LOG_MACROATOM log is inside MY_IF_HOST(), which is empty for hipcc, so the AMD ROCm job reports the mutex as unused after PR 595. The checksums stay identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)