### PR TITLE
Search the line list from nu_cmf after an expansion-opacity step

### DIFF
--- a/rpkt.cc
+++ b/rpkt.cc
@@ -535,6 +535,8 @@ auto do_rpkt_step(Packet& pkt, const double t2, ContinuumOpacity& chi_rpkt_cont)
     } else if constexpr (RPKT_USE_EXPANSION_OPACITIES) {
       std::tie(edist, event_is_boundbound) = get_possible_event_expansion_opacity(
           nonemptymgi, pkt, chi_rpkt_cont, pktmastate, tau_rnd, nu_cmf_abort, dnu_on_dl, doppler);
+      // the bin walk passes lines without a line position, so the next step searches from nu_cmf
+      pkt.next_trans = -1;
     } else {
       std::tie(edist, pkt.next_trans, event_is_boundbound) =
           get_possible_event(nonemptymgi, pkt, chi_rpkt_cont, pktmastate, tau_rnd, abort_dist, nu_cmf_abort, dnu_on_dl,


### PR DESCRIPTION
The bin walk of `get_possible_event_expansion_opacity()` passes lines without a line position, but `pkt.next_trans` kept its old value. The retrace at the start of the next step (PR 588) and a virtual packet launched at an electron scatter (PR 589) then read a stale position, which `closest_transition()` returns without a frequency test. The step now resets `next_trans` to -1, and a macro-atom emission sets it again, so only a fresh position is reused.

No CI test reaches the retrace (the expansionopac test sets the thermalisation probability), so the checksums stay identical. Found by the Codex review of PR 589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)